### PR TITLE
fix: mitigate Slowloris with ReadHeaderTimeout and IdleTimeout

### DIFF
--- a/main.go
+++ b/main.go
@@ -30,8 +30,10 @@ func main() {
 	}
 
 	srv := &http.Server{
-		Addr:    ":" + common.Port,
-		Handler: buildEngine(cm).Handler(),
+		Addr:              ":" + common.Port,
+		Handler:           buildEngine(cm).Handler(),
+		ReadHeaderTimeout: 10 * time.Second,
+		IdleTimeout:       120 * time.Second,
 	}
 	go func() {
 		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {


### PR DESCRIPTION
# Fix: Add HTTP Server Timeouts to Prevent Slowloris DoS

## The problem

The HTTP server in `main.go` was created with **zero timeouts**:

```go
srv := &http.Server{
    Addr:    ":" + common.Port,
    Handler: buildEngine(cm).Handler(),
}
```

In Go, when you don't set timeouts on `http.Server`, they default to **0 — which means infinite**. The server will wait forever for a client to finish sending data or to go away.

This opens the door to a classic attack called **Slowloris**: an attacker opens hundreds of connections and sends HTTP headers extremely slowly — one byte every few seconds. The server keeps all those connections open, waiting patiently for them to finish. Eventually it runs out of available connections and legitimate users can't get in.

A single laptop can take down an unprotected server this way.

## What this PR does

Adds two timeouts to the HTTP server — just two lines:

```go
srv := &http.Server{
    Addr:              ":" + common.Port,
    Handler:           buildEngine(cm).Handler(),
    ReadHeaderTimeout: 10 * time.Second,
    IdleTimeout:       120 * time.Second,
}
```

**`ReadHeaderTimeout: 10 seconds`** — The client has 10 seconds to send the complete HTTP headers. If it takes longer, the connection is closed. Normal clients send headers in under 100ms, so this is extremely generous. A Slowloris attacker sending one byte per second gets cut off.

**`IdleTimeout: 120 seconds`** — Keep-alive connections that sit idle for more than 2 minutes are closed. This prevents accumulation of zombie connections that consume server resources without doing anything.

## Why not WriteTimeout?

This is the important nuance. Kite has three types of long-lived connections that would break with a write timeout:

1. **SSE streams** for AI chat — LLM responses are streamed token by token and can take 30+ seconds
2. **WebSockets** for pod/node terminals — interactive sessions that stay open minutes or hours
3. **WebSockets** for live log streaming — continuous log output with no natural end

Setting a `WriteTimeout` would kill all of these mid-stream. That's why it's intentionally omitted — the protection comes from the read side (where Slowloris attacks happen), not the write side.

## Impact

- **Zero functional impact** — all existing features (AI chat, terminals, log streaming, normal API calls) continue working exactly as before
- **Blocks Slowloris** — slow header delivery gets disconnected
- **Cleans up idle connections** — stale keep-alive connections freed after 2 minutes
- **Severity closed: CRITICAL → resolved** (OWASP A05: Security Misconfiguration)

## File changed

- `main.go` — 2 lines added to `http.Server` initialization
