### PR TITLE
Add native Helm release resource support

### DIFF
--- a/pkg/common/resource.go
+++ b/pkg/common/resource.go
@@ -39,6 +39,7 @@ const (
 	Gateways                 ResourceType = "gateways"
 	HTTPRoutes               ResourceType = "httproutes"
 	HorizontalPodAutoscalers ResourceType = "horizontalpodautoscalers"
+	HelmReleases             ResourceType = "helmrelease"
 )
 
 // ResourceMeta holds all metadata for a known Kubernetes resource type.
@@ -111,6 +112,9 @@ var Registry = []ResourceMeta{
 
 	// autoscaling/v2
 	{Kind: "HorizontalPodAutoscaler", Singular: "horizontalpodautoscaler", Plural: HorizontalPodAutoscalers, Short: []string{"hpa"}, Group: "autoscaling", Version: "v2", GlobalSearch: true, Related: true},
+
+	// Synthetic resources
+	{Kind: "HelmRelease", Singular: "helmrelease", Plural: HelmReleases, Short: []string{"hr"}, Version: "v1", Searchable: true, GlobalSearch: true},
 }
 
 // resourceIndex maps lowercase alias → *ResourceMeta for O(1) lookups.

--- a/pkg/handlers/resources/handler.go
+++ b/pkg/handlers/resources/handler.go
@@ -83,6 +83,7 @@ func RegisterRoutes(group *gin.RouterGroup) {
 		string(common.Gateways):                 NewGenericResourceHandler[*gatewayapiv1.Gateway, *gatewayapiv1.GatewayList](common.Gateways),
 		string(common.HTTPRoutes):               NewGenericResourceHandler[*gatewayapiv1.HTTPRoute, *gatewayapiv1.HTTPRouteList](common.HTTPRoutes),
 		string(common.HorizontalPodAutoscalers): NewGenericResourceHandler[*autoscalingv2.HorizontalPodAutoscaler, *autoscalingv2.HorizontalPodAutoscalerList](common.HorizontalPodAutoscalers),
+		string(common.HelmReleases):             NewHelmReleaseHandler(),
 	}
 
 	for name, handler := range handlers {

--- a/pkg/handlers/resources/helmrelease_handler.go
+++ b/pkg/handlers/resources/helmrelease_handler.go
@@ -1,0 +1,644 @@
+package resources
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/zxh326/kite/pkg/cluster"
+	"github.com/zxh326/kite/pkg/common"
+	"github.com/zxh326/kite/pkg/model"
+	"github.com/zxh326/kite/pkg/rbac"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/yaml"
+)
+
+const helmReleaseResourceName = "helmrelease"
+
+type HelmReleaseHandler struct{}
+
+type HelmRelease struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata"`
+	Spec              HelmReleaseSpec   `json:"spec"`
+	Status            HelmReleaseStatus `json:"status"`
+}
+
+type HelmReleaseList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty"`
+	Items           []HelmRelease `json:"items"`
+}
+
+type HelmReleaseSpec struct {
+	ReleaseName  string                 `json:"releaseName"`
+	Namespace    string                 `json:"namespace"`
+	Chart        string                 `json:"chart"`
+	ChartName    string                 `json:"chartName"`
+	ChartVersion string                 `json:"chartVersion"`
+	AppVersion   string                 `json:"appVersion,omitempty"`
+	Revision     int                    `json:"revision"`
+	Values       map[string]interface{} `json:"values,omitempty"`
+	Manifest     string                 `json:"manifest,omitempty"`
+	Notes        string                 `json:"notes,omitempty"`
+	Description  string                 `json:"description,omitempty"`
+	Hooks        []helmHook             `json:"hooks,omitempty"`
+}
+
+type HelmReleaseStatus struct {
+	Status        string                `json:"status"`
+	FirstDeployed *time.Time            `json:"firstDeployed,omitempty"`
+	LastDeployed  *time.Time            `json:"lastDeployed,omitempty"`
+	Deleted       *time.Time            `json:"deleted,omitempty"`
+	Resources     []HelmReleaseResource `json:"resources,omitempty"`
+}
+
+type HelmReleaseResource struct {
+	APIVersion string `json:"apiVersion"`
+	Kind       string `json:"kind"`
+	Name       string `json:"name"`
+	Namespace  string `json:"namespace,omitempty"`
+	Status     string `json:"status,omitempty"`
+}
+
+type helmReleaseFile struct {
+	Name      string                 `json:"name"`
+	Namespace string                 `json:"namespace"`
+	Version   int                    `json:"version"`
+	Manifest  string                 `json:"manifest"`
+	Config    map[string]interface{} `json:"config"`
+	Info      helmInfo               `json:"info"`
+	Chart     helmChart              `json:"chart"`
+	Hooks     []helmHook             `json:"hooks"`
+}
+
+type helmInfo struct {
+	FirstDeployed helmTime `json:"first_deployed"`
+	LastDeployed  helmTime `json:"last_deployed"`
+	Deleted       helmTime `json:"deleted"`
+	Description   string   `json:"description"`
+	Status        string   `json:"status"`
+	Notes         string   `json:"notes"`
+}
+
+type helmChart struct {
+	Metadata helmChartMetadata `json:"metadata"`
+}
+type helmChartMetadata struct {
+	Name       string `json:"name"`
+	Version    string `json:"version"`
+	AppVersion string `json:"appVersion"`
+}
+type helmHook struct {
+	Name     string                 `json:"name"`
+	Kind     string                 `json:"kind"`
+	Path     string                 `json:"path"`
+	Manifest string                 `json:"manifest"`
+	Events   []string               `json:"events"`
+	LastRun  map[string]interface{} `json:"last_run,omitempty"`
+	Weight   int                    `json:"weight,omitempty"`
+}
+
+type helmTime struct{ time.Time }
+
+func (t *helmTime) UnmarshalJSON(b []byte) error {
+	s := strings.Trim(string(b), "\"")
+	if s == "" || s == "null" {
+		return nil
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, s)
+	if err != nil {
+		return err
+	}
+	t.Time = parsed
+	return nil
+}
+func timePtr(t helmTime) *time.Time {
+	if t.IsZero() {
+		return nil
+	}
+	v := t.Time
+	return &v
+}
+
+func NewHelmReleaseHandler() *HelmReleaseHandler    { return &HelmReleaseHandler{} }
+func (h *HelmReleaseHandler) IsClusterScoped() bool { return false }
+func (h *HelmReleaseHandler) Searchable() bool      { return true }
+func (h *HelmReleaseHandler) ListHistory(c *gin.Context) {
+	c.JSON(http.StatusNotImplemented, gin.H{
+		"error": "helm release history is included in Helm storage and is not exposed as resource history yet",
+	})
+}
+func (h *HelmReleaseHandler) Create(c *gin.Context) {
+	c.JSON(http.StatusNotImplemented, gin.H{"error": "installing Helm charts is not supported yet"})
+}
+func (h *HelmReleaseHandler) Update(c *gin.Context) {
+	c.JSON(http.StatusNotImplemented, gin.H{"error": "helm release upgrade is not supported in storage-only mode"})
+}
+func (h *HelmReleaseHandler) Patch(c *gin.Context) {
+	c.JSON(http.StatusNotImplemented, gin.H{"error": "patching Helm releases is not supported"})
+}
+func (h *HelmReleaseHandler) Describe(c *gin.Context) {
+	obj, err := h.get(c, c.Param("namespace"), c.Param("name"), true)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{
+		"result": fmt.Sprintf(
+			"Name: %s\nNamespace: %s\nRevision: %d\nStatus: %s\nChart: %s\nDescription: %s\n",
+			obj.Name,
+			obj.Namespace,
+			obj.Spec.Revision,
+			obj.Status.Status,
+			obj.Spec.Chart,
+			obj.Spec.Description,
+		),
+	})
+}
+
+func (h *HelmReleaseHandler) registerCustomRoutes(group *gin.RouterGroup) {
+	group.POST("/:namespace/:name/upgrade", h.Upgrade)
+	group.POST("/:namespace/:name/rollback", h.Rollback)
+}
+
+func (h *HelmReleaseHandler) List(c *gin.Context) {
+	list, err := h.list(c, c.Param("namespace"), false)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, list)
+}
+func (h *HelmReleaseHandler) Get(c *gin.Context) {
+	obj, err := h.get(c, c.Param("namespace"), c.Param("name"), true)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, obj)
+}
+func (h *HelmReleaseHandler) GetResource(c *gin.Context, namespace, name string) (interface{}, error) {
+	return h.get(c, namespace, name, true)
+}
+
+func (h *HelmReleaseHandler) Search(c *gin.Context, q string, limit int64) ([]common.SearchResult, error) {
+	list, err := h.list(c, common.AllNamespaces, false)
+	if err != nil {
+		return nil, err
+	}
+	results := []common.SearchResult{}
+	for _, item := range list.Items {
+		if !strings.Contains(strings.ToLower(item.Name), strings.ToLower(q)) {
+			continue
+		}
+		results = append(results, common.SearchResult{ID: string(item.UID), Name: item.Name, Namespace: item.Namespace, ResourceType: helmReleaseResourceName, CreatedAt: item.CreationTimestamp.String()})
+		if limit > 0 && int64(len(results)) >= limit {
+			break
+		}
+	}
+	return results, nil
+}
+
+func (h *HelmReleaseHandler) Delete(c *gin.Context) {
+	cs := c.MustGet("cluster").(*cluster.ClientSet)
+	ctx := c.Request.Context()
+	ns, name := c.Param("namespace"), c.Param("name")
+	rel, err := h.get(c, ns, name, true)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	for _, rr := range rel.Status.Resources {
+		_ = deleteManifestResource(ctx, cs, rr)
+	}
+	secrets, err := h.releaseSecrets(ctx, cs, ns, name)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	for i := range secrets {
+		if err := cs.K8sClient.Delete(ctx, &secrets[i]); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+	}
+	c.JSON(http.StatusOK, gin.H{"message": "helm release deleted"})
+}
+
+type helmReleaseActionRequest struct {
+	Revision    int                    `json:"revision"`
+	Manifest    string                 `json:"manifest"`
+	Values      map[string]interface{} `json:"values"`
+	Description string                 `json:"description"`
+}
+
+func (h *HelmReleaseHandler) Upgrade(c *gin.Context) {
+	cs := c.MustGet("cluster").(*cluster.ClientSet)
+	ctx := c.Request.Context()
+	namespace, name := c.Param("namespace"), c.Param("name")
+	var req helmReleaseActionRequest
+	_ = c.ShouldBindJSON(&req)
+
+	secrets, err := h.releaseSecrets(ctx, cs, namespace, name)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	latest, rel, err := latestHelmReleaseSecret(secrets)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	if req.Manifest != "" {
+		rel.Manifest = req.Manifest
+	}
+	if req.Values != nil {
+		rel.Config = req.Values
+	}
+	description := req.Description
+	if description == "" {
+		description = "Upgrade requested from Kite"
+	}
+	if err := h.createRevision(ctx, cs, latest, rel, description); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"message": "helm release upgraded"})
+}
+
+func (h *HelmReleaseHandler) Rollback(c *gin.Context) {
+	cs := c.MustGet("cluster").(*cluster.ClientSet)
+	ctx := c.Request.Context()
+	namespace, name := c.Param("namespace"), c.Param("name")
+	var req helmReleaseActionRequest
+	_ = c.ShouldBindJSON(&req)
+
+	secrets, err := h.releaseSecrets(ctx, cs, namespace, name)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	if len(secrets) == 0 {
+		c.JSON(http.StatusNotFound, gin.H{"error": fmt.Sprintf("helm release %s/%s not found", namespace, name)})
+		return
+	}
+	sort.Slice(secrets, func(i, j int) bool {
+		return helmSecretVersion(secrets[i]) > helmSecretVersion(secrets[j])
+	})
+	targetRevision := req.Revision
+	if targetRevision == 0 && len(secrets) > 1 {
+		targetRevision = helmSecretVersion(secrets[1])
+	}
+	if targetRevision == 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "no previous helm release revision found"})
+		return
+	}
+	var target *corev1.Secret
+	for i := range secrets {
+		if helmSecretVersion(secrets[i]) == targetRevision {
+			target = &secrets[i]
+			break
+		}
+	}
+	if target == nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("revision %d not found", targetRevision)})
+		return
+	}
+	rel, err := decodeHelmReleaseSecret(*target)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	description := req.Description
+	if description == "" {
+		description = fmt.Sprintf("Rollback to %d requested from Kite", targetRevision)
+	}
+	if err := h.createRevision(ctx, cs, secrets[0], rel, description); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"message": "helm release rolled back", "revision": targetRevision})
+}
+
+func (h *HelmReleaseHandler) createRevision(
+	ctx context.Context,
+	cs *cluster.ClientSet,
+	latest corev1.Secret,
+	rel *helmReleaseFile,
+	description string,
+) error {
+	if err := applyManifestResources(ctx, cs, rel.Manifest, rel.Namespace); err != nil {
+		return err
+	}
+	nextVersion := helmSecretVersion(latest) + 1
+	rel.Version = nextVersion
+	rel.Info.Status = "deployed"
+	rel.Info.Description = description
+	rel.Info.LastDeployed = helmTime{Time: time.Now().UTC()}
+	rel.Info.Deleted = helmTime{}
+
+	payload, err := encodeHelmRelease(rel)
+	if err != nil {
+		return err
+	}
+	labels := map[string]string{}
+	for k, v := range latest.Labels {
+		labels[k] = v
+	}
+	labels["owner"] = "helm"
+	labels["name"] = rel.Name
+	labels["status"] = "deployed"
+	labels["version"] = strconv.Itoa(nextVersion)
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("sh.helm.release.v1.%s.v%d", rel.Name, nextVersion),
+			Namespace: rel.Namespace,
+			Labels:    labels,
+		},
+		Type: corev1.SecretType("helm.sh/release.v1"),
+		Data: map[string][]byte{"release": payload},
+	}
+	if latest.Labels == nil {
+		latest.Labels = map[string]string{}
+	}
+	latest.Labels["status"] = "superseded"
+	_ = cs.K8sClient.Update(ctx, &latest)
+	return cs.K8sClient.Create(ctx, secret)
+}
+
+func (h *HelmReleaseHandler) list(c *gin.Context, namespace string, details bool) (*HelmReleaseList, error) {
+	cs := c.MustGet("cluster").(*cluster.ClientSet)
+	user := c.MustGet("user").(model.User)
+	ctx := c.Request.Context()
+	var opts []client.ListOption
+	opts = append(opts, client.MatchingLabels{"owner": "helm"})
+	if namespace != "" && namespace != common.AllNamespaces {
+		opts = append(opts, client.InNamespace(namespace))
+	}
+	var secretList corev1.SecretList
+	if err := cs.K8sClient.List(ctx, &secretList, opts...); err != nil {
+		return nil, err
+	}
+	latest := map[string]HelmRelease{}
+	for i := range secretList.Items {
+		sec := secretList.Items[i]
+		if namespace == common.AllNamespaces && !rbac.CanAccessNamespace(user, cs.Name, sec.Namespace) {
+			continue
+		}
+		rel, err := decodeHelmReleaseSecret(sec)
+		if err != nil {
+			continue
+		}
+		hr := toHelmRelease(sec, rel)
+		if details {
+			hr.Status.Resources = resolveManifestResources(ctx, cs, rel.Manifest, rel.Namespace)
+		}
+		key := hr.Namespace + "/" + hr.Name
+		if prev, ok := latest[key]; !ok || hr.Spec.Revision > prev.Spec.Revision {
+			latest[key] = hr
+		}
+	}
+	items := make([]HelmRelease, 0, len(latest))
+	for _, v := range latest {
+		items = append(items, v)
+	}
+	sort.Slice(items, func(i, j int) bool {
+		return items[i].CreationTimestamp.After(items[j].CreationTimestamp.Time)
+	})
+	return &HelmReleaseList{TypeMeta: metav1.TypeMeta{Kind: "HelmReleaseList", APIVersion: "v1"}, Items: items}, nil
+}
+
+func (h *HelmReleaseHandler) get(c *gin.Context, namespace, name string, details bool) (*HelmRelease, error) {
+	cs := c.MustGet("cluster").(*cluster.ClientSet)
+	ctx := c.Request.Context()
+	secrets, err := h.releaseSecrets(ctx, cs, namespace, name)
+	if err != nil {
+		return nil, err
+	}
+	if len(secrets) == 0 {
+		return nil, fmt.Errorf("helm release %s/%s not found", namespace, name)
+	}
+	sort.Slice(secrets, func(i, j int) bool {
+		return helmSecretVersion(secrets[i]) > helmSecretVersion(secrets[j])
+	})
+	rel, err := decodeHelmReleaseSecret(secrets[0])
+	if err != nil {
+		return nil, err
+	}
+	hr := toHelmRelease(secrets[0], rel)
+	if details {
+		hr.Status.Resources = resolveManifestResources(ctx, cs, rel.Manifest, rel.Namespace)
+	}
+	return &hr, nil
+}
+
+func latestHelmReleaseSecret(secrets []corev1.Secret) (corev1.Secret, *helmReleaseFile, error) {
+	if len(secrets) == 0 {
+		return corev1.Secret{}, nil, fmt.Errorf("helm release not found")
+	}
+	sort.Slice(secrets, func(i, j int) bool {
+		return helmSecretVersion(secrets[i]) > helmSecretVersion(secrets[j])
+	})
+	rel, err := decodeHelmReleaseSecret(secrets[0])
+	if err != nil {
+		return corev1.Secret{}, nil, err
+	}
+	return secrets[0], rel, nil
+}
+
+func (h *HelmReleaseHandler) releaseSecrets(ctx context.Context, cs *cluster.ClientSet, namespace, name string) ([]corev1.Secret, error) {
+	var sl corev1.SecretList
+	opts := []client.ListOption{client.InNamespace(namespace), client.MatchingLabels{"owner": "helm", "name": name}}
+	if err := cs.K8sClient.List(ctx, &sl, opts...); err != nil {
+		return nil, err
+	}
+	return sl.Items, nil
+}
+
+func decodeHelmReleaseSecret(sec corev1.Secret) (*helmReleaseFile, error) {
+	raw, ok := sec.Data["release"]
+	if !ok {
+		return nil, fmt.Errorf("secret %s has no release payload", sec.Name)
+	}
+	decoded, err := base64.StdEncoding.DecodeString(string(raw))
+	if err != nil {
+		decoded = raw
+	}
+	gz, err := gzip.NewReader(bytes.NewReader(decoded))
+	if err == nil {
+		defer gz.Close()
+		decoded, err = io.ReadAll(gz)
+		if err != nil {
+			return nil, err
+		}
+	}
+	var rel helmReleaseFile
+	if err := json.Unmarshal(decoded, &rel); err != nil {
+		return nil, err
+	}
+	return &rel, nil
+}
+
+func encodeHelmRelease(rel *helmReleaseFile) ([]byte, error) {
+	jsonPayload, err := json.Marshal(rel)
+	if err != nil {
+		return nil, err
+	}
+	var compressed bytes.Buffer
+	gz := gzip.NewWriter(&compressed)
+	if _, err := gz.Write(jsonPayload); err != nil {
+		_ = gz.Close()
+		return nil, err
+	}
+	if err := gz.Close(); err != nil {
+		return nil, err
+	}
+	encoded := base64.StdEncoding.EncodeToString(compressed.Bytes())
+	return []byte(encoded), nil
+}
+
+func toHelmRelease(sec corev1.Secret, rel *helmReleaseFile) HelmRelease {
+	chart := rel.Chart.Metadata.Name
+	if rel.Chart.Metadata.Version != "" {
+		chart += "-" + rel.Chart.Metadata.Version
+	}
+	return HelmRelease{
+		TypeMeta: metav1.TypeMeta{Kind: "HelmRelease", APIVersion: "v1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              rel.Name,
+			Namespace:         rel.Namespace,
+			UID:               sec.UID,
+			ResourceVersion:   sec.ResourceVersion,
+			CreationTimestamp: sec.CreationTimestamp,
+			Labels:            sec.Labels,
+			Annotations:       sec.Annotations,
+		},
+		Spec: HelmReleaseSpec{
+			ReleaseName:  rel.Name,
+			Namespace:    rel.Namespace,
+			Chart:        chart,
+			ChartName:    rel.Chart.Metadata.Name,
+			ChartVersion: rel.Chart.Metadata.Version,
+			AppVersion:   rel.Chart.Metadata.AppVersion,
+			Revision:     rel.Version,
+			Values:       rel.Config,
+			Manifest:     rel.Manifest,
+			Notes:        rel.Info.Notes,
+			Description:  rel.Info.Description,
+			Hooks:        rel.Hooks,
+		},
+		Status: HelmReleaseStatus{
+			Status:        rel.Info.Status,
+			FirstDeployed: timePtr(rel.Info.FirstDeployed),
+			LastDeployed:  timePtr(rel.Info.LastDeployed),
+			Deleted:       timePtr(rel.Info.Deleted),
+		},
+	}
+}
+
+func helmSecretVersion(sec corev1.Secret) int {
+	if v := sec.Labels["version"]; v != "" {
+		n, _ := strconv.Atoi(v)
+		return n
+	}
+	parts := strings.Split(sec.Name, ".v")
+	if len(parts) > 1 {
+		n, _ := strconv.Atoi(parts[len(parts)-1])
+		return n
+	}
+	return 0
+}
+
+func resolveManifestResources(ctx context.Context, cs *cluster.ClientSet, manifest, defaultNamespace string) []HelmReleaseResource {
+	docs := strings.Split(manifest, "\n---")
+	out := []HelmReleaseResource{}
+	for _, doc := range docs {
+		doc = strings.TrimSpace(doc)
+		if doc == "" {
+			continue
+		}
+		var u unstructured.Unstructured
+		if err := yaml.Unmarshal([]byte(doc), &u.Object); err != nil || u.GetKind() == "" || u.GetName() == "" {
+			continue
+		}
+		ns := u.GetNamespace()
+		if ns == "" {
+			ns = defaultNamespace
+		}
+		rr := HelmReleaseResource{
+			APIVersion: u.GetAPIVersion(),
+			Kind:       u.GetKind(),
+			Name:       u.GetName(),
+			Namespace:  ns,
+		}
+		live := &unstructured.Unstructured{}
+		live.SetGroupVersionKind(u.GroupVersionKind())
+		key := types.NamespacedName{Name: u.GetName(), Namespace: ns}
+		if err := cs.K8sClient.Get(ctx, key, live); err == nil {
+			rr.Status = "Ready"
+		} else {
+			rr.Status = "NotFound"
+		}
+		out = append(out, rr)
+	}
+	return out
+}
+
+func applyManifestResources(ctx context.Context, cs *cluster.ClientSet, manifest, defaultNamespace string) error {
+	docs := strings.Split(manifest, "\n---")
+	for _, doc := range docs {
+		doc = strings.TrimSpace(doc)
+		if doc == "" {
+			continue
+		}
+		var u unstructured.Unstructured
+		if err := yaml.Unmarshal([]byte(doc), &u.Object); err != nil || u.GetKind() == "" || u.GetName() == "" {
+			continue
+		}
+		if u.GetNamespace() == "" {
+			u.SetNamespace(defaultNamespace)
+		}
+		if err := cs.K8sClient.Patch(
+			ctx,
+			&u,
+			client.Apply,
+			client.FieldOwner("kite-helmrelease"),
+			client.ForceOwnership,
+		); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func deleteManifestResource(ctx context.Context, cs *cluster.ClientSet, rr HelmReleaseResource) error {
+	gv, err := schema.ParseGroupVersion(rr.APIVersion)
+	if err != nil {
+		return err
+	}
+	u := &unstructured.Unstructured{}
+	u.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   gv.Group,
+		Version: gv.Version,
+		Kind:    rr.Kind,
+	})
+	u.SetName(rr.Name)
+	u.SetNamespace(rr.Namespace)
+	return cs.K8sClient.Delete(ctx, u)
+}

--- a/ui/src/contexts/sidebar-config-defaults.ts
+++ b/ui/src/contexts/sidebar-config-defaults.ts
@@ -48,7 +48,13 @@ resourceCatalog
     })
   })
 
-export const SIDEBAR_CONFIG_VERSION = 1
+defaultMenus['sidebar.groups.application'].push({
+  titleKey: 'nav.chartRepositories',
+  url: '/chartrepositories',
+  icon: getResourceIconComponent('IconPackage'),
+})
+
+export const SIDEBAR_CONFIG_VERSION = 2
 
 function getIconName(iconComponent: ComponentType<{ className?: string }>) {
   const entry = Object.entries(sidebarIconMap).find(

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -340,7 +340,8 @@
       "config": "config",
       "other": "other",
       "security": "Security",
-      "workloads": "Workloads"
+      "workloads": "Workloads",
+      "application": "Application"
     },
     "short": {
       "pvcs": "PVCs",
@@ -394,7 +395,9 @@
     "rolebindings": "Role Bindings",
     "clusterroles": "Cluster Roles",
     "clusterrolebindings": "Cluster Role Bindings",
-    "horizontalpodautoscalers": "HPA"
+    "horizontalpodautoscalers": "HPA",
+    "helmReleases": "Helm Release",
+    "chartRepositories": "Chart Repository"
   },
   "overview": {
     "title": "Overview",
@@ -992,5 +995,32 @@
     "forceDelete": "Force delete (set grace period to 0)",
     "finalizerNote": "If finalizers exist and resource is not deleted after 3 seconds, finalizers will be removed automatically",
     "deleting": "Deleting..."
+  },
+  "helm": {
+    "actions": {
+      "upgrade": "Upgrade",
+      "rollback": "Rollback"
+    },
+    "fields": {
+      "chart": "Chart",
+      "version": "Version",
+      "appVersion": "App Version",
+      "lastDeployed": "Last Deployed",
+      "rollbackRevision": "Revision"
+    },
+    "tabs": {
+      "manifest": "Manifest",
+      "values": "Values",
+      "notes": "Notes"
+    },
+    "messages": {
+      "noResources": "No resources found",
+      "upgradeStarted": "Upgrade requested",
+      "rollbackStarted": "Rollback requested",
+      "chartRepositoryTodo": "Chart repository management is not implemented yet."
+    },
+    "placeholders": {
+      "latestPrevious": "Previous revision"
+    }
   }
 }

--- a/ui/src/i18n/locales/zh.json
+++ b/ui/src/i18n/locales/zh.json
@@ -340,7 +340,8 @@
       "config": "配置",
       "other": "其他",
       "security": "安全",
-      "workloads": "工作负载"
+      "workloads": "工作负载",
+      "application": "应用"
     },
     "short": {
       "pvcs": "PVCs",
@@ -400,7 +401,9 @@
     "rolebindings": "RoleBindings",
     "clusterroles": "ClusterRoles",
     "clusterrolebindings": "ClusterRoleBindings",
-    "horizontalpodautoscalers": "HPA"
+    "horizontalpodautoscalers": "HPA",
+    "helmReleases": "Helm Release",
+    "chartRepositories": "Chart Repository"
   },
   "overview": {
     "title": "概览",
@@ -1080,5 +1083,32 @@
   },
   "log": {
     "jumpToBottom": "跳到底部"
+  },
+  "helm": {
+    "actions": {
+      "upgrade": "升级",
+      "rollback": "回滚"
+    },
+    "fields": {
+      "chart": "Chart",
+      "version": "版本",
+      "appVersion": "App 版本",
+      "lastDeployed": "上次部署",
+      "rollbackRevision": "版本号"
+    },
+    "tabs": {
+      "manifest": "Manifest",
+      "values": "Values",
+      "notes": "Notes"
+    },
+    "messages": {
+      "noResources": "未找到资源",
+      "upgradeStarted": "已发起升级",
+      "rollbackStarted": "已发起回滚",
+      "chartRepositoryTodo": "Chart Repository 管理功能暂未实现。"
+    },
+    "placeholders": {
+      "latestPrevious": "上一个版本"
+    }
   }
 }

--- a/ui/src/lib/api/core.ts
+++ b/ui/src/lib/api/core.ts
@@ -113,6 +113,28 @@ export const scaleDeployment = async (
   return response
 }
 
+export const upgradeHelmRelease = async (
+  namespace: string,
+  name: string,
+  body?: Record<string, unknown>
+): Promise<{ message?: string }> => {
+  return apiClient.post<{ message?: string }>(
+    `/helmrelease/${namespace}/${name}/upgrade`,
+    body || {}
+  )
+}
+
+export const rollbackHelmRelease = async (
+  namespace: string,
+  name: string,
+  revision?: number
+): Promise<{ message?: string }> => {
+  return apiClient.post<{ message?: string }>(
+    `/helmrelease/${namespace}/${name}/rollback`,
+    revision ? { revision } : {}
+  )
+}
+
 // Node operation APIs
 export const drainNode = async (
   nodeName: string,

--- a/ui/src/lib/resource-catalog.ts
+++ b/ui/src/lib/resource-catalog.ts
@@ -12,6 +12,7 @@ import {
   IconLock,
   IconMap,
   IconNetwork,
+  IconPackage,
   IconPlayerPlay,
   IconRocket,
   IconRoute,
@@ -32,12 +33,14 @@ type SidebarGroupKey =
   | 'sidebar.groups.config'
   | 'sidebar.groups.security'
   | 'sidebar.groups.other'
+  | 'sidebar.groups.application'
 
 export const resourceIconMap = {
   IconBox,
   IconRocket,
   IconStack2,
   IconTopologyBus,
+  IconPackage,
   IconPlayerPlay,
   IconClockHour4,
   IconRouter,
@@ -85,6 +88,7 @@ export const sidebarGroupOrder = [
   'sidebar.groups.config',
   'sidebar.groups.security',
   'sidebar.groups.other',
+  'sidebar.groups.application',
 ] as const satisfies readonly SidebarGroupKey[]
 
 export const resourceCatalog = [
@@ -399,6 +403,16 @@ export const resourceCatalog = [
     titleKey: 'nav.poddisruptionbudgets',
     icon: 'IconShield',
     sidebar: { groupKey: 'sidebar.groups.config', order: 3 },
+  },
+  {
+    type: 'helmrelease',
+    singular: 'helmrelease',
+    singularLabel: 'Helm Release',
+    pluralLabel: 'Helm Releases',
+    clusterScope: false,
+    titleKey: 'nav.helmReleases',
+    icon: 'IconPackage',
+    sidebar: { groupKey: 'sidebar.groups.application', order: 0 },
   },
 ] as const satisfies readonly ResourceCatalogEntryBase[]
 

--- a/ui/src/pages/chart-repository-page.tsx
+++ b/ui/src/pages/chart-repository-page.tsx
@@ -1,0 +1,17 @@
+import { useTranslation } from 'react-i18next'
+
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+
+export function ChartRepositoryPage() {
+  const { t } = useTranslation()
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{t('nav.chartRepositories')}</CardTitle>
+      </CardHeader>
+      <CardContent className="text-sm text-muted-foreground">
+        {t('helm.messages.chartRepositoryTodo')}
+      </CardContent>
+    </Card>
+  )
+}

--- a/ui/src/pages/helmrelease-detail.tsx
+++ b/ui/src/pages/helmrelease-detail.tsx
@@ -1,0 +1,283 @@
+import { useMemo, useState } from 'react'
+import * as yaml from 'js-yaml'
+import { useTranslation } from 'react-i18next'
+import { toast } from 'sonner'
+
+import { HelmRelease, HelmReleaseResource } from '@/types/api'
+import { rollbackHelmRelease, upgradeHelmRelease, useResource } from '@/lib/api'
+import { translateError } from '@/lib/utils'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover'
+import { SimpleTable } from '@/components/simple-table'
+import { YamlEditor } from '@/components/yaml-editor'
+
+import {
+  ResourceDetailShell,
+  type ResourceDetailShellTab,
+} from './resource-detail-shell'
+
+function TextCard({ title, content }: { title: string; content?: string }) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{title}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {content ? (
+          <pre className="max-h-[60vh] overflow-auto whitespace-pre-wrap rounded-md bg-muted p-3 text-sm">
+            {content}
+          </pre>
+        ) : (
+          <div className="text-sm text-muted-foreground">No data</div>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+function ResourcesTable({ resources }: { resources?: HelmReleaseResource[] }) {
+  const { t } = useTranslation()
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{t('common.fields.resources')}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <SimpleTable
+          data={resources || []}
+          emptyMessage={t('helm.messages.noResources')}
+          columns={[
+            {
+              header: 'Kind',
+              accessor: (item) => item.kind,
+              cell: (value) => value as string,
+              align: 'left',
+            },
+            {
+              header: t('common.fields.name'),
+              accessor: (item) => item.name,
+              cell: (value) => value as string,
+              align: 'left',
+            },
+            {
+              header: t('common.fields.namespace'),
+              accessor: (item) => item.namespace || '-',
+              cell: (value) => value as string,
+              align: 'left',
+            },
+            {
+              header: 'API Version',
+              accessor: (item) => item.apiVersion,
+              cell: (value) => value as string,
+              align: 'left',
+            },
+            {
+              header: t('common.fields.status'),
+              accessor: (item) => item.status || '-',
+              cell: (value) => value as string,
+            },
+          ]}
+          pagination={{ enabled: true, pageSize: 10 }}
+        />
+      </CardContent>
+    </Card>
+  )
+}
+
+export function HelmReleaseDetail(props: { namespace: string; name: string }) {
+  const { namespace, name } = props
+  const { t } = useTranslation()
+  const [rollbackRevision, setRollbackRevision] = useState('')
+  const [isRollbackOpen, setIsRollbackOpen] = useState(false)
+  const [isActionLoading, setIsActionLoading] = useState(false)
+  const { data, isLoading, error, refetch } = useResource(
+    'helmrelease',
+    name,
+    namespace
+  )
+
+  const handleUpgrade = async () => {
+    setIsActionLoading(true)
+    try {
+      await upgradeHelmRelease(namespace, name)
+      toast.success(t('helm.messages.upgradeStarted'))
+      await refetch()
+    } catch (err) {
+      toast.error(translateError(err, t))
+    } finally {
+      setIsActionLoading(false)
+    }
+  }
+
+  const handleRollback = async () => {
+    setIsActionLoading(true)
+    try {
+      await rollbackHelmRelease(
+        namespace,
+        name,
+        rollbackRevision ? Number(rollbackRevision) : undefined
+      )
+      toast.success(t('helm.messages.rollbackStarted'))
+      setIsRollbackOpen(false)
+      await refetch()
+    } catch (err) {
+      toast.error(translateError(err, t))
+    } finally {
+      setIsActionLoading(false)
+    }
+  }
+
+  const tabs = useMemo<ResourceDetailShellTab<HelmRelease>[]>(
+    () => [
+      {
+        value: 'manifest',
+        label: t('helm.tabs.manifest'),
+        content: data ? (
+          <YamlEditor
+            value={data.spec?.manifest || ''}
+            title={t('helm.tabs.manifest')}
+            readOnly
+            showControls={false}
+          />
+        ) : null,
+      },
+      {
+        value: 'values',
+        label: t('helm.tabs.values'),
+        content: data ? (
+          <YamlEditor
+            value={yaml.dump(data.spec?.values || {}, { indent: 2 })}
+            title={t('helm.tabs.values')}
+            readOnly
+            showControls={false}
+          />
+        ) : null,
+      },
+      {
+        value: 'resources',
+        label: t('common.fields.resources'),
+        content: <ResourcesTable resources={data?.status?.resources} />,
+      },
+      {
+        value: 'notes',
+        label: t('helm.tabs.notes'),
+        content: (
+          <TextCard title={t('helm.tabs.notes')} content={data?.spec?.notes} />
+        ),
+      },
+      {
+        value: 'description',
+        label: t('common.fields.description'),
+        content: (
+          <TextCard
+            title={t('common.fields.description')}
+            content={data?.spec?.description}
+          />
+        ),
+      },
+    ],
+    [data, t]
+  )
+
+  return (
+    <ResourceDetailShell
+      resourceType="helmrelease"
+      resourceLabel="Helm Release"
+      name={name}
+      namespace={namespace}
+      data={data}
+      isLoading={isLoading}
+      error={error}
+      onRefresh={refetch}
+      overview={
+        data ? (
+          <Card>
+            <CardHeader>
+              <CardTitle>{t('common.fields.basicInformation')}</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="grid gap-x-8 gap-y-3 md:grid-cols-2">
+                {[
+                  [t('helm.fields.chart'), data.spec?.chart || '-'],
+                  [t('helm.fields.version'), data.spec?.chartVersion || '-'],
+                  [t('common.fields.revision'), data.spec?.revision || '-'],
+                  [t('common.fields.status'), data.status?.status || '-'],
+                  [t('helm.fields.appVersion'), data.spec?.appVersion || '-'],
+                  [
+                    t('helm.fields.lastDeployed'),
+                    data.status?.lastDeployed || '-',
+                  ],
+                  [
+                    t('common.fields.resourceVersion'),
+                    data.metadata?.resourceVersion || '-',
+                  ],
+                  [t('common.fields.uid'), data.metadata?.uid || '-'],
+                ].map(([label, value]) => (
+                  <div key={String(label)} className="space-y-1">
+                    <div className="text-xs font-medium uppercase text-muted-foreground">
+                      {label}
+                    </div>
+                    <div className="break-all text-sm">{value}</div>
+                  </div>
+                ))}
+              </div>
+            </CardContent>
+          </Card>
+        ) : null
+      }
+      preYamlTabs={tabs}
+      showDelete
+      headerActions={
+        <>
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={isActionLoading}
+            onClick={handleUpgrade}
+          >
+            {t('helm.actions.upgrade')}
+          </Button>
+          <Popover open={isRollbackOpen} onOpenChange={setIsRollbackOpen}>
+            <PopoverTrigger asChild>
+              <Button variant="outline" size="sm" disabled={isActionLoading}>
+                {t('helm.actions.rollback')}
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent className="w-72">
+              <div className="space-y-3">
+                <div className="space-y-1">
+                  <Label htmlFor="rollback-revision">
+                    {t('helm.fields.rollbackRevision')}
+                  </Label>
+                  <Input
+                    id="rollback-revision"
+                    type="number"
+                    min="1"
+                    value={rollbackRevision}
+                    onChange={(e) => setRollbackRevision(e.target.value)}
+                    placeholder={t('helm.placeholders.latestPrevious')}
+                  />
+                </div>
+                <Button
+                  size="sm"
+                  className="w-full"
+                  disabled={isActionLoading}
+                  onClick={handleRollback}
+                >
+                  {t('helm.actions.rollback')}
+                </Button>
+              </div>
+            </PopoverContent>
+          </Popover>
+        </>
+      }
+    />
+  )
+}

--- a/ui/src/pages/helmrelease-list-page.tsx
+++ b/ui/src/pages/helmrelease-list-page.tsx
@@ -1,0 +1,83 @@
+import { useMemo } from 'react'
+import { createColumnHelper } from '@tanstack/react-table'
+import { useTranslation } from 'react-i18next'
+import { Link } from 'react-router-dom'
+
+import { HelmRelease } from '@/types/api'
+import { createSearchFilter } from '@/lib/k8s'
+import { formatDate } from '@/lib/utils'
+import { Badge } from '@/components/ui/badge'
+import { ResourceTable } from '@/components/resource-table'
+
+const helmReleaseSearchFilter = createSearchFilter<HelmRelease>(
+  (release) => release.metadata?.name,
+  (release) => release.metadata?.namespace,
+  (release) => release.spec?.chart,
+  (release) => release.status?.status
+)
+
+export function HelmReleaseListPage() {
+  const { t } = useTranslation()
+  const columnHelper = createColumnHelper<HelmRelease>()
+
+  const columns = useMemo(
+    () => [
+      columnHelper.accessor((row) => row.metadata?.name, {
+        id: 'name',
+        header: t('common.fields.name'),
+        cell: ({ row }) => (
+          <div className="font-medium app-link">
+            <Link
+              to={`/helmrelease/${row.original.metadata?.namespace}/${row.original.metadata?.name}`}
+            >
+              {row.original.metadata?.name}
+            </Link>
+          </div>
+        ),
+      }),
+      columnHelper.accessor((row) => row.spec?.chartName || row.spec?.chart, {
+        id: 'chart',
+        header: t('helm.fields.chart'),
+        cell: ({ getValue }) => getValue() || '-',
+      }),
+      columnHelper.accessor((row) => row.spec?.chartVersion, {
+        id: 'version',
+        header: t('helm.fields.version'),
+        cell: ({ getValue }) => getValue() || '-',
+      }),
+      columnHelper.accessor((row) => row.spec?.revision, {
+        id: 'revision',
+        header: t('common.fields.revision'),
+        cell: ({ getValue }) => getValue() || '-',
+      }),
+      columnHelper.accessor((row) => row.status?.status, {
+        id: 'status',
+        header: t('common.fields.status'),
+        cell: ({ getValue }) => (
+          <Badge variant="outline" className="text-muted-foreground px-1.5">
+            {getValue() || '-'}
+          </Badge>
+        ),
+      }),
+      columnHelper.accessor((row) => row.status?.lastDeployed, {
+        id: 'lastDeployed',
+        header: t('helm.fields.lastDeployed'),
+        cell: ({ getValue }) => (
+          <span className="text-muted-foreground text-sm">
+            {getValue() ? formatDate(getValue() || '') : '-'}
+          </span>
+        ),
+      }),
+    ],
+    [columnHelper, t]
+  )
+
+  return (
+    <ResourceTable
+      resourceName="Helm Releases"
+      resourceType="helmrelease"
+      columns={columns}
+      searchQueryFilter={helmReleaseSearchFilter}
+    />
+  )
+}

--- a/ui/src/pages/resource-definitions.tsx
+++ b/ui/src/pages/resource-definitions.tsx
@@ -21,6 +21,8 @@ import { DeploymentDetail } from './deployment-detail'
 import { DeploymentListPage } from './deployment-list-page'
 import { EventListPage } from './event-list-page'
 import { GatewayListPage } from './gateway-list-page'
+import { HelmReleaseDetail } from './helmrelease-detail'
+import { HelmReleaseListPage } from './helmrelease-list-page'
 import { HorizontalPodAutoscalerListPage } from './horizontalpodautoscaler-list-page'
 import { HTTPRouteListPage } from './httproute-list-page'
 import { IngressListPage } from './ingress-list-page'
@@ -161,6 +163,13 @@ function getResourceViews(resourceType: ResourceType): ResourceViewDefinition {
     case 'httproutes':
       return {
         listPage: () => <HTTPRouteListPage />,
+      }
+    case 'helmrelease':
+      return {
+        listPage: () => <HelmReleaseListPage />,
+        detailPage: ({ name, namespace }: ResourceDetailProps) => (
+          <HelmReleaseDetail namespace={namespace!} name={name} />
+        ),
       }
     default:
       return {}

--- a/ui/src/routes.tsx
+++ b/ui/src/routes.tsx
@@ -4,6 +4,7 @@ import App, { StandaloneAIChatApp } from './App'
 import { InitCheckRoute } from './components/init-check-route'
 import { ProtectedRoute } from './components/protected-route'
 import { getSubPath } from './lib/subpath'
+import { ChartRepositoryPage } from './pages/chart-repository-page'
 import { CRListPage } from './pages/cr-list-page'
 import { InitializationPage } from './pages/initialization'
 import { LoginPage } from './pages/login'
@@ -63,6 +64,10 @@ export const router = createBrowserRouter(
         {
           path: 'crds/:crd',
           element: <CRListPage />,
+        },
+        {
+          path: 'chartrepositories',
+          element: <ChartRepositoryPage />,
         },
         {
           path: 'crds/:resource/:namespace/:name',

--- a/ui/src/types/api.ts
+++ b/ui/src/types/api.ts
@@ -99,6 +99,55 @@ export interface DeploymentRelatedResource {
   services: Service[]
 }
 
+export interface HelmReleaseResource {
+  apiVersion: string
+  kind: string
+  name: string
+  namespace?: string
+  status?: string
+}
+
+export interface HelmRelease {
+  apiVersion: 'v1'
+  kind: 'HelmRelease'
+  metadata: {
+    name: string
+    namespace: string
+    uid?: string
+    resourceVersion?: string
+    creationTimestamp?: string
+    labels?: Record<string, string>
+    annotations?: Record<string, string>
+  }
+  spec: {
+    releaseName: string
+    namespace: string
+    chart: string
+    chartName: string
+    chartVersion: string
+    appVersion?: string
+    revision: number
+    values?: Record<string, unknown>
+    manifest?: string
+    notes?: string
+    description?: string
+  }
+  status: {
+    status: string
+    firstDeployed?: string
+    lastDeployed?: string
+    deleted?: string
+    resources?: HelmReleaseResource[]
+  }
+}
+
+export interface HelmReleaseList {
+  apiVersion: 'v1'
+  kind: 'HelmReleaseList'
+  items: HelmRelease[]
+  metadata?: listMetadataType
+}
+
 type listMetadataType = {
   continue?: string
   remainingItemCount?: number
@@ -154,6 +203,7 @@ export interface ResourcesTypeMap {
   clusterroles: ClusterRoleList
   clusterrolebindings: ClusterRoleBindingList
   horizontalpodautoscalers: HorizontalPodAutoscalerList
+  helmrelease: HelmReleaseList
 }
 
 export interface PodMetrics {
@@ -225,6 +275,7 @@ export interface ResourceTypeMap {
   clusterroles: ClusterRole
   clusterrolebindings: ClusterRoleBinding
   horizontalpodautoscalers: HorizontalPodAutoscaler
+  helmrelease: HelmRelease
 }
 
 export interface RecentEvent {


### PR DESCRIPTION
### Motivation

- Expose Helm v3 releases as a first-class read-only resource to allow users to browse installed releases and take management actions from the UI.  
- Keep the UI/UX consistent with existing Kubernetes resource pages by reusing `ResourceTable` and `ResourceDetailShell` components and making Helm releases discoverable like other resources.

### Description

- Backend: introduce a new handler `pkg/handlers/resources/helmrelease_handler.go` that treats Helm v3 release Secrets as `HelmRelease`/`HelmReleaseList`, implements listing, getting, searching, deleting, and storage-only `upgrade`/`rollback` endpoints, decodes Helm release payloads, resolves manifest resources, and (in storage-mode) can create new revision Secrets and apply manifests via the cluster client.  
- Registration: register `helmrelease` as a resource in `pkg/common/resource.go` and add `NewHelmReleaseHandler()` to the resources registry in `pkg/handlers/resources/handler.go` so it is exposed under `/api/v1/helmrelease`.  
- Frontend: add types and API helpers (`ui/src/types/api.ts`, `ui/src/lib/api/core.ts`), add `helmrelease` to the resource catalog and Application sidebar group (`ui/src/lib/resource-catalog.ts`, `ui/src/contexts/sidebar-config-defaults.ts`), and wire resource views in `ui/src/pages/resource-definitions.tsx`.  
- UI pages: add a list view `ui/src/pages/helmrelease-list-page.tsx` and a detail view `ui/src/pages/helmrelease-detail.tsx` (manifest/values/resources/notes/description tabs and upgrade/rollback actions), plus a placeholder `ChartRepository` page `ui/src/pages/chart-repository-page.tsx` and i18n strings for Helm UI elements.  

### Testing

- Ran backend unit/build checks with `go test -vet=off ./pkg/handlers/resources ./pkg/common` and they passed.  
- Ran frontend type-check `cd ui && pnpm exec tsc --noEmit` and it succeeded.  
- Ran ESLint checks for the modified UI files (`pnpm exec eslint ...`) and they completed without errors.  
- Manual code formatting/validation was applied to new/modified UI files (prettier/tsc/eslint as part of the verification above).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc44a9966c832fa70f974b3a062f06)