### PR TITLE
docs: add in-cluster mode quick setup guide to installation

### DIFF
--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -162,7 +162,7 @@ For the simplest setup, select **`in-cluster`** as the cluster type. This option
 - **Automatic authentication**: Works out of the box with the default RBAC permissions
 - **Ideal for single-cluster deployments**: Perfect when Kite is managing the same cluster it's running in
 
-This is the recommended option for getting started quickly, especially in development or when Kite only needs to manage its own cluste
+This is the recommended option for getting started quickly, especially in development or when Kite only needs to manage its own cluster.
 
 ## Uninstalling Kite
 


### PR DESCRIPTION
Add a new section explaining the in-cluster cluster type option, which allows Kite to automatically use its service account credentials without requiring manual kubeconfig configuration.