### PR TITLE
fix(search): scope cache by cluster and limit

### DIFF
--- a/pkg/handlers/search_handler.go
+++ b/pkg/handlers/search_handler.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"fmt"
 	"net/http"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -11,6 +12,7 @@ import (
 	"github.com/hashicorp/golang-lru/v2/expirable"
 	"github.com/zxh326/kite/pkg/common"
 	"github.com/zxh326/kite/pkg/handlers/resources"
+	"github.com/zxh326/kite/pkg/middleware"
 	"github.com/zxh326/kite/pkg/utils"
 )
 
@@ -22,17 +24,36 @@ type SearchResponse struct {
 	Total   int                   `json:"total"`
 }
 
+const (
+	defaultSearchLimit = 50
+	maxSearchLimit     = 100
+)
+
+var searchResourceOrder = map[string]int{
+	"deployments":  1,
+	"pods":         2,
+	"daemonsets":   3,
+	"statefulsets": 4,
+	"configmaps":   5,
+	"services":     6,
+	"secrets":      7,
+	"ingresses":    8,
+	"namespaces":   9,
+}
+
 func NewSearchHandler() *SearchHandler {
 	return &SearchHandler{
 		cache: expirable.NewLRU[string, []common.SearchResult](100, nil, time.Minute*10),
 	}
 }
 
-func (h *SearchHandler) createCacheKey(query string) string {
-	return fmt.Sprintf("search:%s", query)
+func (h *SearchHandler) createCacheKey(clusterName, query string, limit int) string {
+	return fmt.Sprintf("search:%s:%d:%s", clusterName, limit, normalizeSearchQuery(query))
 }
 
 func (h *SearchHandler) Search(c *gin.Context, query string, limit int) ([]common.SearchResult, error) {
+	query = normalizeSearchQuery(query)
+	limit = normalizeSearchLimit(limit)
 	var allResults []common.SearchResult
 
 	// Search in different resource types
@@ -56,35 +77,37 @@ func (h *SearchHandler) Search(c *gin.Context, query string, limit int) ([]commo
 		allResults = allResults[:limit]
 	}
 
-	h.cache.Add(h.createCacheKey(query), allResults)
+	h.cache.Add(h.createCacheKey(getSearchClusterName(c), query, limit), allResults)
 	return allResults, nil
 }
 
 // GlobalSearch handles global search across multiple resource types
 func (h *SearchHandler) GlobalSearch(c *gin.Context) {
-	query := c.Query("q")
+	query := normalizeSearchQuery(c.Query("q"))
 	if len(query) < 2 {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "Query must be at least 2 characters long"})
 		return
 	}
 
 	// Parse limit parameter
-	limitStr := c.DefaultQuery("limit", "50")
+	limitStr := c.DefaultQuery("limit", strconv.Itoa(defaultSearchLimit))
 	limit, err := strconv.Atoi(limitStr)
-	if err != nil || limit > 100 {
-		limit = 50
+	if err != nil {
+		limit = defaultSearchLimit
 	}
+	limit = normalizeSearchLimit(limit)
 
-	cacheKey := h.createCacheKey(query)
+	cacheKey := h.createCacheKey(getSearchClusterName(c), query, limit)
 
 	if cachedResults, found := h.cache.Get(cacheKey); found {
 		response := SearchResponse{
 			Results: cachedResults,
 			Total:   len(cachedResults),
 		}
+		copiedCtx := c.Copy()
 		go func() {
 			// Perform search in the background to update cache
-			_, _ = h.Search(c, query, limit)
+			_, _ = h.Search(copiedCtx, query, limit)
 		}()
 		c.JSON(http.StatusOK, response)
 		return
@@ -105,21 +128,10 @@ func (h *SearchHandler) GlobalSearch(c *gin.Context) {
 }
 
 func getResourceOrder(resourceType string) int {
-	resourceOrder := map[string]int{
-		"deployments":  1,
-		"pods":         2,
-		"daemonsets":   3,
-		"statefulsets": 4,
-		"configmaps":   5,
-		"services":     6,
-		"secrets":      7,
-		"ingresses":    8,
-		"namespaces":   9,
-	}
-	if order, exists := resourceOrder[resourceType]; exists {
+	if order, exists := searchResourceOrder[resourceType]; exists {
 		return order
 	}
-	return len(resourceOrder) // Default to the end if not found
+	return len(searchResourceOrder) // Default to the end if not found
 }
 
 // sortResults sorts the search results with exact matches first, then by resource type
@@ -139,23 +151,38 @@ func sortResults(results []common.SearchResult, query string) {
 		return getResourceOrder(a.ResourceType) < getResourceOrder(b.ResourceType)
 	}
 
-	// Simple bubble sort for demonstration
-	for i := 0; i < len(exactMatches)-1; i++ {
-		for j := 0; j < len(exactMatches)-i-1; j++ {
-			if !sortByResources(exactMatches[j], exactMatches[j+1]) {
-				exactMatches[j], exactMatches[j+1] = exactMatches[j+1], exactMatches[j]
-			}
-		}
-	}
-
-	for i := 0; i < len(partialMatches)-1; i++ {
-		for j := 0; j < len(partialMatches)-i-1; j++ {
-			if !sortByResources(partialMatches[j], partialMatches[j+1]) {
-				partialMatches[j], partialMatches[j+1] = partialMatches[j+1], partialMatches[j]
-			}
-		}
-	}
+	sort.SliceStable(exactMatches, func(i, j int) bool {
+		return sortByResources(exactMatches[i], exactMatches[j])
+	})
+	sort.SliceStable(partialMatches, func(i, j int) bool {
+		return sortByResources(partialMatches[i], partialMatches[j])
+	})
 
 	// Combine results
 	copy(results, append(exactMatches, partialMatches...))
+}
+
+func normalizeSearchLimit(limit int) int {
+	if limit < 1 || limit > maxSearchLimit {
+		return defaultSearchLimit
+	}
+	return limit
+}
+
+func normalizeSearchQuery(query string) string {
+	return strings.Join(strings.Fields(query), " ")
+}
+
+func getSearchClusterName(c *gin.Context) string {
+	if clusterName := c.GetString(middleware.ClusterNameKey); clusterName != "" {
+		return clusterName
+	}
+	if clusterName := c.GetHeader(middleware.ClusterNameHeader); clusterName != "" {
+		return clusterName
+	}
+	if clusterName, ok := c.GetQuery(middleware.ClusterNameHeader); ok {
+		return clusterName
+	}
+	clusterName, _ := c.Cookie(middleware.ClusterNameHeader)
+	return clusterName
 }

--- a/pkg/handlers/search_handler_test.go
+++ b/pkg/handlers/search_handler_test.go
@@ -1,0 +1,165 @@
+package handlers
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/zxh326/kite/pkg/common"
+	"github.com/zxh326/kite/pkg/handlers/resources"
+	"github.com/zxh326/kite/pkg/middleware"
+)
+
+func TestNormalizeSearchLimit(t *testing.T) {
+	tests := []struct {
+		name  string
+		input int
+		want  int
+	}{
+		{name: "valid lower bound", input: 1, want: 1},
+		{name: "valid upper bound", input: 100, want: 100},
+		{name: "zero defaults", input: 0, want: defaultSearchLimit},
+		{name: "negative defaults", input: -1, want: defaultSearchLimit},
+		{name: "too large defaults", input: 101, want: defaultSearchLimit},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := normalizeSearchLimit(tt.input)
+			if got != tt.want {
+				t.Fatalf("normalizeSearchLimit(%d) = %d, want %d", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSortResults(t *testing.T) {
+	results := []common.SearchResult{
+		{Name: "pod-1", ResourceType: "pods"},
+		{Name: "target", ResourceType: "namespaces"},
+		{Name: "target", ResourceType: "deployments"},
+		{Name: "target-x", ResourceType: "services"},
+	}
+
+	sortResults(results, "target")
+
+	if results[0].Name != "target" || results[0].ResourceType != "deployments" {
+		t.Fatalf("first result mismatch: got %s/%s", results[0].Name, results[0].ResourceType)
+	}
+	if results[1].Name != "target" || results[1].ResourceType != "namespaces" {
+		t.Fatalf("second result mismatch: got %s/%s", results[1].Name, results[1].ResourceType)
+	}
+}
+
+func TestGlobalSearchNegativeLimitDoesNotPanic(t *testing.T) {
+	oldSearchFuncs := resources.SearchFuncs
+	resources.SearchFuncs = map[string]func(*gin.Context, string, int64) ([]common.SearchResult, error){}
+	t.Cleanup(func() {
+		resources.SearchFuncs = oldSearchFuncs
+	})
+
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(rec)
+	ctx.Request = httptest.NewRequest(http.MethodGet, "/search?q=po&limit=-1", nil)
+
+	handler := NewSearchHandler()
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("GlobalSearch panicked with negative limit: %v", r)
+		}
+	}()
+
+	handler.GlobalSearch(ctx)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("unexpected status code: got %d, want %d", rec.Code, http.StatusOK)
+	}
+}
+
+func TestGlobalSearchCacheKeyIncludesClusterAndLimit(t *testing.T) {
+	oldSearchFuncs := resources.SearchFuncs
+	resources.SearchFuncs = map[string]func(*gin.Context, string, int64) ([]common.SearchResult, error){
+		"pods": func(c *gin.Context, _ string, _ int64) ([]common.SearchResult, error) {
+			clusterName := c.GetString(middleware.ClusterNameKey)
+			switch clusterName {
+			case "cluster-a":
+				return []common.SearchResult{
+					{Name: "target-a-1", ResourceType: "pods"},
+					{Name: "target-a-2", ResourceType: "pods"},
+					{Name: "target-a-3", ResourceType: "pods"},
+				}, nil
+			case "cluster-b":
+				return []common.SearchResult{
+					{Name: "target-b-1", ResourceType: "pods"},
+					{Name: "target-b-2", ResourceType: "pods"},
+				}, nil
+			default:
+				return nil, fmt.Errorf("unexpected cluster: %s", clusterName)
+			}
+		},
+	}
+	t.Cleanup(func() {
+		resources.SearchFuncs = oldSearchFuncs
+	})
+
+	handler := NewSearchHandler()
+
+	ctx := newSearchContext(t, "cluster-a", "/search")
+	if _, err := handler.Search(ctx, "po target", 1); err != nil {
+		t.Fatalf("Search returned error: %v", err)
+	}
+
+	resp := performGlobalSearch(t, handler, "cluster-a", "/search?q=po+target&limit=3")
+	if resp.Total != 3 {
+		t.Fatalf("cluster/limit cache miss returned %d results, want 3", resp.Total)
+	}
+
+	resp = performGlobalSearch(t, handler, "cluster-b", "/search?q=po+target&limit=3")
+	if resp.Total != 2 {
+		t.Fatalf("cluster-specific cache miss returned %d results, want 2", resp.Total)
+	}
+	if len(resp.Results) == 0 || resp.Results[0].Name != "target-b-1" {
+		t.Fatalf("unexpected cluster-b results: %#v", resp.Results)
+	}
+}
+
+func newSearchContext(t *testing.T, clusterName, target string) *gin.Context {
+	t.Helper()
+
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(rec)
+	ctx.Request = httptest.NewRequest(http.MethodGet, target, nil)
+	if clusterName != "" {
+		ctx.Set(middleware.ClusterNameKey, clusterName)
+	}
+	return ctx
+}
+
+func performGlobalSearch(t *testing.T, handler *SearchHandler, clusterName, target string) SearchResponse {
+	t.Helper()
+
+	rec := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(rec)
+	ctx.Request = httptest.NewRequest(http.MethodGet, target, nil)
+	if clusterName != "" {
+		ctx.Set(middleware.ClusterNameKey, clusterName)
+	}
+
+	handler.GlobalSearch(ctx)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("unexpected status code: got %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	var resp SearchResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	return resp
+}

--- a/pkg/utils/search.go
+++ b/pkg/utils/search.go
@@ -2,40 +2,49 @@ package utils
 
 import "strings"
 
+var searchResourceAliases = map[string]string{
+	"po":                     "pods",
+	"pod":                    "pods",
+	"pods":                   "pods",
+	"svc":                    "services",
+	"service":                "services",
+	"services":               "services",
+	"pv":                     "persistentvolumes",
+	"persistentvolume":       "persistentvolumes",
+	"persistentvolumes":      "persistentvolumes",
+	"pvc":                    "persistentvolumeclaims",
+	"persistentvolumeclaim":  "persistentvolumeclaims",
+	"persistentvolumeclaims": "persistentvolumeclaims",
+	"cm":                     "configmaps",
+	"configmap":              "configmaps",
+	"configmaps":             "configmaps",
+	"secret":                 "secrets",
+	"secrets":                "secrets",
+	"dep":                    "deployments",
+	"deploy":                 "deployments",
+	"deployment":             "deployments",
+	"deployments":            "deployments",
+	"ds":                     "daemonsets",
+	"daemonset":              "daemonsets",
+	"daemonsets":             "daemonsets",
+	"statefulset":            "statefulsets",
+	"statefulsets":           "statefulsets",
+	"job":                    "jobs",
+	"jobs":                   "jobs",
+	"cronjob":                "cronjobs",
+	"cronjobs":               "cronjobs",
+}
+
 func GuessSearchResources(query string) (string, string) {
-	guessSearchResources := "all"
-	query = strings.TrimSpace(query)
-	q := strings.Split(query, " ")
-	if len(q) < 2 {
-		return guessSearchResources, query
+	parts := strings.Fields(query)
+	if len(parts) < 2 {
+		return "all", strings.TrimSpace(query)
 	}
-	if len(strings.Split(query, " ")) >= 2 {
-		switch strings.ToLower(strings.Split(query, " ")[0]) {
-		case "po", "pod", "pods":
-			guessSearchResources = "pods"
-		case "svc", "service", "services":
-			guessSearchResources = "services"
-		case "pv", "persistentvolume", "persistentvolumes":
-			guessSearchResources = "persistentvolumes"
-		case "pvc", "persistentvolumeclaim", "persistentvolumeclaims":
-			guessSearchResources = "persistentvolumeclaims"
-		case "cm", "configmap", "configmaps":
-			guessSearchResources = "configmaps"
-		case "secret", "secrets":
-			guessSearchResources = "secrets"
-		case "dep", "deploy", "deployment", "deployments":
-			guessSearchResources = "deployments"
-		case "ds", "daemonset", "daemonsets":
-			guessSearchResources = "daemonsets"
-		case "statefulset", "statefulsets":
-			guessSearchResources = "statefulsets"
-		case "job", "jobs":
-			guessSearchResources = "jobs"
-		case "cronjob", "cronjobs":
-			guessSearchResources = "cronjobs"
-		default:
-			return "all", query
-		}
+
+	resource, ok := searchResourceAliases[strings.ToLower(parts[0])]
+	if !ok {
+		return "all", strings.Join(parts, " ")
 	}
-	return guessSearchResources, strings.Join(q[1:], " ")
+
+	return resource, strings.Join(parts[1:], " ")
 }

--- a/pkg/utils/search_test.go
+++ b/pkg/utils/search_test.go
@@ -1,0 +1,61 @@
+package utils
+
+import "testing"
+
+func TestGuessSearchResources(t *testing.T) {
+	testCases := []struct {
+		name             string
+		query            string
+		wantResourceType string
+		wantKeyword      string
+	}{
+		{
+			name:             "empty query",
+			query:            "   ",
+			wantResourceType: "all",
+			wantKeyword:      "",
+		},
+		{
+			name:             "single token query",
+			query:            "nginx",
+			wantResourceType: "all",
+			wantKeyword:      "nginx",
+		},
+		{
+			name:             "known resource alias with keyword",
+			query:            "po nginx",
+			wantResourceType: "pods",
+			wantKeyword:      "nginx",
+		},
+		{
+			name:             "known resource with mixed case and extra spaces",
+			query:            "  SVC    kube-dns   ",
+			wantResourceType: "services",
+			wantKeyword:      "kube-dns",
+		},
+		{
+			name:             "unknown resource prefix",
+			query:            "xyz kube-system",
+			wantResourceType: "all",
+			wantKeyword:      "xyz kube-system",
+		},
+		{
+			name:             "multi-word keyword",
+			query:            "deploy api server",
+			wantResourceType: "deployments",
+			wantKeyword:      "api server",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotResourceType, gotKeyword := GuessSearchResources(tc.query)
+			if gotResourceType != tc.wantResourceType || gotKeyword != tc.wantKeyword {
+				t.Fatalf(
+					"GuessSearchResources(%q) = (%q, %q), want (%q, %q)",
+					tc.query, gotResourceType, gotKeyword, tc.wantResourceType, tc.wantKeyword,
+				)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary\n- scope search cache keys by cluster name, limit, and normalized query\n- normalize query/limit handling and make background refresh use a copied Gin context\n- add regression tests for cache scoping, limit normalization, and search alias parsing\n\n## Testing\n- go test ./pkg/handlers ./pkg/utils