### PR TITLE
helm: add deployment strategy

### DIFF
--- a/charts/kite/templates/deployment.yaml
+++ b/charts/kite/templates/deployment.yaml
@@ -10,6 +10,10 @@ spec:
   selector:
     matchLabels:
       {{- include "kite.selectorLabels" . | nindent 6 }}
+  {{- with .Values.deploymentStrategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   template:
     metadata:
       {{- with .Values.podAnnotations }}

--- a/charts/kite/values.yaml
+++ b/charts/kite/values.yaml
@@ -13,6 +13,18 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   tag:
 
+# This will set the deployment strategy. More information can be found here: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
+#
+# IMPORTANT: If persistence is enabled and using SQLite with a
+# ReadWriteOnce PersistentVolumeClaim, you MUST set this to "Recreate".
+# Using "RollingUpdate" will cause pod conflicts during upgrades because multiple
+# pods cannot mount the same RWO volume simultaneously.
+deploymentStrategy:
+  type: RollingUpdate
+  # rollingUpdate:
+  #   maxSurge: 25%
+  #   maxUnavailable: 25%
+
 # This is for the secrets for pulling an image from a private repository more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
 imagePullSecrets: []
 # This is to override the chart name.


### PR DESCRIPTION
Just a tiny update to the helm chart to support specifying deployment rollout strategy. 

My use case: Using SQLite with a PVC for Kite on my homelab cluster, I noticed that if the deployment gets updated, the rollout will fail as the new pod won't run with the ReadWriteOnce volume if an existing pod is using it