### PR TITLE
fix: include additional volumes from values

### DIFF
--- a/charts/kite/templates/deployment.yaml
+++ b/charts/kite/templates/deployment.yaml
@@ -106,6 +106,9 @@ spec:
           emptyDir: {}
       {{- end }}
       {{- end }}
+      {{- with .Values.volumes }}
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
This PR updates the Helm deployment to include additional `volumes` defined in the values.