### PR TITLE
fix: prevent chatbox input from hiding send button on mobile

### DIFF
--- a/ui/src/components/ai-chat/ai-chatbox.tsx
+++ b/ui/src/components/ai-chat/ai-chatbox.tsx
@@ -1204,7 +1204,7 @@ export function AIChatbox({
           <div className="flex items-end gap-2">
             <textarea
               ref={inputRef}
-              className="flex-1 resize-none rounded-md border bg-background px-3 py-2 text-sm leading-5 placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+              className="flex-1 min-w-0 resize-none rounded-md border bg-background px-3 py-2 text-sm leading-5 placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
               placeholder="Ask about your cluster..."
               rows={1}
               value={input}


### PR DESCRIPTION
On mobile, when the virtual keyboard opens, the textarea expands to full width and hides the send button.

Root cause: flex items have `min-width: auto` by default. The textarea's intrinsic minimum width prevents it from shrinking below viewport width, pushing the send button off-screen.

Fix: Add `min-w-0` to the textarea so `flex-1` can properly shrink it