### PR TITLE
fix: update ResourceTemplate ID to id for consistency across the code…

### DIFF
--- a/ui/src/components/settings/template-management.tsx
+++ b/ui/src/components/settings/template-management.tsx
@@ -52,7 +52,7 @@ export function TemplateManagement() {
   })
 
   const createMutation = useMutation({
-    mutationFn: (data: Omit<ResourceTemplate, 'ID'>) => createTemplate(data),
+    mutationFn: (data: Omit<ResourceTemplate, 'id'>) => createTemplate(data),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['templates'] })
       toast.success(
@@ -139,7 +139,7 @@ export function TemplateManagement() {
     }
 
     if (editingTemplate) {
-      updateMutation.mutate({ id: editingTemplate.ID, data: formData })
+      updateMutation.mutate({ id: editingTemplate.id, data: formData })
     } else {
       createMutation.mutate(formData)
     }
@@ -147,7 +147,7 @@ export function TemplateManagement() {
 
   const handleDelete = async () => {
     if (!deletingTemplate) return
-    deleteMutation.mutate(deletingTemplate.ID)
+    deleteMutation.mutate(deletingTemplate.id)
   }
 
   const columns = useMemo<ColumnDef<ResourceTemplate>[]>(

--- a/ui/src/lib/api/core.ts
+++ b/ui/src/lib/api/core.ts
@@ -619,7 +619,7 @@ export const fetchTemplates = async (): Promise<ResourceTemplate[]> => {
 }
 
 export const createTemplate = async (
-  data: Omit<ResourceTemplate, 'ID'>
+  data: Omit<ResourceTemplate, 'id'>
 ): Promise<ResourceTemplate> => {
   return apiClient.post<ResourceTemplate>('/admin/templates/', data)
 }

--- a/ui/src/types/api.ts
+++ b/ui/src/types/api.ts
@@ -442,7 +442,7 @@ export interface AuditLogResponse {
   size: number
 }
 export interface ResourceTemplate {
-  ID: number
+  id: number
   name: string
   description: string
   yaml: string


### PR DESCRIPTION
Fix ResourceTemplate interface using ID (uppercase) instead of id (lowercase), causing edit and delete operations to always call /admin/templates/undefined.

Why:
The backend GORM Model struct serializes the primary key as json:"id" (lowercase). The frontend ResourceTemplate TypeScript interface declared it as ID: number (uppercase), so editingTemplate.ID and deletingTemplate.ID were always undefined at runtime making PUT and DELETE requests fail silently.

Validation
Renamed ID → id in ResourceTemplate interface and all call sites
Ran pnpm run build (tsc -b && vite build) — zero type errors, clean build
Manual testing against a live cluster recommended before merge