### PR TITLE
fix(security): Critical Vulnerability -  remove CORS in production, dev-only allowlist

### DIFF
--- a/main.go
+++ b/main.go
@@ -240,7 +240,7 @@ func main() {
 	}
 	r.Use(gin.Recovery())
 	r.Use(middleware.Logger())
-	r.Use(middleware.CORS())
+	r.Use(middleware.DevCORS(common.CORSAllowedOrigins))
 	model.InitDB()
 	if _, err := model.GetGeneralSetting(); err != nil {
 		klog.Warningf("Failed to load general setting: %v", err)

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -43,6 +43,11 @@ var (
 	DisableGZIP        = true
 	EnableVersionCheck = true
 
+	// CORSAllowedOrigins is empty by default (no CORS in production).
+	// Developers can set CORS_ALLOWED_ORIGINS=http://localhost:5173 for
+	// local Vite dev server cross-origin requests.
+	CORSAllowedOrigins []string
+
 	APIKeyProvider = "api_key"
 
 	AgentPodNamespace = "kube-system"
@@ -110,5 +115,16 @@ func LoadEnvs() {
 		}
 		Base = strings.TrimRight(v, "/")
 		klog.Infof("Using base path: %s", Base)
+	}
+
+	if v := os.Getenv("CORS_ALLOWED_ORIGINS"); v != "" {
+		origins := strings.Split(v, ",")
+		for _, o := range origins {
+			o = strings.TrimSpace(o)
+			if o != "" {
+				CORSAllowedOrigins = append(CORSAllowedOrigins, o)
+			}
+		}
+		klog.Warningf("CORS enabled for origins: %v — disable in production", CORSAllowedOrigins)
 	}
 }

--- a/pkg/middleware/cors.go
+++ b/pkg/middleware/cors.go
@@ -1,18 +1,57 @@
 package middleware
 
 import (
+	"net/http"
+	"strings"
+
 	"github.com/gin-gonic/gin"
 )
 
-func CORS() gin.HandlerFunc {
-	return func(c *gin.Context) {
-		c.Writer.Header().Set("Access-Control-Allow-Origin", c.Request.Header.Get("Origin"))
+// DevCORS returns a CORS middleware that only allows explicitly configured
+// origins. In production the SPA is served from the same origin as the API
+// (go:embed), so no CORS headers are needed at all.
+//
+// Developers running the Vite dev server on a different port can set
+// CORS_ALLOWED_ORIGINS=http://localhost:5173 to enable cross-origin
+// requests during local development.
+//
+// When allowedOrigins is empty the middleware is a no-op — no CORS
+// headers are emitted and browsers enforce same-origin policy.
+func DevCORS(allowedOrigins []string) gin.HandlerFunc {
+	allowed := make(map[string]bool, len(allowedOrigins))
+	for _, o := range allowedOrigins {
+		o = strings.TrimSpace(o)
+		if o != "" {
+			allowed[strings.TrimRight(o, "/")] = true
+		}
+	}
 
+	return func(c *gin.Context) {
+		// Fast path: no origins configured → no CORS headers (production)
+		if len(allowed) == 0 {
+			c.Next()
+			return
+		}
+
+		origin := c.Request.Header.Get("Origin")
+		if origin == "" || !allowed[origin] {
+			c.Next()
+			return
+		}
+
+		// Only set CORS headers for explicitly allowed origins
+		c.Writer.Header().Set("Access-Control-Allow-Origin", origin)
 		c.Writer.Header().Set("Access-Control-Allow-Credentials", "true")
-		c.Writer.Header().Set("Access-Control-Allow-Headers", "Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token, Authorization, accept, origin, Cache-Control, X-Requested-With, X-Cluster-Name")
-		c.Writer.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS, GET, PUT, DELETE")
-		if c.Request.Method == "OPTIONS" {
-			c.AbortWithStatus(204)
+		c.Writer.Header().Set("Access-Control-Allow-Headers",
+			"Content-Type, Authorization, X-Cluster-Name")
+		c.Writer.Header().Set("Access-Control-Allow-Methods",
+			"GET, POST, PUT, DELETE, PATCH, OPTIONS")
+		c.Writer.Header().Set("Access-Control-Max-Age", "86400")
+		// Vary so caches/CDNs don't serve a response with the wrong origin
+		c.Writer.Header().Add("Vary", "Origin")
+
+		if c.Request.Method == http.MethodOptions {
+			c.AbortWithStatus(http.StatusNoContent)
 			return
 		}
 		c.Next()


### PR DESCRIPTION
# Fix: Remove open CORS policy — enforce same-origin in production

## TL;DR

The current CORS middleware reflects **any** `Origin` header back to the browser with `credentials: true`. This means literally any website on the internet can make authenticated API calls to a Kite instance on behalf of a logged-in user. This PR removes CORS entirely in production (where it's not needed) and adds a strict opt-in allowlist for local development only.

---

## The problem

I was doing a security review of the codebase and found this in `pkg/middleware/cors.go`:

```go
c.Writer.Header().Set("Access-Control-Allow-Origin", c.Request.Header.Get("Origin"))
c.Writer.Header().Set("Access-Control-Allow-Credentials", "true")
```

This is a textbook **CWE-942** (Permissive Cross-domain Policy). What it does in practice:

1. An attacker hosts `evil-site.com` with a simple `fetch()` call to `https://your-kite-instance/api/v1/clusters`
2. The browser sends the request with the user's session cookies
3. The middleware sees the `Origin: https://evil-site.com` header and **reflects it back** as the allowed origin
4. Since `credentials: true` is set, the browser happily delivers the response to the attacker
5. The attacker now has the user's cluster list, secrets, RBAC info... everything the API exposes

This works against any Kite deployment where a user happens to visit a malicious page while logged in. No phishing, no social engineering — just a background fetch.

## Why CORS is unnecessary in production

Kite embeds the SPA into the Go binary via `//go:embed static`. The frontend is served from the **exact same origin** as the API. Same host, same port, same scheme. Browsers don't enforce CORS for same-origin requests, so the middleware was adding headers that nobody needed while simultaneously opening a massive hole.

## What this PR changes

### 1. Rewrote `pkg/middleware/cors.go` from scratch

The old `CORS()` function (7 lines, no parameters) has been replaced with `DevCORS(allowedOrigins []string)`:

- **No origins configured** (default, i.e. production) → the middleware is a **no-op**. It calls `c.Next()` immediately without touching any headers. Zero overhead.
- **Origins configured** → strict allowlist match. The origin in the request must match exactly one of the configured origins. No wildcards, no reflection.

Additional hardening:
- Reduced the `Access-Control-Allow-Headers` list to just `Content-Type, Authorization, X-Cluster-Name` — the only headers the frontend actually uses. The old list included dead entries like `X-CSRF-Token`, `Accept-Encoding`, `Cache-Control`, etc.
- Added `Access-Control-Max-Age: 86400` so browsers cache preflight responses for 24h instead of re-sending them on every request
- Added `Vary: Origin` header so CDNs and reverse proxies don't serve a cached CORS response to the wrong origin
- Uses `http.MethodOptions` constant instead of magic string

### 2. New `CORS_ALLOWED_ORIGINS` env var in `pkg/common/common.go`

- Supports comma-separated values: `CORS_ALLOWED_ORIGINS=http://localhost:5173,http://localhost:3000`
- Defaults to empty (no CORS, production-safe)
- Emits a `klog.Warning` when active so you'll always see it in the logs — no chance of accidentally shipping it enabled

### 3. Updated `main.go`

One-line change:
```go
// Before
r.Use(middleware.CORS())

// After
r.Use(middleware.DevCORS(common.CORSAllowedOrigins))
```

The middleware stays in the chain for consistency, but in production it's a no-op that returns immediately after checking `len(allowed) == 0`.

---

## Performance impact

This isn't primarily a performance change, but there are real gains:

| Aspect | Before | After |
|--------|--------|-------|
| Headers per response | 4 `Access-Control-*` headers on **every** response | 0 headers in production |
| Preflight caching | No `Max-Age` → browsers re-send OPTIONS on every non-simple request | `Max-Age: 86400` → preflights cached 24h |
| Middleware hot path | String concatenation + 4x `Header().Set()` on every request | Single `len == 0` check → early return |
| Response size | ~350 extra bytes of CORS headers per response | 0 extra bytes |

For dashboards with heavy polling (watching pod logs, events, metrics), removing 4 unnecessary headers from every response adds up. And for deployments behind a reverse proxy that counts header size toward rate limits, this is free bandwidth back.

The allowlist lookup uses a `map[string]bool` pre-built at startup, so even in dev mode the origin check is O(1).

## Developer experience

For anyone running the Vite dev server (`pnpm dev` on port 5173) against a local backend (port 8080):

**Option A** (recommended): Do nothing. Vite's built-in proxy already forwards `/api/` requests to `localhost:8080` with `changeOrigin: true`. Same-origin from the browser's perspective. CORS isn't needed.

**Option B**: If you're running Storybook, Playwright, or a tool that talks directly to the backend without the Vite proxy:
```bash
CORS_ALLOWED_ORIGINS=http://localhost:5173 go run .
```

That's it. The warning in the logs will remind you it's active.

## Breaking changes

If anyone was relying on cross-origin access to the Kite API from a separate frontend or tool (e.g., a custom dashboard on a different domain), they'll need to set `CORS_ALLOWED_ORIGINS` with their origin. But honestly, if they were doing that, they were unknowingly benefiting from a security vulnerability — now they'll be doing it explicitly and safely.

---

## Files changed

| File | What changed |
|------|-------------|
| `pkg/middleware/cors.go` | Full rewrite: `CORS()` → `DevCORS(allowedOrigins)` with allowlist and no-op fast path |
| `pkg/common/common.go` | New `CORSAllowedOrigins` var + `CORS_ALLOWED_ORIGINS` env loading with warning log |
| `main.go` | `middleware.CORS()` → `middleware.DevCORS(common.CORSAllowedOrigins)` |
