### PR TITLE
feat: add CRD not installed error handling and translations

### DIFF
--- a/ui/src/components/error-message.tsx
+++ b/ui/src/components/error-message.tsx
@@ -1,7 +1,7 @@
-import { RotateCcw, ShieldX, XCircle } from 'lucide-react'
+import { PackageX, RotateCcw, ShieldX, XCircle } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 
-import { isRBACError, translateError } from '@/lib/utils'
+import { isCRDNotInstalledError, isRBACError, translateError } from '@/lib/utils'
 
 import { Button } from './ui/button'
 
@@ -26,6 +26,8 @@ export function ErrorMessage({
   }
 
   const isRBAC = error instanceof Error && isRBACError(error.message)
+  const isCRDMissing =
+    error instanceof Error && isCRDNotInstalledError(error.message)
   const message =
     error instanceof Error ? translateError(error, t) : t(fallbackKey)
 
@@ -34,22 +36,26 @@ export function ErrorMessage({
       <div className="mb-4">
         {isRBAC ? (
           <ShieldX className="h-16 w-16 text-amber-500" />
+        ) : isCRDMissing ? (
+          <PackageX className="h-16 w-16 text-muted-foreground" />
         ) : (
           <XCircle className="h-16 w-16 text-red-500" />
         )}
       </div>
       <h3
-        className={`text-lg font-medium mb-1 ${isRBAC ? 'text-amber-600' : 'text-red-500'}`}
+        className={`text-lg font-medium mb-1 ${isRBAC ? 'text-amber-600' : isCRDMissing ? 'text-muted-foreground' : 'text-red-500'}`}
       >
-        {t('resourceTable.errorLoading', {
-          resourceName,
-        })}
+        {isCRDMissing
+          ? t('errors.crdNotInstalledTitle')
+          : t('resourceTable.errorLoading', { resourceName })}
       </h3>
       <p className="text-muted-foreground mb-4">{message}</p>
-      <Button variant="outline" onClick={() => refetch()}>
-        <RotateCcw className="h-4 w-4 mr-2" />
-        {t('resourceTable.tryAgain')}
-      </Button>
+      {!isCRDMissing && (
+        <Button variant="outline" onClick={() => refetch()}>
+          <RotateCcw className="h-4 w-4 mr-2" />
+          {t('resourceTable.tryAgain')}
+        </Button>
+      )}
     </div>
   )
 }

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -264,6 +264,10 @@
     "watch": "Watch",
     "namespace": "Namespace"
   },
+  "errors": {
+    "crdNotInstalledTitle": "Resource Type Not Available",
+    "crdNotInstalled": "The {{kind}} resource type ({{version}}) is not installed in this cluster. Install the required CRD to use this feature."
+  },
   "rbac": {
     "noPermissionCluster": "User {{user}} does not have permission to {{verb}} {{resource}} on cluster {{cluster}}",
     "noPermissionNamespace": "User {{user}} does not have permission to {{verb}} {{resource}} in namespace {{namespace}} on cluster {{cluster}}",

--- a/ui/src/i18n/locales/zh.json
+++ b/ui/src/i18n/locales/zh.json
@@ -282,6 +282,10 @@
     "watch": "监听",
     "namespace": "命名空间"
   },
+  "errors": {
+    "crdNotInstalledTitle": "资源类型不可用",
+    "crdNotInstalled": "此集群中未安装 {{kind}} 资源类型 ({{version}})。请安装所需的 CRD 以使用此功能。"
+  },
   "rbac": {
     "title": "角色管理",
     "noPermissionCluster": "用户 {{user}} 没有权限在集群 {{cluster}} 上执行 {{verb}} {{resource}}",

--- a/ui/src/lib/utils.test.ts
+++ b/ui/src/lib/utils.test.ts
@@ -1,6 +1,6 @@
 import type { NodeCondition } from 'kubernetes-types/core/v1'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-
+import type { TFunction } from 'i18next'
 import type { PodMetrics } from '@/types/api'
 
 import {
@@ -13,6 +13,7 @@ import {
   formatMemory,
   formatPodMetrics,
   getAge,
+  isCRDNotInstalledError,
   parseBytes,
   parseRBACError,
   translateError,
@@ -200,17 +201,58 @@ describe('RBAC helpers', () => {
       return key
     })
 
+    const tf = t as unknown as TFunction
+
     expect(
       translateError(
         new Error(
           'user alice does not have permission to get pods in namespace All on cluster cluster-a'
         ),
-        t
+        tf
       )
     ).toBe('alice|read|Pods|All|cluster-a')
 
-    expect(translateError(new Error('boom'), t)).toBe('boom')
-    expect(translateError({ reason: 'nope' }, t)).toBe('common:[object Object]')
+    expect(translateError(new Error('boom'), tf)).toBe('boom')
+    expect(translateError({ reason: 'nope' }, tf)).toBe('common:[object Object]')
+  })
+
+  it('translates CRD not installed errors', () => {
+    const t = vi.fn((key: string, options?: Record<string, string>) => {
+      if (key === 'errors.crdNotInstalled') {
+        return `crd:${options?.kind}:${options?.version}`
+      }
+      return key
+    })
+    const tf = t as unknown as TFunction
+
+    expect(
+      translateError(
+        new Error(
+          'no matches for kind "Gateway" in version "gateway.networking.k8s.io/v1"'
+        ),
+        tf
+      )
+    ).toBe('crd:Gateway:gateway.networking.k8s.io/v1')
+  })
+})
+
+describe('isCRDNotInstalledError', () => {
+  it('detects CRD not installed errors', () => {
+    expect(
+      isCRDNotInstalledError(
+        'no matches for kind "Gateway" in version "gateway.networking.k8s.io/v1"'
+      )
+    ).toBe(true)
+    expect(
+      isCRDNotInstalledError(
+        'no matches for kind "HTTPRoute" in version "gateway.networking.k8s.io/v1"'
+      )
+    ).toBe(true)
+  })
+
+  it('returns false for unrelated errors', () => {
+    expect(isCRDNotInstalledError('connection refused')).toBe(false)
+    expect(isCRDNotInstalledError('')).toBe(false)
   })
 })
 

--- a/ui/src/lib/utils.ts
+++ b/ui/src/lib/utils.ts
@@ -209,12 +209,28 @@ export function isRBACError(errorMessage: string): boolean {
   return !!parseRBACError(errorMessage)
 }
 
+const CRD_NOT_INSTALLED_RE =
+  /no matches for kind "([^"]+)" in version "([^"]+)"/
+
+export function isCRDNotInstalledError(errorMessage: string): boolean {
+  return CRD_NOT_INSTALLED_RE.test(errorMessage)
+}
+
 export function translateError(error: Error | unknown, t: TFunction): string {
   if (!(error instanceof Error)) {
     return t('common.error', {
       error: String(error),
     })
   }
+
+  const crdMatch = CRD_NOT_INSTALLED_RE.exec(error.message)
+  if (crdMatch) {
+    return t('errors.crdNotInstalled', {
+      kind: crdMatch[1],
+      version: crdMatch[2],
+    })
+  }
+
   const rbacInfo = parseRBACError(error.message)
 
   if (!rbacInfo) {


### PR DESCRIPTION
close: https://github.com/kite-org/kite/issues/396

Root cause - The ErrorMessage component had no awareness of "CRD not installed" errors — it treated them identically to generic failures (red XCircle icon, "Error loading..." title, pointless "Try Again" button).

Changes made:

Added isCRDNotInstalledError() that detects the no matches for kind "X" in version "Y" pattern, and updated translateError() to return a human-readable message for it.

Shows a PackageX icon (muted, not alarming red), renders "Resource Type Not Available" as the title, and hides the "Try Again" button since retrying won't help.

Added errors.crdNotInstalledTitle and errors.crdNotInstalled translation keys.