### PR TITLE
feat: show pod cpu and memory limits in list (#408)

### DIFF
--- a/ui/src/components/metrics-cell.tsx
+++ b/ui/src/components/metrics-cell.tsx
@@ -84,11 +84,17 @@ export function MetricCell({
           </TooltipContent>
         </Tooltip>
         <span
-          className={`${type === 'cpu' ? 'w-[4ch]' : 'w-[10ch]'} text-right inline-block text-xs text-muted-foreground whitespace-nowrap tabular-nums`}
+          className={`${type === 'cpu' ? 'min-w-[4ch]' : 'min-w-[10ch]'} text-right inline-block text-xs text-muted-foreground whitespace-nowrap tabular-nums`}
         >
           {formatValue(metricValue)}
+          {metricLimit && (
+            <>
+              <span className="opacity-30 mx-1">/</span>
+              <span className="opacity-70">{formatValue(metricLimit)}</span>
+            </>
+          )}
           {showPercentage && metricLimit && metricValue > 0 && (
-            <span className="hidden 2xl:inline text-[10px] opacity-70">
+            <span className="hidden xl:inline text-[10px] opacity-50 ml-1">
               ({percentage.toFixed(0)}%)
             </span>
           )}

--- a/ui/src/pages/pod-list-page.tsx
+++ b/ui/src/pages/pod-list-page.tsx
@@ -80,14 +80,22 @@ export function PodListPage() {
         id: 'cpu',
         header: 'CPU',
         cell: ({ row }) => (
-          <MetricCell metrics={row.original.metrics} type="cpu" />
+          <MetricCell
+            metrics={row.original.metrics}
+            type="cpu"
+            showPercentage={true}
+          />
         ),
       }),
       columnHelper.accessor((row) => row.metrics?.memoryUsage || 0, {
         id: 'memory',
         header: 'Memory',
         cell: ({ row }) => (
-          <MetricCell metrics={row.original.metrics} type="memory" />
+          <MetricCell
+            metrics={row.original.metrics}
+            type="memory"
+            showPercentage={true}
+          />
         ),
       }),
       columnHelper.accessor((row) => row.status?.podIP, {


### PR DESCRIPTION
This PR improves the CPU and memory display in the Pods list as requested in #408, making limits more visible.
