### PR TITLE
fix: add default name space

### DIFF
--- a/ui/src/components/selector/namespace-selector.tsx
+++ b/ui/src/components/selector/namespace-selector.tsx
@@ -24,7 +24,7 @@ export function NamespaceSelector({
     const nameA = a.metadata?.name?.toLowerCase() || ''
     const nameB = b.metadata?.name?.toLowerCase() || ''
     return nameA.localeCompare(nameB)
-  })
+  }) || [{ metadata: { name: 'default' } }]
 
   return (
     <Select value={selectedNamespace} onValueChange={handleNamespaceChange}>


### PR DESCRIPTION
fix #91
Add `default` to the `namespace-selector` when there is no permission for the API list namespaces.

- before:
<img width="402" height="202" alt="image" src="https://github.com/user-attachments/assets/16f0da67-407f-4de6-942f-24bd1802c8b6" />

- after:
<img width="400" height="242" alt="image" src="https://github.com/user-attachments/assets/28737e45-0b13-4623-a8b5-d776335200f3" />

