### PR TITLE
Update span class for display value formatting

### DIFF
--- a/ui/src/components/key-value-data-viewer.tsx
+++ b/ui/src/components/key-value-data-viewer.tsx
@@ -119,7 +119,7 @@ export function KeyValueDataViewer({
                 </div>
               </div>
               <div className="bg-muted rounded px-3 py-2 font-mono text-xs break-all">
-                <span className={revealed ? '' : 'blur-sm select-none inline'}>
+                <span className={revealed ? 'whitespace-pre-wrap' : 'blur-sm select-none inline'}>
                   {displayValue}
                 </span>
               </div>


### PR DESCRIPTION
## Summary

修复了多行值在显示时丢失原始换行与缩进格式的问题。

## Why

JSON、TOML、YAML等多行配置在`data`中被渲染成单行，可读性太差。




## Checklist

- [x] I reviewed this PR myself before requesting review.
- [x] I understand the changes, including AI-generated parts (if any).
- [x] For new features, a feature request issue is linked.
- [x] I cleaned up AI noise (unnecessary comments, dead code, and unrelated changes).
- [x] This PR is reasonably scoped (or split into smaller PRs).
