### PR TITLE
pr_for_kyte

### DIFF
--- a/ui/src/pages/deployment-list-page.tsx
+++ b/ui/src/pages/deployment-list-page.tsx
@@ -36,7 +36,7 @@ export function DeploymentListPage() {
           </div>
         ),
       }),
-      columnHelper.accessor((row) => row.status, {
+      columnHelper.accessor((row) => row.status?.readyReplicas ?? 0, {
         id: 'ready',
         header: t('deployments.ready'),
         cell: ({ row }) => {

--- a/ui/src/pages/statefulset-list-page.tsx
+++ b/ui/src/pages/statefulset-list-page.tsx
@@ -31,7 +31,7 @@ export function StatefulSetListPage() {
           </div>
         ),
       }),
-      columnHelper.accessor((row) => row.status, {
+      columnHelper.accessor((row) => row.status?.readyReplicas ?? 0, {
         id: 'ready',
         header: t('deployments.ready'),
         cell: ({ row }) => {


### PR DESCRIPTION
What changed:
- Fix Ready column sorting in Deployments to sort by numeric ready replicas while keeping the ready / desired display.
- Apply the same Ready sorting fix in StatefulSets for consistent behavior.

Files touched:
- ui/src/pages/deployment-list-page.tsx
- ui/src/pages/statefulset-list-page.tsx

Notes
- Sorting now follows ready replica count (ascending/descending via column sort).