### PR TITLE
Issue/search namespace

### DIFF
--- a/pkg/handlers/resources/generic_resource_handler_list.go
+++ b/pkg/handlers/resources/generic_resource_handler_list.go
@@ -138,6 +138,7 @@ func (h *GenericResourceHandler[T, V]) Search(c *gin.Context, q string, limit in
 		return nil, nil
 	}
 	cs := c.MustGet("cluster").(*cluster.ClientSet)
+	user := c.MustGet("user").(model.User)
 	ctx := c.Request.Context()
 	objectList := reflect.New(h.listType).Interface().(V)
 	var listOpts []client.ListOption
@@ -170,6 +171,12 @@ func (h *GenericResourceHandler[T, V]) Search(c *gin.Context, q string, limit in
 			continue
 		}
 		if !isLabelSearch && !strings.Contains(strings.ToLower(obj.GetName()), strings.ToLower(q)) {
+			continue
+		}
+		if h.Name() == string(common.Namespaces) && !rbac.CanAccessNamespace(user, cs.Name, obj.GetName()) {
+			continue
+		}
+		if obj.GetNamespace() != "" && !rbac.CanAccessNamespace(user, cs.Name, obj.GetNamespace()) {
 			continue
 		}
 		result := common.SearchResult{

--- a/ui/src/components/settings/template-management.tsx
+++ b/ui/src/components/settings/template-management.tsx
@@ -52,7 +52,7 @@ export function TemplateManagement() {
   })
 
   const createMutation = useMutation({
-    mutationFn: (data: Omit<ResourceTemplate, 'ID'>) => createTemplate(data),
+    mutationFn: (data: Omit<ResourceTemplate, 'id'>) => createTemplate(data),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['templates'] })
       toast.success(
@@ -139,7 +139,7 @@ export function TemplateManagement() {
     }
 
     if (editingTemplate) {
-      updateMutation.mutate({ id: editingTemplate.ID, data: formData })
+      updateMutation.mutate({ id: editingTemplate.id, data: formData })
     } else {
       createMutation.mutate(formData)
     }
@@ -147,7 +147,7 @@ export function TemplateManagement() {
 
   const handleDelete = async () => {
     if (!deletingTemplate) return
-    deleteMutation.mutate(deletingTemplate.ID)
+    deleteMutation.mutate(deletingTemplate.id)
   }
 
   const columns = useMemo<ColumnDef<ResourceTemplate>[]>(

--- a/ui/src/lib/api/core.ts
+++ b/ui/src/lib/api/core.ts
@@ -619,7 +619,7 @@ export const fetchTemplates = async (): Promise<ResourceTemplate[]> => {
 }
 
 export const createTemplate = async (
-  data: Omit<ResourceTemplate, 'ID'>
+  data: Omit<ResourceTemplate, 'id'>
 ): Promise<ResourceTemplate> => {
   return apiClient.post<ResourceTemplate>('/admin/templates/', data)
 }

--- a/ui/src/types/api.ts
+++ b/ui/src/types/api.ts
@@ -442,7 +442,7 @@ export interface AuditLogResponse {
   size: number
 }
 export interface ResourceTemplate {
-  ID: number
+  id: number
   name: string
   description: string
   yaml: string


### PR DESCRIPTION
Root cause: The namespace list API applies CanAccessNamespace RBAC filtering when listing namespaces, but the Search method had no such filtering. So users could find pods/deployments in namespaces (e.g., norish) via search, while those namespaces were absent from the dropdown — a confusing inconsistency.

Fix: The Search method now applies the same RBAC checks:

Namespace resources: filtered by CanAccessNamespace on the namespace name
Namespace-scoped resources (pods, deployments, etc.): filtered by CanAccessNamespace on obj.GetNamespace()
This makes search results consistent with what's accessible in the namespace dropdown. Users with admin roles (Namespaces: ["*"]) are unaffected — all namespaces remain visible everywhere.