### PR TITLE
[codex] Improve Helm chart and release workflows

### DIFF
--- a/charts/kite/Chart.yaml
+++ b/charts/kite/Chart.yaml
@@ -1,6 +1,7 @@
 apiVersion: v2
 name: kite
 description: A Helm chart for Kubernetes
+icon: https://kite.zzde.me/logo.svg
 
 # A chart can be either an 'application' or a 'library' chart.
 #

--- a/e2e/specs/helm-kite.spec.ts
+++ b/e2e/specs/helm-kite.spec.ts
@@ -27,24 +27,13 @@ async function fillMonacoEditor(
 
   await expect(editor).toBeVisible({ timeout: 60_000 })
   const firstLine = value.trim().split('\n')[0]
-  const shortcutModifier = process.platform === 'darwin' ? 'Meta' : 'Control'
-  const pasteShortcut = `${shortcutModifier}+V`
 
   await editorText.click({ position: { x: 10, y: 10 } })
-  await page.keyboard.press(`${shortcutModifier}+A`)
+  await page.keyboard.press('Control+A')
   await page.keyboard.press('Backspace')
-  await page.evaluate(
-    async (text) => navigator.clipboard.writeText(text),
-    value
-  )
-  await page.keyboard.press(pasteShortcut)
-  const pastedText = ((await editorText.textContent()) || '').replace(
-    /\u00a0/g,
-    ' '
-  )
-  if (!pastedText.includes(firstLine)) {
-    await page.keyboard.press(pasteShortcut)
-  }
+  await page.keyboard.press('Meta+A')
+  await page.keyboard.press('Backspace')
+  await page.keyboard.insertText(value)
   await expect(editorText).toContainText(firstLine)
 }
 
@@ -130,6 +119,57 @@ async function expectReleaseValues(
   if (absentText) {
     await expect(editorText).not.toContainText(absentText)
   }
+}
+
+async function expectAppliedPodLabel(
+  page: Page,
+  releaseName: string,
+  expectedMode: string
+) {
+  await expect
+    .poll(
+      async () => {
+        const response = await page.request.get(
+          `/api/v1/deployments/${namespace}?labelSelector=${encodeURIComponent(
+            `app.kubernetes.io/instance=${releaseName}`
+          )}`
+        )
+        if (!response.ok()) {
+          return ''
+        }
+        const body = (await response.json()) as {
+          items?: Array<{
+            spec?: {
+              template?: {
+                metadata?: {
+                  labels?: Record<string, string>
+                }
+              }
+            }
+          }>
+        }
+        const labels = (body.items || []).map(
+          (item) => item.spec?.template?.metadata?.labels?.['e2e-mode'] || ''
+        )
+        if (!labels.length || labels.some((label) => !label)) {
+          return ''
+        }
+        return labels.every((label) => label === expectedMode)
+          ? expectedMode
+          : labels.join(',')
+      },
+      { timeout: 60_000 }
+    )
+    .toBe(expectedMode)
+}
+
+async function expectDryRunPreview(dialog: Locator) {
+  await expect(dialog.getByText('Dry run preview')).toBeVisible({
+    timeout: 120_000,
+  })
+  await expect(
+    dialog.getByText('No resources rendered by dry run.')
+  ).toBeHidden()
 }
 
 async function deleteReleaseFromCurrentPage(page: Page, releaseName: string) {
@@ -274,6 +314,11 @@ test.describe('helm kite lifecycle', () => {
       await installDialog.getByLabel('Release Name').fill(releaseName)
       await fillMonacoEditor(page, installDialog, 1, baseValues)
       await expect(
+        installDialog.getByRole('button', { name: 'Dry Run' })
+      ).toBeEnabled({ timeout: 60_000 })
+      await installDialog.getByRole('button', { name: 'Dry Run' }).click()
+      await expectDryRunPreview(installDialog)
+      await expect(
         installDialog.getByRole('button', { name: 'Install' })
       ).toBeEnabled({ timeout: 60_000 })
       await installDialog.getByRole('button', { name: 'Install' }).click()
@@ -284,6 +329,7 @@ test.describe('helm kite lifecycle', () => {
       )
       await expectReleaseSummary(page, releaseName, installVersion, 1)
       await expectReleaseValues(page, 'e2e-mode: base', 'e2e-mode: upgraded')
+      await expectAppliedPodLabel(page, releaseName, 'base')
 
       await page.getByRole('button', { name: 'Upgrade' }).click()
       const customValuesUpgradeDialog = page.getByRole('dialog', {
@@ -291,6 +337,16 @@ test.describe('helm kite lifecycle', () => {
       })
       await expect(customValuesUpgradeDialog).toBeVisible()
       await fillMonacoEditor(page, customValuesUpgradeDialog, 1, upgradedValues)
+      await expect(
+        customValuesUpgradeDialog.getByRole('button', { name: 'Dry Run' })
+      ).toBeEnabled({ timeout: 60_000 })
+      await customValuesUpgradeDialog
+        .getByRole('button', { name: 'Dry Run' })
+        .click()
+      await expectDryRunPreview(customValuesUpgradeDialog)
+      await expect(
+        customValuesUpgradeDialog.getByText('Changed').first()
+      ).toBeVisible()
       await expect(
         customValuesUpgradeDialog.getByRole('button', { name: 'Upgrade' })
       ).toBeEnabled({ timeout: 60_000 })
@@ -302,6 +358,7 @@ test.describe('helm kite lifecycle', () => {
       await page.reload()
       await expectReleaseSummary(page, releaseName, installVersion, 2)
       await expectReleaseValues(page, 'e2e-mode: upgraded')
+      await expectAppliedPodLabel(page, releaseName, 'upgraded')
 
       await page.getByRole('tab', { name: 'History' }).click()
       await expect(
@@ -319,6 +376,7 @@ test.describe('helm kite lifecycle', () => {
       await page.reload()
       await expectReleaseSummary(page, releaseName, installVersion, 3)
       await expectReleaseValues(page, 'e2e-mode: base', 'e2e-mode: upgraded')
+      await expectAppliedPodLabel(page, releaseName, 'base')
 
       await page.getByRole('button', { name: 'Upgrade' }).click()
       const versionUpgradeDialog = page.getByRole('dialog', {
@@ -343,6 +401,7 @@ test.describe('helm kite lifecycle', () => {
       await page.reload()
       await expectReleaseSummary(page, releaseName, specifiedUpgradeVersion, 4)
       await expectReleaseValues(page, 'e2e-mode: upgraded')
+      await expectAppliedPodLabel(page, releaseName, 'upgraded')
 
       await deleteReleaseFromCurrentPage(page, releaseName)
       await page.getByPlaceholder('Search Helm Release...').fill(releaseName)

--- a/pkg/auth/middleware.go
+++ b/pkg/auth/middleware.go
@@ -38,7 +38,7 @@ func (h *AuthHandler) RequireAPIKeyAuth(c *gin.Context, token string) {
 		c.Abort()
 		return
 	}
-	if apikey.Provider != common.APIKeyProvider || key == "" || string(apikey.APIKey) == "" || key != string(apikey.APIKey) {
+	if !apikey.Enabled || apikey.Provider != common.APIKeyProvider || key == "" || string(apikey.APIKey) == "" || key != string(apikey.APIKey) {
 		c.JSON(http.StatusUnauthorized, gin.H{
 			"error": "Invalid API key",
 		})

--- a/pkg/auth/oauth_manager.go
+++ b/pkg/auth/oauth_manager.go
@@ -147,13 +147,18 @@ func (om *OAuthManager) RefreshJWT(c *gin.Context, tokenString string) (string, 
 		return "", fmt.Errorf("invalid token signature")
 	}
 
-	// Check if token is close to expiration (within 1 hour)
-	if time.Until(claims.ExpiresAt.Time) > time.Hour {
-		// Token not close to expiry - return original token
-		return tokenString, nil
+	if !time.Now().After(claims.ExpiresAt.Time) {
+		user := &model.User{
+			Model: model.Model{
+				ID: claims.UserID,
+			},
+			Username: claims.Username,
+			Provider: claims.Provider,
+		}
+
+		return om.GenerateJWT(user, claims.RefreshToken)
 	}
 
-	// If we have a refresh token, try to refresh the OAuth token
 	if claims.RefreshToken != "" {
 		provider, err := om.GetProvider(c, claims.Provider)
 		if err != nil {
@@ -170,6 +175,7 @@ func (om *OAuthManager) RefreshJWT(c *gin.Context, tokenString string) (string, 
 		if err != nil {
 			return "", err
 		}
+		user.ID = claims.UserID
 
 		// Generate new JWT with refreshed token
 		newRefreshToken := tokenResp.RefreshToken
@@ -180,15 +186,5 @@ func (om *OAuthManager) RefreshJWT(c *gin.Context, tokenString string) (string, 
 		return om.GenerateJWT(user, newRefreshToken)
 	}
 
-	// If no refresh token available, just generate a new JWT with existing claims
-	// This is for providers like GitHub that don't expire tokens
-	user := &model.User{
-		Model: model.Model{
-			ID: claims.UserID,
-		},
-		Username: claims.Username,
-		Provider: claims.Provider,
-	}
-
-	return om.GenerateJWT(user, "")
+	return "", fmt.Errorf("token expired")
 }

--- a/pkg/handlers/helm_chart_handler.go
+++ b/pkg/handlers/helm_chart_handler.go
@@ -8,11 +8,13 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
 
+	semver "github.com/blang/semver/v4"
 	"github.com/gin-gonic/gin"
 	"github.com/zxh326/kite/pkg/helmutil"
 	"github.com/zxh326/kite/pkg/model"
@@ -26,6 +28,7 @@ import (
 const (
 	helmRepositoryIndexCacheTTL = 5 * time.Minute
 	helmChartContentCacheTTL    = 10 * time.Minute
+	artifactHubCacheTTL         = 5 * time.Minute
 	artifactHubSearchURL        = "https://artifacthub.io/api/v1/packages/search"
 	artifactHubPackageAPIURL    = "https://artifacthub.io/api/v1/packages/helm/"
 	artifactHubValuesAPIURL     = "https://artifacthub.io/api/v1/packages/"
@@ -49,6 +52,17 @@ type cachedChartContent struct {
 	content   helmChartContent
 	expiresAt time.Time
 }
+
+type cachedArtifactHubResponse struct {
+	data      []byte
+	headers   http.Header
+	expiresAt time.Time
+}
+
+var (
+	artifactHubCacheMu sync.Mutex
+	artifactHubCache   = map[string]cachedArtifactHubResponse{}
+)
 
 type createHelmRepositoryRequest struct {
 	Name     string `json:"name" binding:"required"`
@@ -89,9 +103,9 @@ type helmChart struct {
 }
 
 type helmChartVersion struct {
-	Version    string     `json:"version"`
-	AppVersion string     `json:"appVersion,omitempty"`
-	UpdatedAt  *time.Time `json:"updatedAt,omitempty"`
+	Version     string     `json:"version"`
+	AppVersion  string     `json:"appVersion,omitempty"`
+	PublishedAt *time.Time `json:"publishedAt,omitempty"`
 }
 
 type helmChartDetail struct {
@@ -101,13 +115,19 @@ type helmChartDetail struct {
 }
 
 type helmChartContentResponse struct {
+	Content   string          `json:"content,omitempty"`
+	Templates []chartTemplate `json:"templates,omitempty"`
+}
+
+type chartTemplate struct {
+	Path    string `json:"path"`
 	Content string `json:"content"`
 }
 
 type helmChartContent struct {
 	Readme    string
 	Values    string
-	Templates string
+	Templates []chartTemplate
 }
 
 type artifactHubSearchResponse struct {
@@ -435,16 +455,17 @@ func (h *HelmChartHandler) GetArtifactHubChartContent(c *gin.Context) {
 		return
 	}
 
-	content := string(contentData)
 	if contentName == "templates" {
-		content, err = artifactHubTemplates(contentData)
+		templates, err := artifactHubTemplates(contentData)
 		if err != nil {
 			c.JSON(http.StatusBadGateway, gin.H{"error": err.Error()})
 			return
 		}
+		c.JSON(http.StatusOK, helmChartContentResponse{Templates: templates})
+		return
 	}
 
-	c.JSON(http.StatusOK, helmChartContentResponse{Content: content})
+	c.JSON(http.StatusOK, helmChartContentResponse{Content: string(contentData)})
 }
 
 func (h *HelmChartHandler) GetChart(c *gin.Context) {
@@ -479,11 +500,12 @@ func (h *HelmChartHandler) GetChart(c *gin.Context) {
 	versions := []helmChartVersion{}
 	for _, chartVersion := range indexFile.Entries[chartName] {
 		versions = append(versions, helmChartVersion{
-			Version:    chartVersion.Version,
-			AppVersion: chartVersion.AppVersion,
-			UpdatedAt:  chartUpdatedAt(indexFile.Generated, chartVersion),
+			Version:     chartVersion.Version,
+			AppVersion:  chartVersion.AppVersion,
+			PublishedAt: chartUpdatedAt(indexFile.Generated, chartVersion),
 		})
 	}
+	sortHelmChartVersions(versions)
 
 	c.JSON(http.StatusOK, helmChartDetail{
 		helmChart: toHelmChart(repository, indexFile.Generated, entry),
@@ -531,7 +553,7 @@ func (h *HelmChartHandler) GetChartContent(c *gin.Context) {
 		c.JSON(http.StatusOK, helmChartContentResponse{Content: content.Values})
 		return
 	}
-	c.JSON(http.StatusOK, helmChartContentResponse{Content: content.Templates})
+	c.JSON(http.StatusOK, helmChartContentResponse{Templates: content.Templates})
 }
 
 func (h *HelmChartHandler) loadRepositoryIndex(repository model.HelmRepository) (*repo.IndexFile, error) {
@@ -680,11 +702,12 @@ func toArtifactHubChartDetail(pkg artifactHubPackageDetail) helmChartDetail {
 	versions := make([]helmChartVersion, 0, len(pkg.AvailableVersions))
 	for _, version := range pkg.AvailableVersions {
 		versions = append(versions, helmChartVersion{
-			Version:    version.Version,
-			AppVersion: version.AppVersion,
-			UpdatedAt:  artifactHubUpdatedAt(version.TS),
+			Version:     version.Version,
+			AppVersion:  version.AppVersion,
+			PublishedAt: artifactHubUpdatedAt(version.TS),
 		})
 	}
+	sortHelmChartVersions(versions)
 
 	return helmChartDetail{
 		helmChart: helmChart{
@@ -725,6 +748,49 @@ func artifactHubUpdatedAt(ts int64) *time.Time {
 	return &v
 }
 
+func sortHelmChartVersions(versions []helmChartVersion) {
+	sort.SliceStable(versions, func(i, j int) bool {
+		if cmp := compareTimes(versions[i].PublishedAt, versions[j].PublishedAt); cmp != 0 {
+			return cmp > 0
+		}
+		return compareChartVersions(versions[i].Version, versions[j].Version) > 0
+	})
+}
+
+func compareTimes(a, b *time.Time) int {
+	if a == nil && b == nil {
+		return 0
+	}
+	if a == nil {
+		return -1
+	}
+	if b == nil {
+		return 1
+	}
+	if a.After(*b) {
+		return 1
+	}
+	if a.Before(*b) {
+		return -1
+	}
+	return 0
+}
+
+func compareChartVersions(a, b string) int {
+	parsedA, errA := semver.ParseTolerant(a)
+	parsedB, errB := semver.ParseTolerant(b)
+	if errA == nil && errB == nil {
+		return parsedA.Compare(parsedB)
+	}
+	if errA == nil {
+		return 1
+	}
+	if errB == nil {
+		return -1
+	}
+	return strings.Compare(a, b)
+}
+
 func fetchArtifactHubChartDetail(c *gin.Context, repositoryName, chartName, version string) (artifactHubPackageDetail, error) {
 	packageURL := artifactHubPackageAPIURL + url.PathEscape(repositoryName) + "/" + url.PathEscape(chartName)
 	if version != "" {
@@ -748,6 +814,20 @@ func fetchArtifactHub(c *gin.Context, targetURL string) ([]byte, error) {
 }
 
 func fetchArtifactHubWithHeaders(c *gin.Context, targetURL string) ([]byte, http.Header, error) {
+	now := time.Now()
+	artifactHubCacheMu.Lock()
+	cached, ok := artifactHubCache[targetURL]
+	if ok && now.Before(cached.expiresAt) {
+		data := append([]byte(nil), cached.data...)
+		headers := cached.headers.Clone()
+		artifactHubCacheMu.Unlock()
+		return data, headers, nil
+	}
+	if ok {
+		delete(artifactHubCache, targetURL)
+	}
+	artifactHubCacheMu.Unlock()
+
 	req, err := http.NewRequestWithContext(c.Request.Context(), http.MethodGet, targetURL, nil)
 	if err != nil {
 		return nil, nil, err
@@ -768,7 +848,17 @@ func fetchArtifactHubWithHeaders(c *gin.Context, targetURL string) ([]byte, http
 	if err != nil {
 		return nil, nil, err
 	}
-	return data, resp.Header, nil
+	headers := resp.Header.Clone()
+
+	artifactHubCacheMu.Lock()
+	artifactHubCache[targetURL] = cachedArtifactHubResponse{
+		data:      append([]byte(nil), data...),
+		headers:   headers.Clone(),
+		expiresAt: time.Now().Add(artifactHubCacheTTL),
+	}
+	artifactHubCacheMu.Unlock()
+
+	return data, headers, nil
 }
 
 func artifactHubKubeVersion(data json.RawMessage) string {
@@ -783,27 +873,24 @@ func artifactHubKubeVersion(data json.RawMessage) string {
 	return parsed.KubeVersion
 }
 
-func artifactHubTemplates(data []byte) (string, error) {
+func artifactHubTemplates(data []byte) ([]chartTemplate, error) {
 	var result artifactHubTemplatesResponse
 	if err := json.Unmarshal(data, &result); err != nil {
-		return "", err
+		return nil, err
 	}
 
-	var builder strings.Builder
+	templates := make([]chartTemplate, 0, len(result.Templates))
 	for _, file := range result.Templates {
 		content, err := base64.StdEncoding.DecodeString(file.Data)
 		if err != nil {
-			return "", err
+			return nil, err
 		}
-		if builder.Len() > 0 {
-			builder.WriteString("\n---\n")
-		}
-		builder.WriteString("# Source: ")
-		builder.WriteString(file.Name)
-		builder.WriteByte('\n')
-		builder.Write(content)
+		templates = append(templates, chartTemplate{
+			Path:    chartTemplatePath(file.Name),
+			Content: string(content),
+		})
 	}
-	return builder.String(), nil
+	return templates, nil
 }
 
 func chartUpdatedAt(generated time.Time, entry *repo.ChartVersion) *time.Time {
@@ -834,32 +921,25 @@ func helmChartMatchesQuery(chart helmChart, query string) bool {
 }
 
 func repositoryIndexCacheKey(repository model.HelmRepository) string {
-	return strings.Join([]string{
-		repository.Name,
-		repository.URL,
-		repository.Username,
-	}, "\x00")
+	return repository.URL
 }
 
 func chartContentCacheKey(repository model.HelmRepository, entry *repo.ChartVersion) string {
-	return strings.Join([]string{
-		repositoryIndexCacheKey(repository),
-		entry.Name,
-		entry.Version,
-		strings.Join(entry.URLs, "\x00"),
-	}, "\x00")
+	return helmutil.ResolveURL(repository.URL, entry.URLs[0])
 }
 
 func (h *HelmChartHandler) clearRepositoryCache(repository model.HelmRepository) {
 	cacheKey := repositoryIndexCacheKey(repository)
+	helmutil.ClearRepositoryArchiveCache(repository)
 
 	h.indexCacheMu.Lock()
 	delete(h.indexCache, cacheKey)
 	h.indexCacheMu.Unlock()
 
 	h.contentCacheMu.Lock()
+	cacheKeyPrefix := strings.TrimRight(cacheKey, "/") + "/"
 	for key := range h.contentCache {
-		if key == cacheKey || strings.HasPrefix(key, cacheKey+"\x00") {
+		if key == cacheKey || strings.HasPrefix(key, cacheKeyPrefix) {
 			delete(h.contentCache, key)
 		}
 	}
@@ -899,19 +979,20 @@ func chartValues(loadedChart *chart.Chart) (string, error) {
 	return string(values), nil
 }
 
-func chartTemplates(files []*common.File) string {
-	var builder strings.Builder
+func chartTemplates(files []*common.File) []chartTemplate {
+	templates := make([]chartTemplate, 0, len(files))
 	for _, file := range files {
 		if file == nil {
 			continue
 		}
-		if builder.Len() > 0 {
-			builder.WriteString("\n---\n")
-		}
-		builder.WriteString("# Source: ")
-		builder.WriteString(file.Name)
-		builder.WriteByte('\n')
-		builder.Write(file.Data)
+		templates = append(templates, chartTemplate{
+			Path:    chartTemplatePath(file.Name),
+			Content: string(file.Data),
+		})
 	}
-	return builder.String()
+	return templates
+}
+
+func chartTemplatePath(name string) string {
+	return strings.TrimPrefix(strings.TrimPrefix(name, "./"), "templates/")
 }

--- a/pkg/handlers/resource_apply_handler.go
+++ b/pkg/handlers/resource_apply_handler.go
@@ -77,7 +77,12 @@ func (h *ResourceApplyHandler) ApplyResource(c *gin.Context) {
 		}
 
 		resource := strings.ToLower(obj.GetKind()) + "s"
-		if !rbac.CanAccess(user, resource, "create", cs.Name, obj.GetNamespace()) {
+		canCreate := rbac.CanAccess(user, resource, string(common.VerbCreate), cs.Name, obj.GetNamespace())
+		canUpdate := false
+		if !canCreate {
+			canUpdate = rbac.CanAccess(user, resource, string(common.VerbUpdate), cs.Name, obj.GetNamespace())
+		}
+		if !canCreate && !canUpdate {
 			c.JSON(http.StatusForbidden, gin.H{
 				"error": rbac.NoAccess(user.Key(), string(common.VerbCreate), resource, obj.GetNamespace(), cs.Name)})
 			return
@@ -97,12 +102,25 @@ func (h *ResourceApplyHandler) ApplyResource(c *gin.Context) {
 		switch {
 		case apierrors.IsNotFound(err):
 			operation = "create"
+			if !canCreate {
+				c.JSON(http.StatusForbidden, gin.H{
+					"error": rbac.NoAccess(user.Key(), string(common.VerbCreate), resource, obj.GetNamespace(), cs.Name)})
+				return
+			}
 			err = cs.K8sClient.Create(ctx, obj)
 			if err != nil {
 				klog.Errorf("Failed to create resource: %v", err)
 			}
 		case err == nil:
 			operation = "update"
+			if !canUpdate {
+				canUpdate = rbac.CanAccess(user, resource, string(common.VerbUpdate), cs.Name, obj.GetNamespace())
+			}
+			if !canUpdate {
+				c.JSON(http.StatusForbidden, gin.H{
+					"error": rbac.NoAccess(user.Key(), string(common.VerbUpdate), resource, obj.GetNamespace(), cs.Name)})
+				return
+			}
 			obj.SetResourceVersion(existingObj.GetResourceVersion())
 			err = cs.K8sClient.Update(ctx, obj)
 			if err != nil {

--- a/pkg/handlers/resources/generic_resource_handler_write.go
+++ b/pkg/handlers/resources/generic_resource_handler_write.go
@@ -25,6 +25,13 @@ func (h *GenericResourceHandler[T, V]) Create(c *gin.Context) {
 		return
 	}
 
+	if !h.isClusterScoped {
+		namespace := c.Param("namespace")
+		if namespace != "" && namespace != common.AllNamespaces {
+			resource.SetNamespace(namespace)
+		}
+	}
+
 	ctx := c.Request.Context()
 
 	var success bool

--- a/pkg/handlers/resources/helmrelease_handler.go
+++ b/pkg/handlers/resources/helmrelease_handler.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/client-go/restmapper"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/yaml"
 )
 
@@ -100,6 +101,24 @@ type HelmReleaseResource struct {
 	Kind       string `json:"kind"`
 	Name       string `json:"name"`
 	Namespace  string `json:"namespace,omitempty"`
+}
+
+type HelmReleaseDryRunResource struct {
+	HelmReleaseResource
+	Path            string `json:"path"`
+	Content         string `json:"content"`
+	OriginalContent string `json:"originalContent,omitempty"`
+	ModifiedContent string `json:"modifiedContent,omitempty"`
+	Status          string `json:"status,omitempty"`
+}
+
+type HelmReleaseDryRunResponse struct {
+	Resources []HelmReleaseDryRunResource `json:"resources"`
+}
+
+type helmReleaseRunResult struct {
+	current *release.Release
+	release *release.Release
 }
 
 type HelmReleaseHistoryItem struct {
@@ -217,17 +236,36 @@ func (h *HelmReleaseHandler) ListHistory(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"items": items})
 }
 func (h *HelmReleaseHandler) Create(c *gin.Context) {
+	rel, status, err := h.runInstall(c, false)
+	if err != nil {
+		c.JSON(status, gin.H{"error": err.Error()})
+		return
+	}
+
+	result := toHelmRelease(rel, true)
+	c.JSON(http.StatusCreated, result)
+}
+
+func (h *HelmReleaseHandler) DryRunInstall(c *gin.Context) {
+	rel, status, err := h.runInstall(c, true)
+	if err != nil {
+		c.JSON(status, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, toHelmReleaseDryRunResponse(rel))
+}
+
+func (h *HelmReleaseHandler) runInstall(c *gin.Context, dryRun bool) (rel *release.Release, status int, err error) {
 	ctx := c.Request.Context()
 	namespace := strings.TrimSpace(c.Param("namespace"))
 	if namespace == "" || namespace == common.AllNamespaces {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "namespace is required"})
-		return
+		return nil, http.StatusBadRequest, fmt.Errorf("namespace is required")
 	}
 
 	var req helmReleaseInstallRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
-		return
+		return nil, http.StatusBadRequest, err
 	}
 	req.ReleaseName = strings.TrimSpace(req.ReleaseName)
 	req.Namespace = strings.TrimSpace(req.Namespace)
@@ -235,29 +273,29 @@ func (h *HelmReleaseHandler) Create(c *gin.Context) {
 	req.RepositoryName = strings.TrimSpace(req.RepositoryName)
 	req.Source = strings.TrimSpace(req.Source)
 	if req.ReleaseName == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "releaseName is required"})
-		return
+		return nil, http.StatusBadRequest, fmt.Errorf("releaseName is required")
 	}
 	if req.Namespace != "" && req.Namespace != namespace {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "request namespace does not match URL namespace"})
-		return
+		return nil, http.StatusBadRequest, fmt.Errorf("request namespace does not match URL namespace")
+	}
+	if !dryRun {
+		defer func() {
+			h.recordHistory(c, "install", req.ReleaseName, namespace, nil, rel, err == nil, err)
+		}()
 	}
 
 	repository, err := helmChartRepository(req.RepositoryName, req.Source)
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "repository not found"})
-		return
+		return nil, http.StatusBadRequest, fmt.Errorf("repository not found")
 	}
 	loadedChart, err := helmutil.LoadArchive(req.ChartURL, repository)
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
-		return
+		return nil, http.StatusBadRequest, err
 	}
 
 	cfg, err := h.actionConfig(c, namespace)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-		return
+		return nil, http.StatusInternalServerError, err
 	}
 	values := req.Values
 	if values == nil {
@@ -266,6 +304,9 @@ func (h *HelmReleaseHandler) Create(c *gin.Context) {
 	description := req.Description
 	if description == "" {
 		description = "Install requested from Kite"
+		if dryRun {
+			description = "Dry run install requested from Kite"
+		}
 	}
 
 	install := action.NewInstall(cfg)
@@ -274,24 +315,24 @@ func (h *HelmReleaseHandler) Create(c *gin.Context) {
 	install.Timeout = helmActionTimeout
 	install.Description = description
 	install.CreateNamespace = req.CreateNamespace
+	if dryRun {
+		install.DryRunStrategy = action.DryRunClient
+	}
 	install.WaitStrategy = kube.HookOnlyStrategy
 	if req.Wait {
 		install.WaitStrategy = kube.StatusWatcherStrategy
 	}
 	releaser, err := install.RunWithContext(ctx, loadedChart, values)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-		return
+		return nil, http.StatusInternalServerError, err
 	}
-	rel, err := helmReleaseFromReleaser(releaser)
+	rel, err = helmReleaseFromReleaser(releaser)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-		return
+		return nil, http.StatusInternalServerError, err
 	}
-
-	result := toHelmRelease(rel, true)
-	c.JSON(http.StatusCreated, result)
+	return rel, http.StatusOK, nil
 }
+
 func (h *HelmReleaseHandler) Update(c *gin.Context) {
 	c.JSON(http.StatusNotImplemented, gin.H{"error": "helm release updates must use the upgrade action"})
 }
@@ -318,7 +359,9 @@ func (h *HelmReleaseHandler) Describe(c *gin.Context) {
 }
 
 func (h *HelmReleaseHandler) registerCustomRoutes(group *gin.RouterGroup) {
+	group.POST("/:namespace/dry-run", h.DryRunInstall)
 	group.PUT("/:namespace/:name/upgrade", h.Upgrade)
+	group.PUT("/:namespace/:name/upgrade/dry-run", h.DryRunUpgrade)
 	group.PUT("/:namespace/:name/rollback", h.Rollback)
 }
 
@@ -372,14 +415,32 @@ func (h *HelmReleaseHandler) Delete(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
+	currentReleaser, err := action.NewGet(cfg).Run(c.Param("name"))
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	current, err := helmReleaseFromReleaser(currentReleaser)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	success := false
+	var runErr error
+	defer func() {
+		h.recordHistory(c, "delete", c.Param("name"), c.Param("namespace"), current, nil, success, runErr)
+	}()
+
 	uninstall := action.NewUninstall(cfg)
 	uninstall.Timeout = helmActionTimeout
 	uninstall.Description = "Deleted from Kite"
 	uninstall.WaitStrategy = kube.HookOnlyStrategy
 	if _, err := uninstall.Run(c.Param("name")); err != nil {
+		runErr = err
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
+	success = true
 	c.JSON(http.StatusOK, gin.H{"message": "helm release deleted"})
 }
 
@@ -396,7 +457,107 @@ type helmReleaseActionRequest struct {
 }
 
 func (h *HelmReleaseHandler) Upgrade(c *gin.Context) {
+	_, status, err := h.runUpgrade(c, false)
+	if err != nil {
+		c.JSON(status, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"message": "helm release upgraded"})
+}
+
+func (h *HelmReleaseHandler) DryRunUpgrade(c *gin.Context) {
+	result, status, err := h.runUpgrade(c, true)
+	if err != nil {
+		c.JSON(status, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, toHelmReleaseDryRunDiffResponse(result.current, result.release))
+}
+
+func (h *HelmReleaseHandler) runUpgrade(c *gin.Context, dryRun bool) (result helmReleaseRunResult, status int, err error) {
 	ctx := c.Request.Context()
+	namespace, name := c.Param("namespace"), c.Param("name")
+	var req helmReleaseActionRequest
+	_ = c.ShouldBindJSON(&req)
+
+	cfg, err := h.actionConfig(c, namespace)
+	if err != nil {
+		return helmReleaseRunResult{}, http.StatusInternalServerError, err
+	}
+	currentReleaser, err := action.NewGet(cfg).Run(name)
+	if err != nil {
+		return helmReleaseRunResult{}, http.StatusInternalServerError, err
+	}
+	current, err := helmReleaseFromReleaser(currentReleaser)
+	if err != nil {
+		return helmReleaseRunResult{}, http.StatusInternalServerError, err
+	}
+	if current.Chart == nil {
+		return helmReleaseRunResult{}, http.StatusInternalServerError, fmt.Errorf("helm release chart is missing")
+	}
+	result.current = current
+	if !dryRun {
+		defer func() {
+			h.recordHistory(c, "upgrade", name, namespace, current, result.release, err == nil, err)
+		}()
+	}
+
+	chartToUpgrade := current.Chart
+	if strings.TrimSpace(req.ChartURL) != "" {
+		req.ChartURL = strings.TrimSpace(req.ChartURL)
+		repository, err := helmChartRepository(
+			strings.TrimSpace(req.RepositoryName),
+			strings.TrimSpace(req.Source),
+		)
+		if err != nil {
+			return helmReleaseRunResult{}, http.StatusBadRequest, fmt.Errorf("repository not found")
+		}
+		chartToUpgrade, err = helmutil.LoadArchive(req.ChartURL, repository)
+		if err != nil {
+			return helmReleaseRunResult{}, http.StatusBadRequest, err
+		}
+	}
+
+	values := req.Values
+	if values == nil {
+		values = map[string]interface{}{}
+	}
+	description := req.Description
+	if description == "" {
+		description = "Dry run upgrade requested from Kite"
+		if !dryRun {
+			description = "Upgrade requested from Kite"
+		}
+	}
+
+	upgrade := action.NewUpgrade(cfg)
+	upgrade.Namespace = namespace
+	upgrade.Timeout = helmActionTimeout
+	upgrade.ReuseValues = req.Values == nil
+	upgrade.Description = description
+	upgrade.ForceConflicts = req.ForceConflicts
+	upgrade.RollbackOnFailure = req.RollbackOnFailure
+	if dryRun {
+		upgrade.DryRunStrategy = action.DryRunClient
+	}
+	upgrade.WaitStrategy = kube.HookOnlyStrategy
+	if req.Wait {
+		upgrade.WaitStrategy = kube.StatusWatcherStrategy
+	}
+	releaser, err := upgrade.RunWithContext(ctx, name, chartToUpgrade, values)
+	if err != nil {
+		return helmReleaseRunResult{}, http.StatusInternalServerError, err
+	}
+	rel, err := helmReleaseFromReleaser(releaser)
+	if err != nil {
+		return helmReleaseRunResult{}, http.StatusInternalServerError, err
+	}
+	result.release = rel
+	return result, http.StatusOK, nil
+}
+
+func (h *HelmReleaseHandler) Rollback(c *gin.Context) {
 	namespace, name := c.Param("namespace"), c.Param("name")
 	var req helmReleaseActionRequest
 	_ = c.ShouldBindJSON(&req)
@@ -416,81 +577,19 @@ func (h *HelmReleaseHandler) Upgrade(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
-	if current.Chart == nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "helm release chart is missing"})
-		return
-	}
+	success := false
+	var next *release.Release
+	var runErr error
+	defer func() {
+		h.recordHistory(c, "rollback", name, namespace, current, next, success, runErr)
+	}()
 
-	chartToUpgrade := current.Chart
-	if strings.TrimSpace(req.ChartURL) != "" {
-		req.ChartURL = strings.TrimSpace(req.ChartURL)
-		repository, err := helmChartRepository(
-			strings.TrimSpace(req.RepositoryName),
-			strings.TrimSpace(req.Source),
-		)
-		if err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "repository not found"})
-			return
-		}
-		chartToUpgrade, err = helmutil.LoadArchive(req.ChartURL, repository)
-		if err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
-			return
-		}
-	}
-
-	values := req.Values
-	if values == nil {
-		values = map[string]interface{}{}
-	}
-	description := req.Description
-	if description == "" {
-		description = "Upgrade requested from Kite"
-	}
-
-	upgrade := action.NewUpgrade(cfg)
-	upgrade.Namespace = namespace
-	upgrade.Timeout = helmActionTimeout
-	upgrade.ReuseValues = req.Values == nil
-	upgrade.Description = description
-	upgrade.ForceConflicts = req.ForceConflicts
-	upgrade.RollbackOnFailure = req.RollbackOnFailure
-	upgrade.WaitStrategy = kube.HookOnlyStrategy
-	if req.Wait {
-		upgrade.WaitStrategy = kube.StatusWatcherStrategy
-	}
-	if _, err := upgrade.RunWithContext(ctx, name, chartToUpgrade, values); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-		return
-	}
-	c.JSON(http.StatusOK, gin.H{"message": "helm release upgraded"})
-}
-
-func (h *HelmReleaseHandler) Rollback(c *gin.Context) {
-	namespace, name := c.Param("namespace"), c.Param("name")
-	var req helmReleaseActionRequest
-	_ = c.ShouldBindJSON(&req)
-
-	cfg, err := h.actionConfig(c, namespace)
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-		return
-	}
 	targetRevision := req.Revision
 	if targetRevision == 0 {
-		currentReleaser, err := action.NewGet(cfg).Run(name)
-		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-			return
-		}
-		current, err := helmReleaseFromReleaser(currentReleaser)
-		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-			return
-		}
 		targetRevision = current.Version - 1
 	}
 	if targetRevision <= 0 {
+		runErr = fmt.Errorf("no previous helm release revision found")
 		c.JSON(http.StatusBadRequest, gin.H{"error": "no previous helm release revision found"})
 		return
 	}
@@ -500,10 +599,56 @@ func (h *HelmReleaseHandler) Rollback(c *gin.Context) {
 	rollback.Timeout = helmActionTimeout
 	rollback.WaitStrategy = kube.HookOnlyStrategy
 	if err := rollback.Run(name); err != nil {
+		runErr = err
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
+	if nextReleaser, err := action.NewGet(cfg).Run(name); err == nil {
+		next, err = helmReleaseFromReleaser(nextReleaser)
+		if err != nil {
+			klog.Errorf("Failed to read rolled back helm release: %v", err)
+		}
+	} else {
+		klog.Errorf("Failed to read rolled back helm release: %v", err)
+	}
+	success = true
 	c.JSON(http.StatusOK, gin.H{"message": "helm release rolled back", "revision": targetRevision})
+}
+
+func (h *HelmReleaseHandler) recordHistory(c *gin.Context, opType, name, namespace string, prev, curr *release.Release, success bool, err error) {
+	cs := c.MustGet("cluster").(*cluster.ClientSet)
+	user := c.MustGet("user").(model.User)
+	if curr != nil {
+		name = curr.Name
+		namespace = curr.Namespace
+	} else if prev != nil {
+		name = prev.Name
+		namespace = prev.Namespace
+	}
+
+	errMsg := ""
+	if err != nil {
+		errMsg = err.Error()
+	}
+	resourceYAML := helmReleaseToYAML(curr)
+	if opType == "delete" {
+		resourceYAML = ""
+	}
+	history := model.ResourceHistory{
+		ClusterName:   cs.Name,
+		ResourceType:  helmReleaseResourceName,
+		ResourceName:  name,
+		Namespace:     namespace,
+		OperationType: opType,
+		ResourceYAML:  resourceYAML,
+		PreviousYAML:  helmReleaseToYAML(prev),
+		Success:       success,
+		ErrorMessage:  errMsg,
+		OperatorID:    user.ID,
+	}
+	if err := model.DB.Create(&history).Error; err != nil {
+		klog.Errorf("Failed to create helm release history: %v", err)
+	}
 }
 
 func (h *HelmReleaseHandler) list(c *gin.Context, namespace string, details bool) (*HelmReleaseList, error) {
@@ -615,6 +760,21 @@ func helmReleasesFromReleasers(releasers []helmrelease.Releaser) ([]*release.Rel
 	return releases, nil
 }
 
+func helmReleaseToYAML(rel *release.Release) string {
+	if rel == nil {
+		return ""
+	}
+	helmRelease := toHelmRelease(rel, true)
+	helmRelease.Spec.DefaultValues = nil
+	helmRelease.Spec.Manifest = ""
+	helmRelease.Spec.Notes = ""
+	data, err := yaml.Marshal(helmRelease)
+	if err != nil {
+		return ""
+	}
+	return string(data)
+}
+
 func toHelmRelease(rel *release.Release, details bool) HelmRelease {
 	chartName, chartVersion, appVersion := helmChartInfo(rel)
 	chartIcon := ""
@@ -667,6 +827,23 @@ func toHelmRelease(rel *release.Release, details bool) HelmRelease {
 		hr.Status.Resources = resolveManifestResources(rel.Manifest, rel.Namespace)
 	}
 	return hr
+}
+
+func toHelmReleaseDryRunResponse(rel *release.Release) HelmReleaseDryRunResponse {
+	return HelmReleaseDryRunResponse{
+		Resources: resolveManifestPreviewResources(rel.Manifest, rel.Namespace),
+	}
+}
+
+func toHelmReleaseDryRunDiffResponse(current, next *release.Release) HelmReleaseDryRunResponse {
+	return HelmReleaseDryRunResponse{
+		Resources: diffManifestPreviewResources(
+			current.Manifest,
+			current.Namespace,
+			next.Manifest,
+			next.Namespace,
+		),
+	}
 }
 
 func helmChartInfo(rel *release.Release) (string, string, string) {
@@ -749,11 +926,9 @@ func helmHookLastRun(hook *release.Hook) map[string]interface{} {
 }
 
 func resolveManifestResources(manifest, defaultNamespace string) []HelmReleaseResource {
-	docs := strings.Split(manifest, "\n---")
 	out := []HelmReleaseResource{}
-	for _, doc := range docs {
-		doc = strings.TrimSpace(doc)
-		if doc == "" {
+	for _, doc := range splitManifestDocuments(manifest) {
+		if isCommentOnlyManifestDocument(doc) {
 			continue
 		}
 		var u unstructured.Unstructured
@@ -773,4 +948,145 @@ func resolveManifestResources(manifest, defaultNamespace string) []HelmReleaseRe
 		})
 	}
 	return out
+}
+
+func resolveManifestPreviewResources(manifest, defaultNamespace string) []HelmReleaseDryRunResource {
+	out := []HelmReleaseDryRunResource{}
+	for i, doc := range splitManifestDocuments(manifest) {
+		if isCommentOnlyManifestDocument(doc) {
+			continue
+		}
+		content := trimHelmSourceComment(doc)
+		var u unstructured.Unstructured
+		if err := yaml.Unmarshal([]byte(doc), &u.Object); err != nil || u.GetKind() == "" || u.GetName() == "" {
+			out = append(out, HelmReleaseDryRunResource{
+				Path:    fmt.Sprintf("manifest-%d.yaml", i+1),
+				Content: content,
+			})
+			continue
+		}
+		ns := u.GetNamespace()
+		_, clusterScoped := helmClusterScopedKinds[strings.ToLower(u.GetKind())]
+		if ns == "" && !clusterScoped {
+			ns = defaultNamespace
+		}
+		resource := HelmReleaseResource{
+			APIVersion: u.GetAPIVersion(),
+			Kind:       u.GetKind(),
+			Name:       u.GetName(),
+			Namespace:  ns,
+		}
+		out = append(out, HelmReleaseDryRunResource{
+			HelmReleaseResource: resource,
+			Path:                manifestPreviewPath(resource, i),
+			Content:             content,
+		})
+	}
+	return out
+}
+
+func diffManifestPreviewResources(currentManifest, currentNamespace, nextManifest, nextNamespace string) []HelmReleaseDryRunResource {
+	currentResources := resolveManifestPreviewResources(currentManifest, currentNamespace)
+	nextResources := resolveManifestPreviewResources(nextManifest, nextNamespace)
+	currentByPath := make(map[string]HelmReleaseDryRunResource, len(currentResources))
+	nextByPath := make(map[string]HelmReleaseDryRunResource, len(nextResources))
+	for _, resource := range currentResources {
+		currentByPath[resource.Path] = resource
+	}
+	for _, resource := range nextResources {
+		nextByPath[resource.Path] = resource
+	}
+
+	out := make([]HelmReleaseDryRunResource, 0, len(currentResources)+len(nextResources))
+	seen := make(map[string]struct{}, len(currentResources)+len(nextResources))
+	for _, resource := range nextResources {
+		if _, ok := seen[resource.Path]; ok {
+			continue
+		}
+		seen[resource.Path] = struct{}{}
+		nextResource := nextByPath[resource.Path]
+		currentResource, exists := currentByPath[resource.Path]
+		nextResource.OriginalContent = currentResource.Content
+		nextResource.ModifiedContent = nextResource.Content
+		switch {
+		case !exists:
+			nextResource.Status = "added"
+		case currentResource.Content == nextResource.Content:
+			nextResource.Status = "unchanged"
+		default:
+			nextResource.Status = "changed"
+		}
+		out = append(out, nextResource)
+	}
+
+	for _, resource := range currentResources {
+		if _, ok := seen[resource.Path]; ok {
+			continue
+		}
+		if _, exists := nextByPath[resource.Path]; exists {
+			continue
+		}
+		resource.OriginalContent = resource.Content
+		resource.ModifiedContent = ""
+		resource.Status = "deleted"
+		out = append(out, resource)
+	}
+	return out
+}
+
+func splitManifestDocuments(manifest string) []string {
+	docs := []string{}
+	lines := []string{}
+	for _, line := range strings.Split(manifest, "\n") {
+		marker := strings.TrimRight(line, " \t\r")
+		if marker == "---" || strings.HasPrefix(marker, "--- #") {
+			doc := strings.TrimSpace(strings.Join(lines, "\n"))
+			if doc != "" {
+				docs = append(docs, doc)
+			}
+			lines = lines[:0]
+			continue
+		}
+		lines = append(lines, line)
+	}
+
+	doc := strings.TrimSpace(strings.Join(lines, "\n"))
+	if doc != "" {
+		docs = append(docs, doc)
+	}
+	return docs
+}
+
+func isCommentOnlyManifestDocument(content string) bool {
+	for _, line := range strings.Split(content, "\n") {
+		line = strings.TrimSpace(line)
+		if line != "" && !strings.HasPrefix(line, "#") {
+			return false
+		}
+	}
+	return true
+}
+
+func trimHelmSourceComment(content string) string {
+	lines := strings.Split(content, "\n")
+	if len(lines) == 0 || !strings.HasPrefix(strings.TrimSpace(lines[0]), "# Source:") {
+		return content
+	}
+	return strings.TrimSpace(strings.Join(lines[1:], "\n"))
+}
+
+func manifestPreviewPath(resource HelmReleaseResource, index int) string {
+	scope := resource.Namespace
+	if scope == "" {
+		scope = "cluster"
+	}
+	kind := resource.Kind
+	if kind == "" {
+		kind = "Resource"
+	}
+	name := resource.Name
+	if name == "" {
+		name = fmt.Sprintf("manifest-%d", index+1)
+	}
+	return scope + "/" + kind + "/" + name + ".yaml"
 }

--- a/pkg/helmutil/chart.go
+++ b/pkg/helmutil/chart.go
@@ -6,6 +6,8 @@ import (
 	"net/url"
 	"path"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/zxh326/kite/pkg/model"
 	chart "helm.sh/helm/v4/pkg/chart/v2"
@@ -14,6 +16,18 @@ import (
 	"helm.sh/helm/v4/pkg/registry"
 	repo "helm.sh/helm/v4/pkg/repo/v1"
 )
+
+const archiveCacheTTL = 10 * time.Minute
+
+var (
+	archiveCacheMu sync.Mutex
+	archiveCache   = map[string]cachedArchive{}
+)
+
+type cachedArchive struct {
+	data      []byte
+	expiresAt time.Time
+}
 
 func LoadRepositoryArchive(repository model.HelmRepository, entry *repo.ChartVersion) (*chart.Chart, error) {
 	if len(entry.URLs) == 0 {
@@ -35,6 +49,17 @@ func LoadArchive(chartURL string, repository *model.HelmRepository) (*chart.Char
 	if parsedURL.Scheme != "http" && parsedURL.Scheme != "https" && parsedURL.Scheme != "oci" {
 		return nil, fmt.Errorf("unsupported chartUrl scheme")
 	}
+
+	cacheKey := archiveCacheKey(chartURL)
+	now := time.Now()
+	archiveCacheMu.Lock()
+	cached, ok := archiveCache[cacheKey]
+	if ok && now.Before(cached.expiresAt) {
+		data := append([]byte(nil), cached.data...)
+		archiveCacheMu.Unlock()
+		return loader.LoadArchive(bytes.NewReader(data))
+	}
+	archiveCacheMu.Unlock()
 
 	client, err := getter.Getters().ByScheme(parsedURL.Scheme)
 	if err != nil {
@@ -82,7 +107,20 @@ func LoadArchive(chartURL string, repository *model.HelmRepository) (*chart.Char
 	if err != nil {
 		return nil, err
 	}
-	return loader.LoadArchive(bytes.NewReader(data.Bytes()))
+	archiveData := data.Bytes()
+	loadedChart, err := loader.LoadArchive(bytes.NewReader(archiveData))
+	if err != nil {
+		return nil, err
+	}
+
+	archiveCacheMu.Lock()
+	archiveCache[cacheKey] = cachedArchive{
+		data:      append([]byte(nil), archiveData...),
+		expiresAt: time.Now().Add(archiveCacheTTL),
+	}
+	archiveCacheMu.Unlock()
+
+	return loadedChart, nil
 }
 
 func ResolveURL(baseURL, refURL string) string {
@@ -106,4 +144,21 @@ func sameURLHost(baseURL, targetURL string) bool {
 		return false
 	}
 	return strings.EqualFold(base.Hostname(), target.Hostname())
+}
+
+func archiveCacheKey(chartURL string) string {
+	return chartURL
+}
+
+func ClearRepositoryArchiveCache(repository model.HelmRepository) {
+	cacheKey := repository.URL
+	cacheKeyPrefix := strings.TrimRight(cacheKey, "/") + "/"
+
+	archiveCacheMu.Lock()
+	for key := range archiveCache {
+		if key == cacheKey || strings.HasPrefix(key, cacheKeyPrefix) {
+			delete(archiveCache, key)
+		}
+	}
+	archiveCacheMu.Unlock()
 }

--- a/ui/package.json
+++ b/ui/package.json
@@ -85,7 +85,7 @@
     "monaco-editor": "^0.55.1",
     "prettier": "^3.8.3",
     "tw-animate-css": "^1.4.0",
-    "typescript": "~5.9.3",
+    "typescript": "6.0.3",
     "typescript-eslint": "^8.59.2",
     "vite": "^8.0.10",
     "vitest": "^4.1.5"

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -97,7 +97,7 @@ importers:
         version: 4.1.0
       i18next:
         specifier: ^25.10.10
-        version: 25.10.10(typescript@5.9.3)
+        version: 25.10.10(typescript@6.0.3)
       i18next-browser-languagedetector:
         specifier: ^8.2.1
         version: 8.2.1
@@ -124,7 +124,7 @@ importers:
         version: 19.2.5(react@19.2.5)
       react-i18next:
         specifier: ^16.6.6
-        version: 16.6.6(i18next@25.10.10(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)
+        version: 16.6.6(i18next@25.10.10(typescript@6.0.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
       react-markdown:
         specifier: ^10.1.0
         version: 10.1.0(@types/react@19.2.14)(react@19.2.5)
@@ -208,11 +208,11 @@ importers:
         specifier: ^1.4.0
         version: 1.4.0
       typescript:
-        specifier: ~5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
       typescript-eslint:
         specifier: ^8.59.2
-        version: 8.59.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+        version: 8.59.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3)
       vite:
         specifier: ^8.0.10
         version: 8.0.10(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)
@@ -1220,36 +1220,42 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
     resolution: {integrity: sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
     resolution: {integrity: sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
     resolution: {integrity: sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==}
@@ -1329,24 +1335,28 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.2.4':
     resolution: {integrity: sha512-bBADEGAbo4ASnppIziaQJelekCxdMaxisrk+fB7Thit72IBnALp9K6ffA2G4ruj90G9XRS2VQ6q2bCKbfFV82g==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.2.4':
     resolution: {integrity: sha512-7Mx25E4WTfnht0TVRTyC00j3i0M+EeFe7wguMDTlX4mRxafznw0CA8WJkFjWYH5BlgELd1kSjuU2JiPnNZbJDA==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.2.4':
     resolution: {integrity: sha512-2wwJRF7nyhOR0hhHoChc04xngV3iS+akccHTGtz965FwF0up4b2lOdo6kI1EbDaEXKgvcrFBYcYQQ/rrnWFVfA==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.2.4':
     resolution: {integrity: sha512-FQsqApeor8Fo6gUEklzmaa9994orJZZDBAlQpK2Mq+DslRKFJeD6AjHpBQ0kZFQohVr8o85PPh8eOy86VlSCmw==}
@@ -2266,24 +2276,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -2887,8 +2901,8 @@ packages:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
-  typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -4320,40 +4334,40 @@ snapshots:
 
   '@types/unist@3.0.3': {}
 
-  '@typescript-eslint/eslint-plugin@8.59.2(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@8.59.2(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.59.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.59.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3)
       '@typescript-eslint/scope-manager': 8.59.2
-      '@typescript-eslint/type-utils': 8.59.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.59.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/type-utils': 8.59.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.59.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 8.59.2
       eslint: 9.39.4(jiti@2.6.1)
       ignore: 7.0.5
       natural-compare: 1.4.0
-      ts-api-utils: 2.5.0(typescript@5.9.3)
-      typescript: 5.9.3
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.59.2
       '@typescript-eslint/types': 8.59.2
-      '@typescript-eslint/typescript-estree': 8.59.2(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.59.2(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 8.59.2
       debug: 4.4.3
       eslint: 9.39.4(jiti@2.6.1)
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.59.2(typescript@5.9.3)':
+  '@typescript-eslint/project-service@8.59.2(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.59.2(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.59.2(typescript@6.0.3)
       '@typescript-eslint/types': 8.59.2
       debug: 4.4.3
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -4362,47 +4376,47 @@ snapshots:
       '@typescript-eslint/types': 8.59.2
       '@typescript-eslint/visitor-keys': 8.59.2
 
-  '@typescript-eslint/tsconfig-utils@8.59.2(typescript@5.9.3)':
+  '@typescript-eslint/tsconfig-utils@8.59.2(typescript@6.0.3)':
     dependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
 
-  '@typescript-eslint/type-utils@8.59.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/type-utils@8.59.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/types': 8.59.2
-      '@typescript-eslint/typescript-estree': 8.59.2(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.59.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.59.2(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.59.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3)
       debug: 4.4.3
       eslint: 9.39.4(jiti@2.6.1)
-      ts-api-utils: 2.5.0(typescript@5.9.3)
-      typescript: 5.9.3
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
   '@typescript-eslint/types@8.59.2': {}
 
-  '@typescript-eslint/typescript-estree@8.59.2(typescript@5.9.3)':
+  '@typescript-eslint/typescript-estree@8.59.2(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.59.2(typescript@5.9.3)
-      '@typescript-eslint/tsconfig-utils': 8.59.2(typescript@5.9.3)
+      '@typescript-eslint/project-service': 8.59.2(typescript@6.0.3)
+      '@typescript-eslint/tsconfig-utils': 8.59.2(typescript@6.0.3)
       '@typescript-eslint/types': 8.59.2
       '@typescript-eslint/visitor-keys': 8.59.2
       debug: 4.4.3
       minimatch: 10.2.5
       semver: 7.7.4
       tinyglobby: 0.2.16
-      ts-api-utils: 2.5.0(typescript@5.9.3)
-      typescript: 5.9.3
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.59.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/utils@8.59.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.6.1))
       '@typescript-eslint/scope-manager': 8.59.2
       '@typescript-eslint/types': 8.59.2
-      '@typescript-eslint/typescript-estree': 8.59.2(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.59.2(typescript@6.0.3)
       eslint: 9.39.4(jiti@2.6.1)
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -4949,11 +4963,11 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.28.4
 
-  i18next@25.10.10(typescript@5.9.3):
+  i18next@25.10.10(typescript@6.0.3):
     dependencies:
       '@babel/runtime': 7.29.2
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
 
   ignore@5.3.2: {}
 
@@ -5595,16 +5609,16 @@ snapshots:
       react: 19.2.5
       scheduler: 0.27.0
 
-  react-i18next@16.6.6(i18next@25.10.10(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3):
+  react-i18next@16.6.6(i18next@25.10.10(typescript@6.0.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3):
     dependencies:
       '@babel/runtime': 7.29.2
       html-parse-stringify: 3.0.1
-      i18next: 25.10.10(typescript@5.9.3)
+      i18next: 25.10.10(typescript@6.0.3)
       react: 19.2.5
       use-sync-external-store: 1.6.0(react@19.2.5)
     optionalDependencies:
       react-dom: 19.2.5(react@19.2.5)
-      typescript: 5.9.3
+      typescript: 6.0.3
 
   react-is@16.13.1: {}
 
@@ -5879,9 +5893,9 @@ snapshots:
 
   trough@2.2.0: {}
 
-  ts-api-utils@2.5.0(typescript@5.9.3):
+  ts-api-utils@2.5.0(typescript@6.0.3):
     dependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
 
   tslib@2.8.1: {}
 
@@ -5891,18 +5905,18 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
 
-  typescript-eslint@8.59.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3):
+  typescript-eslint@8.59.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.59.2(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/parser': 8.59.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/typescript-estree': 8.59.2(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.59.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/eslint-plugin': 8.59.2(@typescript-eslint/parser@8.59.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.59.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 8.59.2(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.59.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3)
       eslint: 9.39.4(jiti@2.6.1)
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  typescript@5.9.3: {}
+  typescript@6.0.3: {}
 
   underscore@1.13.6: {}
 

--- a/ui/src/components/helm-install-dialog.tsx
+++ b/ui/src/components/helm-install-dialog.tsx
@@ -1,0 +1,405 @@
+import { useState, type FormEvent } from 'react'
+import * as yaml from 'js-yaml'
+import { Loader2 } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import { useNavigate } from 'react-router-dom'
+import { toast } from 'sonner'
+
+import type {
+  HelmChartDetail,
+  HelmReleaseDryRunResponse,
+  HelmReleaseInstallRequest,
+} from '@/types/api'
+import {
+  dryRunInstallHelmRelease,
+  installHelmRelease,
+  useHelmChartContent,
+} from '@/lib/api'
+import { translateError } from '@/lib/utils'
+import { Button } from '@/components/ui/button'
+import { Checkbox } from '@/components/ui/checkbox'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { NamespaceSelector } from '@/components/selector/namespace-selector'
+import { SimpleYamlEditor } from '@/components/simple-yaml-editor'
+import { YamlFileTreeViewerNative as YamlFileTreeViewer } from '@/components/yaml-file-tree-viewer-native'
+
+function defaultReleaseName(name: string) {
+  return (
+    name
+      .toLowerCase()
+      .replace(/[^a-z0-9-]+/g, '-')
+      .replace(/^-+|-+$/g, '') || name
+  )
+}
+
+export function HelmInstallDialog({
+  chart,
+  open,
+  onOpenChange,
+}: {
+  chart: HelmChartDetail
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}) {
+  const { t } = useTranslation()
+  const navigate = useNavigate()
+  const [releaseName, setReleaseName] = useState(() =>
+    defaultReleaseName(chart.name)
+  )
+  const [namespace, setNamespace] = useState('default')
+  const [isNamespaceManual, setIsNamespaceManual] = useState(false)
+  const [createNamespace, setCreateNamespace] = useState(true)
+  const [valuesYaml, setValuesYaml] = useState('')
+  const [error, setError] = useState('')
+  const [isInstalling, setIsInstalling] = useState(false)
+  const [isDryRunning, setIsDryRunning] = useState(false)
+  const [dryRunPreview, setDryRunPreview] =
+    useState<HelmReleaseDryRunResponse | null>(null)
+  const defaultValuesQuery = useHelmChartContent(
+    chart.repositoryName,
+    chart.name,
+    'values',
+    chart.version,
+    chart.source,
+    open
+  )
+  const defaultValues = defaultValuesQuery.isLoading
+    ? t('common.messages.loading')
+    : defaultValuesQuery.data?.content || ''
+  const readableError = error.replace(/\s&&\s/g, '\n')
+
+  const buildInstallRequest = (): {
+    targetNamespace: string
+    request: HelmReleaseInstallRequest
+  } | null => {
+    setError('')
+
+    if (!chart.chartUrl) {
+      setError(
+        t('helmCharts.messages.noChartUrl', {
+          defaultValue: 'Chart package URL is missing.',
+        })
+      )
+      return null
+    }
+
+    let values: Record<string, unknown> = {}
+    if (valuesYaml.trim()) {
+      try {
+        const parsed = yaml.load(valuesYaml)
+        if (parsed && (typeof parsed !== 'object' || Array.isArray(parsed))) {
+          setError(
+            t('helmCharts.messages.invalidValues', {
+              defaultValue: 'Values must be a YAML object.',
+            })
+          )
+          return null
+        }
+        values = (parsed || {}) as Record<string, unknown>
+      } catch (err) {
+        setError(translateError(err, t))
+        return null
+      }
+    }
+
+    const targetNamespace = namespace.trim()
+    const request = {
+      releaseName: releaseName.trim(),
+      namespace: targetNamespace,
+      chartUrl: chart.chartUrl,
+      repositoryName: chart.repositoryName,
+      source: chart.source,
+      createNamespace: isNamespaceManual && createNamespace,
+      values,
+    }
+
+    return { targetNamespace, request }
+  }
+
+  const handleDryRun = async () => {
+    const payload = buildInstallRequest()
+    if (!payload) {
+      return
+    }
+
+    setIsDryRunning(true)
+    try {
+      const preview = await dryRunInstallHelmRelease(
+        payload.targetNamespace,
+        payload.request
+      )
+      setDryRunPreview(preview)
+    } catch (err) {
+      setError(translateError(err, t))
+    } finally {
+      setIsDryRunning(false)
+    }
+  }
+
+  const handleInstall = async () => {
+    const payload = buildInstallRequest()
+    if (!payload) {
+      return
+    }
+
+    setIsInstalling(true)
+    try {
+      const release = await installHelmRelease(
+        payload.targetNamespace,
+        payload.request
+      )
+      const installedNamespace =
+        release.metadata?.namespace || payload.targetNamespace
+      const targetName = release.metadata?.name || releaseName.trim()
+      toast.success(
+        t('helmCharts.messages.installed', {
+          defaultValue: 'Helm release installed',
+        })
+      )
+      onOpenChange(false)
+      navigate(
+        `/helmrelease/${encodeURIComponent(installedNamespace)}/${encodeURIComponent(targetName)}`
+      )
+    } catch (err) {
+      setError(translateError(err, t))
+    } finally {
+      setIsInstalling(false)
+    }
+  }
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    if (dryRunPreview) {
+      await handleInstall()
+      return
+    }
+    await handleDryRun()
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        className="flex h-[calc(100dvh-4rem)] max-h-[calc(100dvh-4rem)] w-[calc(100vw-4rem)] !max-w-[calc(100vw-4rem)] flex-col overflow-hidden"
+        onPointerDownOutside={(event) => {
+          event.preventDefault()
+        }}
+        onEscapeKeyDown={(event) => {
+          event.preventDefault()
+        }}
+      >
+        <form
+          onSubmit={handleSubmit}
+          className="flex h-full min-h-0 flex-col gap-4"
+        >
+          <DialogHeader>
+            <DialogTitle>
+              {t('helmCharts.actions.install', { defaultValue: 'Install' })}
+            </DialogTitle>
+            <DialogDescription>
+              {chart.repositoryName}/{chart.name}:{chart.version}
+            </DialogDescription>
+          </DialogHeader>
+
+          {error ? (
+            <div
+              role="alert"
+              className="max-h-40 overflow-y-auto rounded-md border border-destructive/30 bg-destructive/5 p-3 text-sm leading-5"
+            >
+              <div className="mb-1 font-medium text-destructive">
+                {t('common.fields.errorDetails')}
+              </div>
+              <pre className="m-0 whitespace-pre-wrap break-words font-mono text-xs leading-5 text-foreground">
+                {readableError}
+              </pre>
+            </div>
+          ) : null}
+
+          <div
+            className={
+              dryRunPreview
+                ? 'flex min-h-0 flex-1 flex-col gap-4 overflow-hidden pr-1'
+                : 'min-h-0 flex-1 space-y-4 overflow-y-auto pr-1'
+            }
+          >
+            <div className="grid gap-4 md:grid-cols-2">
+              <div className="grid gap-2">
+                <Label htmlFor="helm-release-name">
+                  {t('helm.fields.releaseName')}
+                </Label>
+                <Input
+                  id="helm-release-name"
+                  value={releaseName}
+                  onChange={(event) => {
+                    setReleaseName(event.target.value)
+                    setDryRunPreview(null)
+                  }}
+                  disabled={isInstalling || isDryRunning || !!dryRunPreview}
+                  required
+                />
+              </div>
+
+              <div className="grid gap-2">
+                <Label htmlFor="helm-release-namespace">
+                  {t('common.fields.namespace', { defaultValue: 'Namespace' })}
+                </Label>
+                <div className="flex flex-wrap items-center gap-2">
+                  <NamespaceSelector
+                    selectedNamespace={namespace}
+                    handleNamespaceChange={(value) => {
+                      setNamespace(value)
+                      setIsNamespaceManual(false)
+                      setDryRunPreview(null)
+                    }}
+                    disabled={isInstalling || isDryRunning || !!dryRunPreview}
+                    triggerClassName="w-44 sm:w-44 sm:min-w-0"
+                    modal
+                  />
+                  <Input
+                    id="helm-release-namespace"
+                    value={namespace}
+                    onChange={(event) => {
+                      setNamespace(event.target.value)
+                      setIsNamespaceManual(true)
+                      setCreateNamespace(true)
+                      setDryRunPreview(null)
+                    }}
+                    disabled={isInstalling || isDryRunning || !!dryRunPreview}
+                    required
+                    className="w-48"
+                  />
+                </div>
+              </div>
+            </div>
+
+            {dryRunPreview ? (
+              <YamlFileTreeViewer
+                files={dryRunPreview.resources}
+                title={t('helm.fields.dryRunPreview')}
+                emptyMessage={t('helm.messages.noDryRunResources')}
+                fillHeight
+              />
+            ) : (
+              <div className="grid min-h-0 gap-4 lg:grid-cols-2">
+                <div className="grid min-h-0 gap-2">
+                  <Label>{t('helmCharts.fields.defaultValues')}</Label>
+                  <SimpleYamlEditor
+                    value={defaultValues}
+                    onChange={() => undefined}
+                    disabled
+                    height="calc(100dvh - 20rem)"
+                  />
+                </div>
+
+                <div className="grid min-h-0 gap-2">
+                  <Label>{t('helmCharts.fields.customValues')}</Label>
+                  <SimpleYamlEditor
+                    value={valuesYaml}
+                    onChange={(value) => {
+                      setValuesYaml(value || '')
+                      setDryRunPreview(null)
+                    }}
+                    disabled={isInstalling || isDryRunning}
+                    height="calc(100dvh - 20rem)"
+                  />
+                </div>
+              </div>
+            )}
+
+            {defaultValuesQuery.error ? (
+              <p className="text-sm text-destructive">
+                {translateError(defaultValuesQuery.error, t)}
+              </p>
+            ) : null}
+          </div>
+
+          <DialogFooter className="items-center gap-3 sm:justify-end">
+            {!dryRunPreview && isNamespaceManual ? (
+              <div className="flex items-center gap-2">
+                <Checkbox
+                  id="helm-create-namespace"
+                  checked={createNamespace}
+                  onCheckedChange={(value) => {
+                    setCreateNamespace(value === true)
+                    setDryRunPreview(null)
+                  }}
+                  disabled={isInstalling || isDryRunning}
+                />
+                <Label
+                  htmlFor="helm-create-namespace"
+                  className="text-sm font-normal"
+                >
+                  {t('helm.fields.createNamespace')}
+                </Label>
+              </div>
+            ) : null}
+            <div className="flex flex-col-reverse gap-2 sm:flex-row">
+              {dryRunPreview ? (
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => setDryRunPreview(null)}
+                  disabled={isInstalling || isDryRunning}
+                >
+                  {t('helm.actions.backToValues')}
+                </Button>
+              ) : (
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => onOpenChange(false)}
+                  disabled={isInstalling || isDryRunning}
+                >
+                  {t('common.actions.cancel')}
+                </Button>
+              )}
+              {!dryRunPreview ? (
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => void handleDryRun()}
+                  disabled={
+                    !releaseName.trim() ||
+                    !namespace.trim() ||
+                    !chart.chartUrl ||
+                    isInstalling ||
+                    isDryRunning
+                  }
+                >
+                  {isDryRunning ? (
+                    <Loader2 className="size-4 animate-spin" />
+                  ) : null}
+                  {t('helm.actions.dryRun')}
+                </Button>
+              ) : null}
+              <Button
+                type="button"
+                onClick={() => void handleInstall()}
+                disabled={
+                  !releaseName.trim() ||
+                  !namespace.trim() ||
+                  !chart.chartUrl ||
+                  isInstalling ||
+                  isDryRunning
+                }
+              >
+                {isInstalling ? (
+                  <Loader2 className="size-4 animate-spin" />
+                ) : null}
+                {t('helmCharts.actions.install', { defaultValue: 'Install' })}
+              </Button>
+            </div>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/ui/src/components/selector/namespace-selector.tsx
+++ b/ui/src/components/selector/namespace-selector.tsx
@@ -27,6 +27,7 @@ export function NamespaceSelector({
   disabled = false,
   triggerClassName,
   multiple = false,
+  modal = false,
 }: {
   selectedNamespace?: string
   handleNamespaceChange: (namespace: string) => void
@@ -34,6 +35,7 @@ export function NamespaceSelector({
   disabled?: boolean
   triggerClassName?: string
   multiple?: boolean
+  modal?: boolean
 }) {
   const [open, setOpen] = useState(false)
   const { data, isLoading } = useResources('namespaces')
@@ -88,7 +90,7 @@ export function NamespaceSelector({
   }
 
   return (
-    <Popover open={open} onOpenChange={setOpen}>
+    <Popover open={open} onOpenChange={setOpen} modal={modal}>
       <PopoverTrigger asChild>
         <Button
           variant="outline"
@@ -111,7 +113,7 @@ export function NamespaceSelector({
       >
         <Command>
           <CommandInput placeholder="Search..." className="h-9" />
-          <CommandList className="max-h-[300px] overflow-x-hidden overflow-y-auto [ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+          <CommandList className="max-h-[min(50dvh,300px)] overflow-x-hidden overflow-y-auto overscroll-contain">
             {isLoading ? (
               <div className="flex items-center justify-center p-6 text-sm">
                 <Loader2 className="h-4 w-4 animate-spin mr-2" />

--- a/ui/src/components/text-viewer.tsx
+++ b/ui/src/components/text-viewer.tsx
@@ -3,6 +3,7 @@ import {
   defineMonacoBackgroundThemes,
   useMonacoBackgroundColor,
 } from '@/lib/monaco-theme'
+import { cn } from '@/lib/utils'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { useAppearance } from '@/components/appearance-provider'
 
@@ -10,12 +11,14 @@ interface TextViewerProps {
   value: string
   title?: string
   className?: string
+  fillHeight?: boolean
 }
 
 export function TextViewer({
   value,
   title = 'Text',
   className,
+  fillHeight = false,
 }: TextViewerProps) {
   const { actualTheme, colorTheme } = useAppearance()
   const themeMode = actualTheme === 'dark' ? 'dark' : 'light'
@@ -28,17 +31,28 @@ export function TextViewer({
   const lightThemeName = `text-viewer-light-${colorTheme}`
 
   return (
-    <Card className={className}>
+    <Card className={cn(fillHeight && 'flex min-h-0 flex-col', className)}>
       <CardHeader className="flex flex-row items-center justify-between">
         <div className="space-y-1">
           <CardTitle>{title}</CardTitle>
         </div>
       </CardHeader>
-      <CardContent>
-        <div className="space-y-2">
-          <div className="overflow-hidden h-[calc(100dvh-300px)]">
+      <CardContent className={cn(fillHeight && 'min-h-0 flex-1')}>
+        <div
+          className={cn(
+            'space-y-2',
+            fillHeight && 'flex h-full min-h-0 flex-col'
+          )}
+        >
+          <div
+            className={cn(
+              'overflow-hidden h-[calc(100dvh-300px)]',
+              fillHeight && 'h-auto min-h-0 flex-1'
+            )}
+          >
             <MonacoEditor
               key={`text-viewer-${colorTheme}-${actualTheme}-${backgroundColor}`}
+              height={fillHeight ? '100%' : undefined}
               language="yaml"
               theme={actualTheme === 'dark' ? darkThemeName : lightThemeName}
               value={value}

--- a/ui/src/components/yaml-file-tree-viewer-native.tsx
+++ b/ui/src/components/yaml-file-tree-viewer-native.tsx
@@ -1,0 +1,524 @@
+import { useMemo, useState, type ReactNode } from 'react'
+import {
+  ChevronDown,
+  ChevronRight,
+  FileText,
+  Folder,
+  FolderOpen,
+} from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+
+import { MonacoDiffEditor } from '@/lib/monaco-loader'
+import {
+  defineMonacoBackgroundThemes,
+  useMonacoBackgroundColor,
+} from '@/lib/monaco-theme'
+import { cn } from '@/lib/utils'
+import { Badge } from '@/components/ui/badge'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { useAppearance } from '@/components/appearance-provider'
+import { TextViewer } from '@/components/text-viewer'
+
+export interface YamlFileTreeItem {
+  path: string
+  content: string
+}
+
+export type YamlDiffTreeItemStatus =
+  | 'added'
+  | 'deleted'
+  | 'changed'
+  | 'unchanged'
+
+export interface YamlDiffTreeItem {
+  path: string
+  originalContent: string
+  modifiedContent: string
+  status: YamlDiffTreeItemStatus
+}
+
+type NativeTreeStatus = 'added' | 'deleted' | 'modified'
+
+interface NativeTreeNode<T extends { path: string }> {
+  children: NativeTreeNode<T>[]
+  file?: T
+  name: string
+  path: string
+  status: NativeTreeStatus | null
+  type: 'directory' | 'file'
+}
+
+interface NativeTreeRow<T extends { path: string }> {
+  depth: number
+  node: NativeTreeNode<T>
+}
+
+const defaultTreeHeightClassName = 'h-[calc(100dvh-350px)] min-h-72'
+
+function gitStatusForDiffStatus(
+  status: YamlDiffTreeItemStatus
+): NativeTreeStatus | null {
+  switch (status) {
+    case 'added':
+    case 'deleted':
+      return status
+    case 'changed':
+      return 'modified'
+    case 'unchanged':
+      return null
+  }
+}
+
+function getYamlFileSearchText(file: YamlFileTreeItem) {
+  return `${file.path}\n${file.content}`
+}
+
+function getYamlDiffSearchText(file: YamlDiffTreeItem) {
+  return `${file.path}\n${file.status}\n${file.originalContent}\n${file.modifiedContent}`
+}
+
+function getYamlDiffGitStatus(file: YamlDiffTreeItem) {
+  return gitStatusForDiffStatus(file.status)
+}
+
+function emptyDirectory<T extends { path: string }>(
+  name: string,
+  path: string
+): NativeTreeNode<T> {
+  return {
+    children: [],
+    name,
+    path,
+    status: null,
+    type: 'directory',
+  }
+}
+
+function sortTreeNodes<T extends { path: string }>(nodes: NativeTreeNode<T>[]) {
+  nodes.sort((left, right) => {
+    if (left.type !== right.type) {
+      return left.type === 'directory' ? -1 : 1
+    }
+    return left.name.localeCompare(right.name)
+  })
+
+  for (const node of nodes) {
+    sortTreeNodes(node.children)
+  }
+}
+
+function markDirectoryStatus<T extends { path: string }>(
+  node: NativeTreeNode<T>
+) {
+  for (const child of node.children) {
+    markDirectoryStatus(child)
+    if (!node.status && child.status) {
+      node.status = 'modified'
+    }
+  }
+}
+
+function buildTree<T extends { path: string }>(
+  files: T[],
+  getGitStatus?: (file: T) => NativeTreeStatus | null
+) {
+  const root = emptyDirectory<T>('', '')
+  const directories = new Map<string, NativeTreeNode<T>>([['', root]])
+  const fileByPath = new Map<string, T>()
+
+  for (const file of files) {
+    const parts = file.path.split('/').filter(Boolean)
+    let parent = root
+    let parentPath = ''
+
+    for (const part of parts.slice(0, -1)) {
+      const directoryPath = parentPath ? `${parentPath}/${part}` : part
+      let directory = directories.get(directoryPath)
+      if (!directory) {
+        directory = emptyDirectory(part, directoryPath)
+        directories.set(directoryPath, directory)
+        parent.children.push(directory)
+      }
+      parent = directory
+      parentPath = directoryPath
+    }
+
+    const name = parts[parts.length - 1] || file.path
+    const fileNode: NativeTreeNode<T> = {
+      children: [],
+      file,
+      name,
+      path: file.path,
+      status: getGitStatus?.(file) || null,
+      type: 'file',
+    }
+    parent.children.push(fileNode)
+    fileByPath.set(file.path, file)
+  }
+
+  sortTreeNodes(root.children)
+  markDirectoryStatus(root)
+
+  return {
+    fileByPath,
+    roots: root.children,
+  }
+}
+
+function flattenTree<T extends { path: string }>(
+  nodes: NativeTreeNode<T>[],
+  collapsedPaths: ReadonlySet<string>,
+  depth = 0
+) {
+  const rows: NativeTreeRow<T>[] = []
+
+  for (const node of nodes) {
+    rows.push({ depth, node })
+    if (node.type === 'directory' && !collapsedPaths.has(node.path)) {
+      rows.push(...flattenTree(node.children, collapsedPaths, depth + 1))
+    }
+  }
+
+  return rows
+}
+
+function statusClassName(status: NativeTreeStatus | null) {
+  switch (status) {
+    case 'added':
+      return 'text-emerald-600 dark:text-emerald-400'
+    case 'deleted':
+      return 'text-destructive'
+    case 'modified':
+      return 'text-sky-600 dark:text-sky-400'
+    default:
+      return 'text-muted-foreground'
+  }
+}
+
+function statusLabel(status: NativeTreeStatus | null) {
+  switch (status) {
+    case 'added':
+      return 'A'
+    case 'deleted':
+      return 'D'
+    case 'modified':
+      return 'M'
+    default:
+      return null
+  }
+}
+
+function NativeYamlFileTree<T extends { path: string }>({
+  roots,
+  selectedPath,
+  fillHeight,
+  onSelect,
+}: {
+  roots: NativeTreeNode<T>[]
+  selectedPath: string
+  fillHeight: boolean
+  onSelect: (path: string) => void
+}) {
+  const [collapsedPaths, setCollapsedPaths] = useState<Set<string>>(new Set())
+  const rows = useMemo(
+    () => flattenTree(roots, collapsedPaths),
+    [collapsedPaths, roots]
+  )
+
+  return (
+    <div
+      className={cn(
+        'overflow-y-auto overscroll-contain rounded-md bg-card px-2 py-1 text-[13px]',
+        fillHeight ? 'min-h-0 flex-1' : defaultTreeHeightClassName
+      )}
+    >
+      {rows.map(({ depth, node }) => {
+        const isDirectory = node.type === 'directory'
+        const isCollapsed = collapsedPaths.has(node.path)
+        const isSelected = node.path === selectedPath
+        const StatusIcon = isDirectory
+          ? isCollapsed
+            ? Folder
+            : FolderOpen
+          : FileText
+        const label = statusLabel(node.status)
+
+        return (
+          <button
+            key={`${node.type}:${node.path}`}
+            type="button"
+            className={cn(
+              'flex h-[30px] w-full min-w-0 items-center rounded-md pr-2 text-left outline-none transition-colors hover:bg-muted/70 focus-visible:ring-1 focus-visible:ring-ring',
+              isSelected && 'bg-accent text-accent-foreground hover:bg-accent'
+            )}
+            style={{ paddingLeft: 8 + depth * 18 }}
+            onClick={() => {
+              if (isDirectory) {
+                setCollapsedPaths((current) => {
+                  const next = new Set(current)
+                  if (next.has(node.path)) {
+                    next.delete(node.path)
+                  } else {
+                    next.add(node.path)
+                  }
+                  return next
+                })
+                return
+              }
+              onSelect(node.path)
+            }}
+          >
+            <span className="mr-1 flex size-4 shrink-0 items-center justify-center text-muted-foreground">
+              {isDirectory ? (
+                isCollapsed ? (
+                  <ChevronRight className="size-3.5" />
+                ) : (
+                  <ChevronDown className="size-3.5" />
+                )
+              ) : null}
+            </span>
+            <StatusIcon
+              className={cn(
+                'mr-1.5 size-3.5 shrink-0',
+                statusClassName(node.status)
+              )}
+            />
+            <span className="min-w-0 flex-1 truncate">{node.name}</span>
+            {label ? (
+              <span
+                className={cn(
+                  'ml-2 shrink-0 text-[10px] font-semibold tabular-nums',
+                  statusClassName(node.status)
+                )}
+              >
+                {label}
+              </span>
+            ) : null}
+          </button>
+        )
+      })}
+    </div>
+  )
+}
+
+function NativeYamlTreeViewer<T extends { path: string }>({
+  files,
+  title,
+  emptyMessage,
+  fillHeight = false,
+  getSearchText,
+  getGitStatus,
+  renderSelectedFile,
+}: {
+  files: T[]
+  title: string
+  emptyMessage: string
+  fillHeight?: boolean
+  getSearchText: (file: T) => string
+  getGitStatus?: (file: T) => NativeTreeStatus | null
+  renderSelectedFile: (file: T, fillHeight: boolean) => ReactNode
+}) {
+  const { t } = useTranslation()
+  const [searchQuery, setSearchQuery] = useState('')
+  const normalizedSearchQuery = searchQuery.trim().toLowerCase()
+  const visibleFiles = useMemo(
+    () =>
+      files.filter(
+        (file) =>
+          !normalizedSearchQuery ||
+          getSearchText(file).toLowerCase().includes(normalizedSearchQuery)
+      ),
+    [files, getSearchText, normalizedSearchQuery]
+  )
+  const tree = useMemo(
+    () => buildTree(visibleFiles, getGitStatus),
+    [getGitStatus, visibleFiles]
+  )
+  const [selectedPath, setSelectedPath] = useState('')
+  const selectedFile = tree.fileByPath.get(selectedPath) || visibleFiles[0]
+
+  return (
+    <div
+      className={cn(
+        'grid min-h-0 gap-4 lg:grid-cols-[minmax(16rem,0.32fr)_minmax(0,1fr)]',
+        fillHeight && 'h-full min-h-0 flex-1 overflow-hidden'
+      )}
+    >
+      <Card className="flex min-h-0 flex-col gap-0 overflow-hidden rounded-lg border-border/70 py-0 shadow-none">
+        <CardHeader className="shrink-0 px-3 py-2 !pb-2">
+          <CardTitle className="text-balance text-sm">{title}</CardTitle>
+        </CardHeader>
+        <CardContent className="flex min-h-0 flex-1 flex-col gap-2 px-2 pb-2 pt-0">
+          <Input
+            aria-label={t('common.actions.search')}
+            value={searchQuery}
+            onChange={(event) => setSearchQuery(event.target.value)}
+            placeholder={t('common.actions.search')}
+            className="h-8"
+          />
+          {selectedFile ? (
+            <NativeYamlFileTree
+              roots={tree.roots}
+              selectedPath={selectedFile.path}
+              fillHeight={fillHeight}
+              onSelect={setSelectedPath}
+            />
+          ) : (
+            <div
+              className={cn(
+                'flex items-center justify-center rounded-md text-sm text-muted-foreground',
+                fillHeight ? 'min-h-0 flex-1' : defaultTreeHeightClassName
+              )}
+            >
+              {emptyMessage}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+      {selectedFile ? (
+        renderSelectedFile(selectedFile, fillHeight)
+      ) : (
+        <Card className={cn(fillHeight && 'h-full')}>
+          <CardContent className="pt-6 text-sm text-muted-foreground">
+            {emptyMessage}
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  )
+}
+
+export function YamlFileTreeViewerNative({
+  files,
+  title,
+  emptyMessage,
+  fillHeight,
+}: {
+  files: YamlFileTreeItem[]
+  title: string
+  emptyMessage: string
+  fillHeight?: boolean
+}) {
+  return (
+    <NativeYamlTreeViewer
+      files={files}
+      title={title}
+      emptyMessage={emptyMessage}
+      fillHeight={fillHeight}
+      getSearchText={getYamlFileSearchText}
+      renderSelectedFile={(file, fillHeight) => (
+        <TextViewer
+          value={file.content}
+          title={file.path}
+          fillHeight={fillHeight}
+        />
+      )}
+    />
+  )
+}
+
+export function YamlDiffPanel({
+  file,
+  fillHeight,
+}: {
+  file: YamlDiffTreeItem
+  fillHeight: boolean
+}) {
+  const { t } = useTranslation()
+  const { actualTheme, colorTheme } = useAppearance()
+  const themeMode = actualTheme === 'dark' ? 'dark' : 'light'
+  const backgroundColor = useMonacoBackgroundColor(
+    '--card',
+    themeMode,
+    colorTheme
+  )
+  const darkThemeName = `yaml-diff-dark-${colorTheme}`
+  const lightThemeName = `yaml-diff-light-${colorTheme}`
+  const statusLabel = {
+    added: t('helm.diff.added'),
+    deleted: t('helm.diff.deleted'),
+    changed: t('helm.diff.changed'),
+    unchanged: t('helm.diff.unchanged'),
+  }[file.status]
+
+  return (
+    <Card className={cn('flex min-h-0 flex-col', fillHeight && 'h-full')}>
+      <CardHeader className="flex shrink-0 flex-row items-center justify-between">
+        <CardTitle className="min-w-0 truncate">{file.path}</CardTitle>
+        <Badge variant="outline">{statusLabel}</Badge>
+      </CardHeader>
+      <CardContent className="min-h-0 flex-1">
+        <div
+          className={cn(
+            'overflow-hidden h-[calc(100dvh-300px)]',
+            fillHeight && 'h-full min-h-0'
+          )}
+        >
+          <MonacoDiffEditor
+            key={`yaml-diff-${colorTheme}-${actualTheme}-${backgroundColor}`}
+            height={fillHeight ? '100%' : undefined}
+            language="yaml"
+            original={file.originalContent}
+            modified={file.modifiedContent}
+            loading={
+              <div className="flex h-full items-center justify-center text-muted-foreground">
+                Loading editor...
+              </div>
+            }
+            beforeMount={(monaco) => {
+              defineMonacoBackgroundThemes(monaco, {
+                darkThemeName,
+                lightThemeName,
+                backgroundColor,
+              })
+            }}
+            theme={actualTheme === 'dark' ? darkThemeName : lightThemeName}
+            options={{
+              readOnly: true,
+              minimap: { enabled: false },
+              scrollBeyondLastLine: false,
+              automaticLayout: true,
+              wordWrap: 'on',
+              lineNumbers: 'on',
+              folding: true,
+              fontSize: 14,
+              fontFamily:
+                "'Maple Mono',Monaco, 'Cascadia Code', 'Roboto Mono', Consolas, 'Courier New', monospace",
+              renderSideBySide: true,
+              enableSplitViewResizing: true,
+              ignoreTrimWhitespace: false,
+              renderOverviewRuler: true,
+            }}
+          />
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
+export function YamlFileTreeDiffViewerNative({
+  files,
+  title,
+  emptyMessage,
+  fillHeight,
+}: {
+  files: YamlDiffTreeItem[]
+  title: string
+  emptyMessage: string
+  fillHeight?: boolean
+}) {
+  return (
+    <NativeYamlTreeViewer
+      files={files}
+      title={title}
+      emptyMessage={emptyMessage}
+      fillHeight={fillHeight}
+      getSearchText={getYamlDiffSearchText}
+      getGitStatus={getYamlDiffGitStatus}
+      renderSelectedFile={(file, fillHeight) => (
+        <YamlDiffPanel file={file} fillHeight={fillHeight} />
+      )}
+    />
+  )
+}

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -1052,7 +1052,8 @@
       "keywords": "Keywords",
       "versions": "Versions",
       "defaultValues": "Default values",
-      "customValues": "Custom values"
+      "customValues": "Custom values",
+      "updatedAt": "Updated"
     },
     "filters": {
       "allRepositories": "All repositories",
@@ -1072,6 +1073,7 @@
       "noVersions": "No versions found",
       "noChartUrl": "Chart package URL is missing.",
       "invalidValues": "Values must be a YAML object.",
+      "artifactHubTrafficNotice": "Security notice: Kite contacts <artifactHub>Artifact Hub</artifactHub> when searching or viewing chart information from this source. Kite only displays third-party data and is not responsible for its content.",
       "installed": "Helm release installed"
     },
     "placeholders": {
@@ -1080,6 +1082,8 @@
   },
   "helm": {
     "actions": {
+      "backToValues": "Back",
+      "dryRun": "Dry Run",
       "upgrade": "Upgrade",
       "rollback": "Rollback"
     },
@@ -1087,14 +1091,23 @@
       "chart": "Chart",
       "version": "Version",
       "appVersion": "App Version",
+      "publishedAt": "Published",
       "kubeVersion": "Kubernetes Version",
       "releaseName": "Release Name",
       "createNamespace": "Create namespace",
+      "dryRunPreview": "Dry run preview",
+      "ignoreLabelsAnnotationsChanges": "Ignore labels/annotations changes (diff only)",
       "forceConflicts": "force-conflicts",
       "wait": "wait",
       "rollbackOnFailure": "rollback-on-failure",
       "firstDeployed": "First Deployed",
       "lastDeployed": "Last Deployed"
+    },
+    "diff": {
+      "added": "Added",
+      "deleted": "Deleted",
+      "changed": "Changed",
+      "unchanged": "Unchanged"
     },
     "tabs": {
       "manifest": "Manifest",
@@ -1103,6 +1116,7 @@
     },
     "messages": {
       "noResources": "No resources found",
+      "noDryRunResources": "No resources rendered by dry run.",
       "noHistory": "No history found",
       "rollbackStarted": "Rollback requested",
       "rollbackConfirmTitle": "Rollback release?",
@@ -1112,6 +1126,7 @@
       "chartSourceArtifactHubVerified": "Using Artifact Hub chart from {{repository}} (verified publisher).",
       "chartSourceArtifactHubVerifiedShort": "Artifact Hub (verified)",
       "chartSourceArtifactHub": "Using Artifact Hub chart from {{repository}}.",
+      "chartDetailsLink": "Chart details",
       "chartSourceCurrentRelease": "Using the chart stored in the current release.",
       "chartSourceSelectChart": "Select a chart to use a different chart package. Defaults to the current chart.",
       "newVersionAvailable": "New {{version}}",

--- a/ui/src/i18n/locales/zh.json
+++ b/ui/src/i18n/locales/zh.json
@@ -1139,7 +1139,8 @@
       "keywords": "关键词",
       "versions": "版本",
       "defaultValues": "默认 Values",
-      "customValues": "自定义 Values"
+      "customValues": "自定义 Values",
+      "updatedAt": "更新时间"
     },
     "filters": {
       "allRepositories": "全部 Repository",
@@ -1159,6 +1160,7 @@
       "noVersions": "未找到版本",
       "noChartUrl": "缺少 Chart 包 URL。",
       "invalidValues": "Values 必须是 YAML 对象。",
+      "artifactHubTrafficNotice": "从该来源搜索或查看 Chart 信息时，Kite 会访问 <artifactHub>Artifact Hub</artifactHub>。Kite 仅展示第三方数据，不对其中内容负责。",
       "installed": "Helm Release 已安装"
     },
     "placeholders": {
@@ -1167,6 +1169,8 @@
   },
   "helm": {
     "actions": {
+      "backToValues": "上一步",
+      "dryRun": "Dry Run",
       "upgrade": "升级",
       "rollback": "回滚"
     },
@@ -1174,14 +1178,23 @@
       "chart": "Chart",
       "version": "版本",
       "appVersion": "App 版本",
+      "publishedAt": "发布日期",
       "kubeVersion": "Kubernetes 版本",
       "releaseName": "Release 名称",
       "createNamespace": "创建 Namespace",
+      "dryRunPreview": "Dry Run 预览",
+      "ignoreLabelsAnnotationsChanges": "忽略标签/注解变更（仅 Diff）",
       "forceConflicts": "force-conflicts",
       "wait": "wait",
       "rollbackOnFailure": "rollback-on-failure",
       "firstDeployed": "首次部署",
       "lastDeployed": "上次部署"
+    },
+    "diff": {
+      "added": "新增",
+      "deleted": "删除",
+      "changed": "变更",
+      "unchanged": "未变化"
     },
     "tabs": {
       "manifest": "Manifest",
@@ -1190,6 +1203,7 @@
     },
     "messages": {
       "noResources": "未找到资源",
+      "noDryRunResources": "Dry Run 没有渲染出资源。",
       "noHistory": "未找到历史记录",
       "rollbackStarted": "已发起回滚",
       "rollbackConfirmTitle": "确认回滚 Release？",
@@ -1197,8 +1211,8 @@
       "chartNotFound": "在已管理的 Helm Repository 和 Artifact Hub 中均未找到这个 Chart。",
       "chartSourceManagedRepository": "当前使用已管理的 Chart Repository：{{repository}}。",
       "chartSourceArtifactHubVerified": "当前使用 Artifact Hub Chart：{{repository}}（Verified Publisher）。",
-      "chartSourceArtifactHubVerifiedShort": "Artifact Hub（已验证）",
       "chartSourceArtifactHub": "当前使用 Artifact Hub Chart：{{repository}}。",
+      "chartDetailsLink": "Chart 详情",
       "chartSourceCurrentRelease": "当前使用 Release 中保存的 Chart。",
       "chartSourceSelectChart": "请选择要使用的 Chart 包。默认使用当前 Chart。",
       "newVersionAvailable": "新版本 {{version}}",

--- a/ui/src/lib/api/core.ts
+++ b/ui/src/lib/api/core.ts
@@ -8,6 +8,7 @@ import {
   HelmChartDetail,
   HelmChartList,
   HelmRelease,
+  HelmReleaseDryRunResponse,
   HelmReleaseHistoryResponse,
   HelmReleaseInstallRequest,
   HelmReleaseUpgradeRequest,
@@ -133,6 +134,17 @@ export const upgradeHelmRelease = async (
   )
 }
 
+export const dryRunUpgradeHelmRelease = async (
+  namespace: string,
+  name: string,
+  body?: HelmReleaseUpgradeRequest
+): Promise<HelmReleaseDryRunResponse> => {
+  return apiClient.put<HelmReleaseDryRunResponse>(
+    `/helmrelease/${encodeURIComponent(namespace)}/${encodeURIComponent(name)}/upgrade/dry-run`,
+    body || {}
+  )
+}
+
 export const rollbackHelmRelease = async (
   namespace: string,
   name: string,
@@ -150,6 +162,16 @@ export const installHelmRelease = async (
 ): Promise<HelmRelease> => {
   return apiClient.post<HelmRelease>(
     `/helmrelease/${encodeURIComponent(namespace)}`,
+    body
+  )
+}
+
+export const dryRunInstallHelmRelease = async (
+  namespace: string,
+  body: HelmReleaseInstallRequest
+): Promise<HelmReleaseDryRunResponse> => {
+  return apiClient.post<HelmReleaseDryRunResponse>(
+    `/helmrelease/${encodeURIComponent(namespace)}/dry-run`,
     body
   )
 }

--- a/ui/src/pages/helm-chart-detail-page.tsx
+++ b/ui/src/pages/helm-chart-detail-page.tsx
@@ -1,45 +1,29 @@
-import { useMemo, useState, type FormEvent, type ReactNode } from 'react'
-import * as yaml from 'js-yaml'
-import { Download, ExternalLink, Loader2 } from 'lucide-react'
+import { useMemo, useState, type ReactNode } from 'react'
+import { Download, ExternalLink } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import ReactMarkdown from 'react-markdown'
-import { Link, useNavigate, useParams, useSearchParams } from 'react-router-dom'
+import { Link, useParams, useSearchParams } from 'react-router-dom'
 import remarkGfm from 'remark-gfm'
-import { toast } from 'sonner'
 
 import type {
   HelmChartContentType,
   HelmChartDetail,
+  HelmChartTemplate,
   HelmChartVersion,
 } from '@/types/api'
-import {
-  installHelmRelease,
-  useHelmChart,
-  useHelmChartContent,
-} from '@/lib/api'
-import { cn, formatDate, translateError } from '@/lib/utils'
+import { useHelmChart, useHelmChartContent } from '@/lib/api'
+import { cn, formatDate } from '@/lib/utils'
 import { usePageTitle } from '@/hooks/use-page-title'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
-import { Checkbox } from '@/components/ui/checkbox'
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog'
-import { Input } from '@/components/ui/input'
-import { Label } from '@/components/ui/label'
 import { ResponsiveTabs } from '@/components/ui/responsive-tabs'
 import { ErrorMessage } from '@/components/error-message'
 import { HelmChartIcon } from '@/components/helm-chart-icon'
-import { NamespaceSelector } from '@/components/selector/namespace-selector'
+import { HelmInstallDialog } from '@/components/helm-install-dialog'
 import { SimpleTable } from '@/components/simple-table'
-import { SimpleYamlEditor } from '@/components/simple-yaml-editor'
 import { TextViewer } from '@/components/text-viewer'
+import { YamlFileTreeViewerNative as YamlFileTreeViewer } from '@/components/yaml-file-tree-viewer-native'
 
 const artifactHubSource = 'artifacthub'
 
@@ -245,11 +229,34 @@ function ChartTextTab({
   title,
   value,
   emptyMessage,
+  content,
+  templates,
 }: {
   title: string
   value?: string
   emptyMessage: string
+  content?: HelmChartContentType
+  templates?: HelmChartTemplate[]
 }) {
+  if (content === 'templates') {
+    if (!templates?.length) {
+      return (
+        <Card>
+          <CardContent className="pt-6 text-sm text-muted-foreground">
+            {emptyMessage}
+          </CardContent>
+        </Card>
+      )
+    }
+    return (
+      <YamlFileTreeViewer
+        files={templates}
+        title={title}
+        emptyMessage={emptyMessage}
+      />
+    )
+  }
+
   if (!value) {
     return (
       <Card>
@@ -317,6 +324,8 @@ function LazyChartTextTab({
       title={title}
       value={data?.content}
       emptyMessage={emptyMessage}
+      content={content}
+      templates={data?.templates}
     />
   )
 }
@@ -359,8 +368,8 @@ function HelmChartVersionsTable({ chart }: { chart: HelmChartDetail }) {
               cell: (value) => value as string,
             },
             {
-              header: t('common.fields.updated'),
-              accessor: (item) => item.updatedAt,
+              header: t('helm.fields.publishedAt'),
+              accessor: (item) => item.publishedAt,
               cell: (value) => (
                 <span className="text-sm text-muted-foreground tabular-nums">
                   {value ? formatDate(value as string) : '-'}
@@ -372,249 +381,6 @@ function HelmChartVersionsTable({ chart }: { chart: HelmChartDetail }) {
         />
       </CardContent>
     </Card>
-  )
-}
-
-function defaultReleaseName(name: string) {
-  return (
-    name
-      .toLowerCase()
-      .replace(/[^a-z0-9-]+/g, '-')
-      .replace(/^-+|-+$/g, '') || name
-  )
-}
-
-function InstallHelmChartDialog({
-  chart,
-  open,
-  onOpenChange,
-}: {
-  chart: HelmChartDetail
-  open: boolean
-  onOpenChange: (open: boolean) => void
-}) {
-  const { t } = useTranslation()
-  const navigate = useNavigate()
-  const [releaseName, setReleaseName] = useState(() =>
-    defaultReleaseName(chart.name)
-  )
-  const [namespace, setNamespace] = useState('default')
-  const [isNamespaceManual, setIsNamespaceManual] = useState(false)
-  const [createNamespace, setCreateNamespace] = useState(true)
-  const [valuesYaml, setValuesYaml] = useState('')
-  const [error, setError] = useState('')
-  const [isInstalling, setIsInstalling] = useState(false)
-  const defaultValuesQuery = useHelmChartContent(
-    chart.repositoryName,
-    chart.name,
-    'values',
-    chart.version,
-    chart.source,
-    open
-  )
-  const defaultValues = defaultValuesQuery.isLoading
-    ? t('common.messages.loading')
-    : defaultValuesQuery.data?.content || ''
-
-  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault()
-    setError('')
-
-    if (!chart.chartUrl) {
-      setError(
-        t('helmCharts.messages.noChartUrl', {
-          defaultValue: 'Chart package URL is missing.',
-        })
-      )
-      return
-    }
-
-    let values: Record<string, unknown> = {}
-    if (valuesYaml.trim()) {
-      try {
-        const parsed = yaml.load(valuesYaml)
-        if (parsed && (typeof parsed !== 'object' || Array.isArray(parsed))) {
-          setError(
-            t('helmCharts.messages.invalidValues', {
-              defaultValue: 'Values must be a YAML object.',
-            })
-          )
-          return
-        }
-        values = (parsed || {}) as Record<string, unknown>
-      } catch (err) {
-        setError(translateError(err, t))
-        return
-      }
-    }
-
-    const targetNamespace = namespace.trim()
-    setIsInstalling(true)
-    try {
-      const release = await installHelmRelease(targetNamespace, {
-        releaseName: releaseName.trim(),
-        namespace: targetNamespace,
-        chartUrl: chart.chartUrl,
-        repositoryName: chart.repositoryName,
-        source: chart.source,
-        createNamespace: isNamespaceManual && createNamespace,
-        values,
-      })
-      const installedNamespace = release.metadata?.namespace || targetNamespace
-      const targetName = release.metadata?.name || releaseName.trim()
-      toast.success(
-        t('helmCharts.messages.installed', {
-          defaultValue: 'Helm release installed',
-        })
-      )
-      onOpenChange(false)
-      navigate(
-        `/helmrelease/${encodeURIComponent(installedNamespace)}/${encodeURIComponent(targetName)}`
-      )
-    } catch (err) {
-      setError(translateError(err, t))
-    } finally {
-      setIsInstalling(false)
-    }
-  }
-
-  return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="flex h-[calc(100dvh-4rem)] max-h-[calc(100dvh-4rem)] w-[calc(100vw-4rem)] !max-w-[calc(100vw-4rem)] flex-col overflow-hidden">
-        <form
-          onSubmit={handleSubmit}
-          className="flex h-full min-h-0 flex-col gap-4"
-        >
-          <DialogHeader>
-            <DialogTitle>
-              {t('helmCharts.actions.install', { defaultValue: 'Install' })}
-            </DialogTitle>
-            <DialogDescription>
-              {chart.repositoryName}/{chart.name}:{chart.version}
-            </DialogDescription>
-          </DialogHeader>
-
-          <div className="min-h-0 flex-1 space-y-4 overflow-y-auto pr-1">
-            <div className="grid gap-4 md:grid-cols-2">
-              <div className="grid gap-2">
-                <Label htmlFor="helm-release-name">
-                  {t('helm.fields.releaseName')}
-                </Label>
-                <Input
-                  id="helm-release-name"
-                  value={releaseName}
-                  onChange={(event) => setReleaseName(event.target.value)}
-                  required
-                />
-              </div>
-
-              <div className="grid gap-2">
-                <Label htmlFor="helm-release-namespace">
-                  {t('common.fields.namespace', { defaultValue: 'Namespace' })}
-                </Label>
-                <div className="flex flex-wrap items-center gap-2">
-                  <NamespaceSelector
-                    selectedNamespace={namespace}
-                    handleNamespaceChange={(value) => {
-                      setNamespace(value)
-                      setIsNamespaceManual(false)
-                    }}
-                    disabled={isInstalling}
-                    triggerClassName="w-44 sm:w-44 sm:min-w-0"
-                  />
-                  <Input
-                    id="helm-release-namespace"
-                    value={namespace}
-                    onChange={(event) => {
-                      setNamespace(event.target.value)
-                      setIsNamespaceManual(true)
-                      setCreateNamespace(true)
-                    }}
-                    disabled={isInstalling}
-                    required
-                    className="w-48"
-                  />
-                </div>
-              </div>
-            </div>
-
-            <div className="grid min-h-0 gap-4 lg:grid-cols-2">
-              <div className="grid min-h-0 gap-2">
-                <Label>{t('helmCharts.fields.defaultValues')}</Label>
-                <SimpleYamlEditor
-                  value={defaultValues}
-                  onChange={() => undefined}
-                  disabled
-                  height="calc(100dvh - 20rem)"
-                />
-              </div>
-
-              <div className="grid min-h-0 gap-2">
-                <Label>{t('helmCharts.fields.customValues')}</Label>
-                <SimpleYamlEditor
-                  value={valuesYaml}
-                  onChange={(value) => setValuesYaml(value || '')}
-                  disabled={isInstalling}
-                  height="calc(100dvh - 20rem)"
-                />
-              </div>
-            </div>
-
-            {defaultValuesQuery.error ? (
-              <p className="text-sm text-destructive">
-                {translateError(defaultValuesQuery.error, t)}
-              </p>
-            ) : null}
-            {error ? <p className="text-sm text-destructive">{error}</p> : null}
-          </div>
-
-          <DialogFooter className="items-center gap-3 sm:justify-end">
-            {isNamespaceManual ? (
-              <div className="flex items-center gap-2">
-                <Checkbox
-                  id="helm-create-namespace"
-                  checked={createNamespace}
-                  onCheckedChange={(value) =>
-                    setCreateNamespace(value === true)
-                  }
-                  disabled={isInstalling}
-                />
-                <Label
-                  htmlFor="helm-create-namespace"
-                  className="text-sm font-normal"
-                >
-                  {t('helm.fields.createNamespace')}
-                </Label>
-              </div>
-            ) : null}
-            <div className="flex flex-col-reverse gap-2 sm:flex-row">
-              <Button
-                type="button"
-                variant="outline"
-                onClick={() => onOpenChange(false)}
-                disabled={isInstalling}
-              >
-                {t('common.actions.cancel')}
-              </Button>
-              <Button
-                type="submit"
-                disabled={
-                  !releaseName.trim() ||
-                  !namespace.trim() ||
-                  !chart.chartUrl ||
-                  isInstalling
-                }
-              >
-                {isInstalling ? (
-                  <Loader2 className="size-4 animate-spin" />
-                ) : null}
-                {t('helmCharts.actions.install', { defaultValue: 'Install' })}
-              </Button>
-            </div>
-          </DialogFooter>
-        </form>
-      </DialogContent>
-    </Dialog>
   )
 }
 
@@ -736,29 +502,12 @@ export function HelmChartDetailPage() {
                     {data.name}
                   </h1>
                   {data.source === artifactHubSource ? (
-                    data.artifactHubUrl ? (
-                      <a
-                        href={data.artifactHubUrl}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="shrink-0"
-                      >
-                        <Badge
-                          variant="outline"
-                          className="gap-1 font-normal text-muted-foreground"
-                        >
-                          Artifact Hub
-                          <ExternalLink className="size-3" />
-                        </Badge>
-                      </a>
-                    ) : (
-                      <Badge
-                        variant="outline"
-                        className="shrink-0 font-normal text-muted-foreground"
-                      >
-                        Artifact Hub
-                      </Badge>
-                    )
+                    <Badge
+                      variant="outline"
+                      className="shrink-0 font-normal text-muted-foreground"
+                    >
+                      Artifact Hub
+                    </Badge>
                   ) : null}
                 </div>
                 <p className="text-pretty break-words text-sm text-muted-foreground">
@@ -787,7 +536,7 @@ export function HelmChartDetailPage() {
         tabs={tabs}
       />
       {installDialogOpen ? (
-        <InstallHelmChartDialog
+        <HelmInstallDialog
           chart={data}
           open={installDialogOpen}
           onOpenChange={setInstallDialogOpen}

--- a/ui/src/pages/helm-chart-list-page.tsx
+++ b/ui/src/pages/helm-chart-list-page.tsx
@@ -1,4 +1,4 @@
-import { FormEvent, useMemo, useState } from 'react'
+import { useEffect, useMemo, useState, type SubmitEvent } from 'react'
 import { useAuth } from '@/contexts/auth-context'
 import {
   ColumnFiltersState,
@@ -20,7 +20,7 @@ import {
   Trash2,
   XCircle,
 } from 'lucide-react'
-import { useTranslation } from 'react-i18next'
+import { Trans, useTranslation } from 'react-i18next'
 import { Link } from 'react-router-dom'
 import { toast } from 'sonner'
 
@@ -72,6 +72,59 @@ const artifactHubSource = 'artifacthub'
 const repositoriesSource = 'repositories'
 const columnHelper = createColumnHelper<HelmChart>()
 type ChartSource = typeof artifactHubSource | typeof repositoriesSource
+type HelmChartListSessionState = {
+  chartSource?: ChartSource
+  verifiedPublisherOnly?: boolean
+  searchQuery?: string
+  repositoryFilter?: string
+  pagination?: PaginationState
+}
+
+const helmChartListSessionStorageKey = 'kite-helm-chart-list-state'
+const defaultPagination: PaginationState = {
+  pageIndex: 0,
+  pageSize: 20,
+}
+
+function readHelmChartListSessionState(): HelmChartListSessionState {
+  const value = sessionStorage.getItem(helmChartListSessionStorageKey)
+  if (!value) {
+    return {}
+  }
+
+  try {
+    const state = JSON.parse(value) as HelmChartListSessionState
+    const pagination = state.pagination
+
+    return {
+      chartSource:
+        state.chartSource === artifactHubSource ||
+        state.chartSource === repositoriesSource
+          ? state.chartSource
+          : undefined,
+      verifiedPublisherOnly:
+        typeof state.verifiedPublisherOnly === 'boolean'
+          ? state.verifiedPublisherOnly
+          : undefined,
+      searchQuery:
+        typeof state.searchQuery === 'string' ? state.searchQuery : undefined,
+      repositoryFilter:
+        typeof state.repositoryFilter === 'string'
+          ? state.repositoryFilter
+          : undefined,
+      pagination:
+        pagination &&
+        Number.isInteger(pagination.pageIndex) &&
+        pagination.pageIndex >= 0 &&
+        Number.isInteger(pagination.pageSize) &&
+        pagination.pageSize > 0
+          ? pagination
+          : undefined,
+    }
+  } catch {
+    return {}
+  }
+}
 
 function chartDetailPath(chart: HelmChart) {
   const path = `/charts/${encodeURIComponent(chart.repositoryName)}/${encodeURIComponent(chart.name)}`
@@ -125,7 +178,7 @@ function AddRepositoryDialog({
   const [error, setError] = useState('')
   const [isSubmitting, setIsSubmitting] = useState(false)
 
-  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+  const handleSubmit = async (event: SubmitEvent<HTMLFormElement>) => {
     event.preventDefault()
     setError('')
     setIsSubmitting(true)
@@ -226,26 +279,53 @@ function AddRepositoryDialog({
 export function HelmChartListPage() {
   const { t } = useTranslation()
   const { user } = useAuth()
-  const [chartSource, setChartSource] = useState<ChartSource>(artifactHubSource)
-  const [verifiedPublisherOnly, setVerifiedPublisherOnly] = useState(false)
-  const [searchQuery, setSearchQuery] = useState('')
-  const [repositoryFilter, setRepositoryFilter] = useState(allRepositories)
+  const [initialSessionState] = useState(readHelmChartListSessionState)
+  const [chartSource, setChartSource] = useState<ChartSource>(
+    initialSessionState.chartSource ?? artifactHubSource
+  )
+  const [verifiedPublisherOnly, setVerifiedPublisherOnly] = useState(
+    initialSessionState.verifiedPublisherOnly ?? false
+  )
+  const [searchQuery, setSearchQuery] = useState(
+    initialSessionState.searchQuery ?? ''
+  )
+  const [repositoryFilter, setRepositoryFilter] = useState(
+    initialSessionState.repositoryFilter ?? allRepositories
+  )
   const [dialogOpen, setDialogOpen] = useState(false)
   const [repositoryToDelete, setRepositoryToDelete] =
     useState<HelmRepository | null>(null)
   const [isDeletingRepository, setIsDeletingRepository] = useState(false)
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([])
   const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({})
-  const [pagination, setPagination] = useState<PaginationState>({
-    pageIndex: 0,
-    pageSize: 20,
-  })
+  const [pagination, setPagination] = useState<PaginationState>(
+    initialSessionState.pagination ?? defaultPagination
+  )
   const selectedRepository =
     repositoryFilter === allRepositories ? undefined : repositoryFilter
   const isArtifactHubSource = chartSource === artifactHubSource
   const canManageRepositories = user?.isAdmin() ?? false
 
   usePageTitle(t('nav.helmCharts'))
+
+  useEffect(() => {
+    sessionStorage.setItem(
+      helmChartListSessionStorageKey,
+      JSON.stringify({
+        chartSource,
+        verifiedPublisherOnly,
+        searchQuery,
+        repositoryFilter,
+        pagination,
+      })
+    )
+  }, [
+    chartSource,
+    verifiedPublisherOnly,
+    searchQuery,
+    repositoryFilter,
+    pagination,
+  ])
 
   const { data: repositories = [], refetch: refetchRepositories } =
     useHelmRepositories()
@@ -321,7 +401,7 @@ export function HelmChartListPage() {
         ),
       }),
       columnHelper.accessor('updatedAt', {
-        header: t('common.fields.updated'),
+        header: t('helmCharts.fields.updatedAt'),
         cell: ({ getValue }) => (
           <span className="text-sm text-muted-foreground tabular-nums">
             {getValue() ? formatDate(getValue() || '') : '-'}
@@ -607,6 +687,24 @@ export function HelmChartListPage() {
             </div>
           </div>
         </div>
+
+        {isArtifactHubSource ? (
+          <p className="text-pretty text-xs text-muted-foreground">
+            <Trans
+              i18nKey="helmCharts.messages.artifactHubTrafficNotice"
+              components={{
+                artifactHub: (
+                  <a
+                    href="https://artifacthub.io"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="app-link"
+                  />
+                ),
+              }}
+            />
+          </p>
+        ) : null}
 
         <ResourceTableView
           table={table}

--- a/ui/src/pages/helmrelease-detail.tsx
+++ b/ui/src/pages/helmrelease-detail.tsx
@@ -11,11 +11,14 @@ import type {
   HelmChart,
   HelmChartVersion,
   HelmRelease,
+  HelmReleaseDryRunResponse,
   HelmReleaseHistoryItem,
   HelmReleaseResource,
+  HelmReleaseUpgradeRequest,
   RelatedResources,
 } from '@/types/api'
 import {
+  dryRunUpgradeHelmRelease,
   rollbackHelmRelease,
   upgradeHelmRelease,
   useArtifactHubCharts,
@@ -69,10 +72,15 @@ import {
 import { PodStatusIcon } from '@/components/pod-status-icon'
 import { SimpleTable } from '@/components/simple-table'
 import { SimpleYamlEditor } from '@/components/simple-yaml-editor'
-import { TextViewer } from '@/components/text-viewer'
 import { WorkloadSummaryCard } from '@/components/workload-overview-parts'
 import { WorkloadPodsCard } from '@/components/workload-pods-card'
 import { YamlEditor } from '@/components/yaml-editor'
+import {
+  YamlFileTreeDiffViewerNative as YamlFileTreeDiffViewer,
+  YamlFileTreeViewerNative as YamlFileTreeViewer,
+  type YamlDiffTreeItem,
+  type YamlFileTreeItem,
+} from '@/components/yaml-file-tree-viewer-native'
 
 import {
   ResourceDetailShell,
@@ -269,6 +277,164 @@ function sortHelmRelatedResources(resources: RelatedResources[]) {
       `${b.namespace || ''}/${b.name}`
     )
   })
+}
+
+function toDryRunDiffFiles(
+  resources: HelmReleaseDryRunResponse['resources'],
+  options?: { ignoreMetadataChanges?: boolean }
+): YamlDiffTreeItem[] {
+  return resources.map((resource) => {
+    let originalContent = resource.originalContent || ''
+    let modifiedContent = resource.modifiedContent || ''
+    let status = resource.status || 'unchanged'
+
+    if (options?.ignoreMetadataChanges && status === 'changed') {
+      originalContent = stripYamlMetadataChanges(originalContent)
+      modifiedContent = stripYamlMetadataChanges(modifiedContent)
+      if (originalContent === modifiedContent) {
+        status = 'unchanged'
+      }
+    }
+
+    return {
+      path: resource.path,
+      originalContent,
+      modifiedContent,
+      status,
+    }
+  })
+}
+
+function stripYamlMetadataChanges(content: string) {
+  if (!content.trim()) {
+    return content
+  }
+
+  try {
+    const parsed = yaml.load(content)
+    return yaml
+      .dump(stripMetadataLabelsAndAnnotations(parsed), {
+        indent: 2,
+        lineWidth: -1,
+        noRefs: true,
+      })
+      .trim()
+  } catch {
+    return content
+  }
+}
+
+function stripMetadataLabelsAndAnnotations(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(stripMetadataLabelsAndAnnotations)
+  }
+  if (!isRecord(value)) {
+    return value
+  }
+
+  const next: Record<string, unknown> = {}
+  for (const [key, child] of Object.entries(value)) {
+    if (key === 'metadata' && isRecord(child)) {
+      const metadata = stripMetadataLabelsAndAnnotations(child)
+      if (!isRecord(metadata)) {
+        continue
+      }
+      delete metadata.labels
+      delete metadata.annotations
+      if (Object.keys(metadata).length > 0) {
+        next[key] = metadata
+      }
+      continue
+    }
+    next[key] = stripMetadataLabelsAndAnnotations(child)
+  }
+  return next
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function toManifestFiles(
+  manifest: string,
+  defaultNamespace: string,
+  resources: HelmReleaseResource[] = []
+): YamlFileTreeItem[] {
+  let resourceIndex = 0
+
+  return splitManifestDocuments(manifest).map((doc, index) => {
+    const content = trimHelmSourceComment(doc)
+    let path = `manifest-${index + 1}.yaml`
+
+    try {
+      const parsed = yaml.load(doc) as
+        | {
+            kind?: string
+            metadata?: {
+              name?: string
+              namespace?: string
+            }
+          }
+        | undefined
+
+      if (parsed?.kind && parsed.metadata?.name) {
+        const resource = resources[resourceIndex]
+        resourceIndex += 1
+        path = manifestResourcePath(
+          resource || {
+            apiVersion: '',
+            kind: parsed.kind,
+            name: parsed.metadata.name,
+            namespace: parsed.metadata.namespace || defaultNamespace,
+          },
+          index
+        )
+      }
+    } catch {
+      path = `manifest-${index + 1}.yaml`
+    }
+
+    return { path, content }
+  })
+}
+
+function splitManifestDocuments(manifest: string) {
+  const docs: string[] = []
+  let lines: string[] = []
+
+  for (const line of manifest.split('\n')) {
+    const marker = line.replace(/[ \t\r]+$/, '')
+    if (marker === '---' || marker.startsWith('--- #')) {
+      const doc = lines.join('\n').trim()
+      if (doc) {
+        docs.push(doc)
+      }
+      lines = []
+      continue
+    }
+    lines.push(line)
+  }
+
+  const doc = lines.join('\n').trim()
+  if (doc) {
+    docs.push(doc)
+  }
+  return docs
+}
+
+function trimHelmSourceComment(content: string) {
+  const lines = content.split('\n')
+  if (lines[0]?.trim().startsWith('# Source:')) {
+    return lines.slice(1).join('\n').trim()
+  }
+  return content
+}
+
+function manifestResourcePath(resource: HelmReleaseResource, index: number) {
+  const scope = resource.namespace || 'cluster'
+  const kind = resource.kind || 'Resource'
+  const name = resource.name || `manifest-${index + 1}`
+  return `${scope}/${kind}/${name}.yaml`
 }
 
 function HelmReleaseHistoryValuesDialog({
@@ -813,12 +979,16 @@ function UpgradeHelmReleaseDialog({
   const [forceConflicts, setForceConflicts] = useState(false)
   const [wait, setWait] = useState(false)
   const [rollbackOnFailure, setRollbackOnFailure] = useState(false)
+  const [ignoreMetadataChanges, setIgnoreMetadataChanges] = useState(false)
   const releaseDefaultValues = useMemo(
     () => yaml.dump(release.spec?.defaultValues || {}, { indent: 2 }),
     [release.spec?.defaultValues]
   )
   const [error, setError] = useState('')
   const [isUpgrading, setIsUpgrading] = useState(false)
+  const [isDryRunning, setIsDryRunning] = useState(false)
+  const [dryRunPreview, setDryRunPreview] =
+    useState<HelmReleaseDryRunResponse | null>(null)
   const chartsQuery = useHelmCharts({
     query: chartName,
     enabled: open && !!chartName,
@@ -1010,19 +1180,38 @@ function UpgradeHelmReleaseDialog({
       : t('helm.messages.chartSourceCurrentRelease', {
           defaultValue: 'Using the chart stored in the current release.',
         })
+  const chartDetailSearchParams = new URLSearchParams()
+  if (activeChartSource === 'artifacthub') {
+    chartDetailSearchParams.set('source', 'artifacthub')
+  }
+  if (activeVersion) {
+    chartDetailSearchParams.set('version', activeVersion)
+  }
+  const chartDetailSearch = chartDetailSearchParams.toString()
+  const chartDetailPath = activeChart
+    ? `/charts/${encodeURIComponent(activeRepository)}/${encodeURIComponent(activeChart.name)}${chartDetailSearch ? `?${chartDetailSearch}` : ''}`
+    : ''
   const defaultValues = isDefaultValuesLoading
     ? t('helm.messages.loadingValues', {
         defaultValue: 'Loading values...',
       })
     : defaultValuesQuery.data?.content || releaseDefaultValues
+  const dryRunDiffFiles = useMemo(
+    () =>
+      dryRunPreview
+        ? toDryRunDiffFiles(dryRunPreview.resources, {
+            ignoreMetadataChanges,
+          })
+        : [],
+    [dryRunPreview, ignoreMetadataChanges]
+  )
 
-  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault()
+  const buildUpgradeRequest = (): HelmReleaseUpgradeRequest | null => {
     setError('')
 
     if (!chartUrl && !canUseCurrentChart) {
       setError(t('helmCharts.messages.noChartUrl'))
-      return
+      return null
     }
 
     let values: Record<string, unknown> = {}
@@ -1031,13 +1220,56 @@ function UpgradeHelmReleaseDialog({
         const parsed = yaml.load(valuesYaml)
         if (parsed && (typeof parsed !== 'object' || Array.isArray(parsed))) {
           setError(t('helmCharts.messages.invalidValues'))
-          return
+          return null
         }
         values = (parsed || {}) as Record<string, unknown>
       } catch (err) {
         setError(translateError(err, t))
-        return
+        return null
       }
+    }
+
+    return {
+      ...(chartUrl
+        ? {
+            chartUrl,
+            repositoryName: activeChart?.repositoryName,
+            source: activeChart?.source,
+          }
+        : {}),
+      values,
+      forceConflicts,
+      wait,
+      rollbackOnFailure,
+    }
+  }
+
+  const handleDryRun = async () => {
+    const request = buildUpgradeRequest()
+    if (!request) {
+      return
+    }
+
+    setIsDryRunning(true)
+    try {
+      const preview = await dryRunUpgradeHelmRelease(
+        release.metadata.namespace,
+        release.metadata.name,
+        request
+      )
+      setDryRunPreview(preview)
+    } catch (err) {
+      const message = translateError(err, t)
+      setError(message)
+    } finally {
+      setIsDryRunning(false)
+    }
+  }
+
+  const handleUpgrade = async () => {
+    const request = buildUpgradeRequest()
+    if (!request) {
+      return
     }
 
     setIsUpgrading(true)
@@ -1045,19 +1277,7 @@ function UpgradeHelmReleaseDialog({
       await upgradeHelmRelease(
         release.metadata.namespace,
         release.metadata.name,
-        {
-          ...(chartUrl
-            ? {
-                chartUrl,
-                repositoryName: activeChart?.repositoryName,
-                source: activeChart?.source,
-              }
-            : {}),
-          values,
-          forceConflicts,
-          wait,
-          rollbackOnFailure,
-        }
+        request
       )
       onOpenChange(false)
       await onComplete()
@@ -1069,9 +1289,26 @@ function UpgradeHelmReleaseDialog({
     }
   }
 
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    if (dryRunPreview) {
+      await handleUpgrade()
+      return
+    }
+    await handleDryRun()
+  }
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="flex h-[calc(100dvh-4rem)] max-h-[calc(100dvh-4rem)] w-[calc(100vw-4rem)] !max-w-[calc(100vw-4rem)] flex-col overflow-hidden">
+      <DialogContent
+        className="flex h-[calc(100dvh-4rem)] max-h-[calc(100dvh-4rem)] w-[calc(100vw-4rem)] !max-w-[calc(100vw-4rem)] flex-col overflow-hidden"
+        onPointerDownOutside={(event) => {
+          event.preventDefault()
+        }}
+        onEscapeKeyDown={(event) => {
+          event.preventDefault()
+        }}
+      >
         <form
           onSubmit={handleSubmit}
           className="flex h-full min-h-0 flex-col gap-4"
@@ -1097,7 +1334,13 @@ function UpgradeHelmReleaseDialog({
             </div>
           ) : null}
 
-          <div className="min-h-0 flex-1 space-y-4 overflow-y-auto pr-1">
+          <div
+            className={
+              dryRunPreview
+                ? 'flex min-h-0 flex-1 flex-col gap-4 overflow-hidden pr-1'
+                : 'min-h-0 flex-1 space-y-4 overflow-y-auto pr-1'
+            }
+          >
             <div className="grid gap-4 md:grid-cols-[minmax(0,1fr)_14rem]">
               <div className="grid gap-2 md:max-w-xl">
                 <Label>{t('helm.fields.chart')}</Label>
@@ -1116,8 +1359,9 @@ function UpgradeHelmReleaseDialog({
                     onValueChange={(value) => {
                       setSelectedRepository(value)
                       setSelectedVersion('')
+                      setDryRunPreview(null)
                     }}
-                    disabled={isUpgrading}
+                    disabled={isUpgrading || isDryRunning || !!dryRunPreview}
                   >
                     <SelectTrigger className="w-full">
                       <SelectValue
@@ -1156,7 +1400,7 @@ function UpgradeHelmReleaseDialog({
                     </span>
                   </div>
                 )}
-                <p className="text-xs text-muted-foreground">
+                <p className="flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted-foreground">
                   {isChartSourceLoading ? (
                     <span className="inline-flex items-center gap-1">
                       <Loader2 className="size-3 animate-spin" />
@@ -1165,7 +1409,21 @@ function UpgradeHelmReleaseDialog({
                       })}
                     </span>
                   ) : (
-                    chartSourceLabel
+                    <>
+                      <span>{chartSourceLabel}</span>
+                      {chartDetailPath ? (
+                        <Link
+                          to={chartDetailPath}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="app-link whitespace-nowrap"
+                        >
+                          {t('helm.messages.chartDetailsLink', {
+                            defaultValue: 'Chart details',
+                          })}
+                        </Link>
+                      ) : null}
+                    </>
                   )}
                 </p>
               </div>
@@ -1175,17 +1433,24 @@ function UpgradeHelmReleaseDialog({
                 {visibleVersionOptions.length > 0 ? (
                   <Select
                     value={activeVersion}
-                    onValueChange={setSelectedVersion}
-                    disabled={isUpgrading}
+                    onValueChange={(value) => {
+                      setSelectedVersion(value)
+                      setDryRunPreview(null)
+                    }}
+                    disabled={isUpgrading || isDryRunning || !!dryRunPreview}
                   >
                     <SelectTrigger className="w-full">
                       <SelectValue />
                     </SelectTrigger>
-                    <SelectContent viewportClassName="h-auto max-h-72 overflow-y-auto">
+                    <SelectContent
+                      className="min-w-80"
+                      viewportClassName="h-auto max-h-72 overflow-y-auto"
+                    >
                       {visibleVersionOptions.map((version) => (
                         <SelectItem
                           key={version.version}
                           value={version.version}
+                          textValue={version.version}
                         >
                           <span className="tabular-nums">
                             {version.version}
@@ -1201,6 +1466,11 @@ function UpgradeHelmReleaseDialog({
                           {version.appVersion ? (
                             <span className="text-xs text-muted-foreground">
                               {version.appVersion}
+                            </span>
+                          ) : null}
+                          {version.publishedAt ? (
+                            <span className="text-xs text-muted-foreground tabular-nums">
+                              {formatDate(version.publishedAt)}
                             </span>
                           ) : null}
                         </SelectItem>
@@ -1240,37 +1510,67 @@ function UpgradeHelmReleaseDialog({
               </div>
             </div>
 
-            <div className="grid min-h-0 gap-4 lg:grid-cols-2">
-              <div className="grid min-h-0 gap-2">
-                <div className="flex items-center justify-between gap-2">
-                  <Label>{t('helmCharts.fields.defaultValues')}</Label>
-                  {isDefaultValuesLoading ? (
-                    <span className="inline-flex items-center gap-1 text-xs text-muted-foreground">
-                      <Loader2 className="size-3 animate-spin" />
-                      {t('helm.messages.loadingValues', {
-                        defaultValue: 'Loading values...',
-                      })}
-                    </span>
-                  ) : null}
+            {dryRunPreview ? (
+              <div className="flex min-h-0 flex-1 flex-col gap-2">
+                <div className="flex flex-wrap items-center justify-end gap-3 text-sm">
+                  <Label
+                    htmlFor="helm-dry-run-ignore-metadata-changes"
+                    className="flex items-center gap-2 font-normal text-muted-foreground"
+                  >
+                    <Checkbox
+                      id="helm-dry-run-ignore-metadata-changes"
+                      checked={ignoreMetadataChanges}
+                      onCheckedChange={(value) =>
+                        setIgnoreMetadataChanges(value === true)
+                      }
+                      disabled={isUpgrading || isDryRunning}
+                    />
+                    {t('helm.fields.ignoreLabelsAnnotationsChanges')}
+                  </Label>
                 </div>
-                <SimpleYamlEditor
-                  value={defaultValues}
-                  onChange={() => undefined}
-                  disabled
-                  height="calc(100dvh - 20rem)"
+                <YamlFileTreeDiffViewer
+                  files={dryRunDiffFiles}
+                  title={t('helm.fields.dryRunPreview')}
+                  emptyMessage={t('helm.messages.noDryRunResources')}
+                  fillHeight
                 />
               </div>
+            ) : (
+              <div className="grid min-h-0 gap-4 lg:grid-cols-2">
+                <div className="grid min-h-0 gap-2">
+                  <div className="flex items-center justify-between gap-2">
+                    <Label>{t('helmCharts.fields.defaultValues')}</Label>
+                    {isDefaultValuesLoading ? (
+                      <span className="inline-flex items-center gap-1 text-xs text-muted-foreground">
+                        <Loader2 className="size-3 animate-spin" />
+                        {t('helm.messages.loadingValues', {
+                          defaultValue: 'Loading values...',
+                        })}
+                      </span>
+                    ) : null}
+                  </div>
+                  <SimpleYamlEditor
+                    value={defaultValues}
+                    onChange={() => undefined}
+                    disabled
+                    height="calc(100dvh - 20rem)"
+                  />
+                </div>
 
-              <div className="grid min-h-0 gap-2">
-                <Label>{t('helmCharts.fields.customValues')}</Label>
-                <SimpleYamlEditor
-                  value={valuesYaml}
-                  onChange={(value) => setValuesYaml(value || '')}
-                  disabled={isUpgrading}
-                  height="calc(100dvh - 20rem)"
-                />
+                <div className="grid min-h-0 gap-2">
+                  <Label>{t('helmCharts.fields.customValues')}</Label>
+                  <SimpleYamlEditor
+                    value={valuesYaml}
+                    onChange={(value) => {
+                      setValuesYaml(value || '')
+                      setDryRunPreview(null)
+                    }}
+                    disabled={isUpgrading || isDryRunning}
+                    height="calc(100dvh - 20rem)"
+                  />
+                </div>
               </div>
-            </div>
+            )}
 
             {chartLookupError ? (
               <p className="text-sm text-muted-foreground">
@@ -1294,7 +1594,7 @@ function UpgradeHelmReleaseDialog({
                   id="helm-upgrade-force-conflicts"
                   checked={forceConflicts}
                   onCheckedChange={(value) => setForceConflicts(value === true)}
-                  disabled={isUpgrading}
+                  disabled={isUpgrading || isDryRunning}
                 />
                 {t('helm.fields.forceConflicts')}
               </Label>
@@ -1306,7 +1606,7 @@ function UpgradeHelmReleaseDialog({
                   id="helm-upgrade-wait"
                   checked={wait}
                   onCheckedChange={(value) => setWait(value === true)}
-                  disabled={isUpgrading}
+                  disabled={isUpgrading || isDryRunning}
                 />
                 {t('helm.fields.wait')}
               </Label>
@@ -1320,23 +1620,55 @@ function UpgradeHelmReleaseDialog({
                   onCheckedChange={(value) =>
                     setRollbackOnFailure(value === true)
                   }
-                  disabled={isUpgrading}
+                  disabled={isUpgrading || isDryRunning}
                 />
                 {t('helm.fields.rollbackOnFailure')}
               </Label>
             </div>
+            {dryRunPreview ? (
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => setDryRunPreview(null)}
+                disabled={isUpgrading || isDryRunning}
+              >
+                {t('helm.actions.backToValues')}
+              </Button>
+            ) : (
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => onOpenChange(false)}
+                disabled={isUpgrading || isDryRunning}
+              >
+                {t('common.actions.cancel')}
+              </Button>
+            )}
+            {!dryRunPreview ? (
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => void handleDryRun()}
+                disabled={
+                  isUpgrading ||
+                  isDryRunning ||
+                  !activeVersion ||
+                  isChartPackageLoading ||
+                  (!chartUrl && !canUseCurrentChart)
+                }
+              >
+                {isDryRunning ? (
+                  <Loader2 className="size-4 animate-spin" />
+                ) : null}
+                {t('helm.actions.dryRun')}
+              </Button>
+            ) : null}
             <Button
               type="button"
-              variant="outline"
-              onClick={() => onOpenChange(false)}
-              disabled={isUpgrading}
-            >
-              {t('common.actions.cancel')}
-            </Button>
-            <Button
-              type="submit"
+              onClick={() => void handleUpgrade()}
               disabled={
                 isUpgrading ||
+                isDryRunning ||
                 !activeVersion ||
                 isChartPackageLoading ||
                 (!chartUrl && !canUseCurrentChart)
@@ -1401,6 +1733,20 @@ export function HelmReleaseDetail(props: { namespace: string; name: string }) {
     }
     return items
   }, [releasePods])
+  const manifestFiles = useMemo(
+    () =>
+      toManifestFiles(
+        data?.spec?.manifest || '',
+        data?.spec?.namespace || namespace,
+        data?.status?.resources
+      ),
+    [
+      data?.spec?.manifest,
+      data?.spec?.namespace,
+      data?.status?.resources,
+      namespace,
+    ]
+  )
 
   const tabs = useMemo<ResourceDetailShellTab<HelmRelease>[]>(
     () => [
@@ -1450,9 +1796,10 @@ export function HelmReleaseDetail(props: { namespace: string; name: string }) {
         value: 'manifest',
         label: t('helm.tabs.manifest'),
         content: data ? (
-          <TextViewer
-            value={data.spec?.manifest || ''}
+          <YamlFileTreeViewer
+            files={manifestFiles}
             title={t('helm.tabs.manifest')}
+            emptyMessage={t('helm.messages.noResources')}
           />
         ) : null,
       },
@@ -1462,6 +1809,7 @@ export function HelmReleaseDetail(props: { namespace: string; name: string }) {
       data,
       initContainers,
       labelSelector,
+      manifestFiles,
       name,
       namespace,
       refetch,

--- a/ui/src/types/api.ts
+++ b/ui/src/types/api.ts
@@ -205,7 +205,7 @@ export interface HelmChart {
 export interface HelmChartVersion {
   version: string
   appVersion?: string
-  updatedAt?: string
+  publishedAt?: string
 }
 
 export interface HelmChartList {
@@ -215,8 +215,14 @@ export interface HelmChartList {
 
 export type HelmChartContentType = 'values' | 'templates'
 
+export interface HelmChartTemplate {
+  path: string
+  content: string
+}
+
 export interface HelmChartContent {
   content?: string
+  templates?: HelmChartTemplate[]
 }
 
 export interface HelmChartDetail extends HelmChart {
@@ -245,6 +251,22 @@ export interface HelmReleaseUpgradeRequest {
   forceConflicts?: boolean
   wait?: boolean
   rollbackOnFailure?: boolean
+}
+
+export interface HelmReleaseDryRunResource {
+  path: string
+  content: string
+  originalContent?: string
+  modifiedContent?: string
+  status?: 'added' | 'deleted' | 'changed' | 'unchanged'
+  apiVersion?: string
+  kind?: string
+  name?: string
+  namespace?: string
+}
+
+export interface HelmReleaseDryRunResponse {
+  resources: HelmReleaseDryRunResource[]
 }
 
 type listMetadataType = {

--- a/ui/tsconfig.app.json
+++ b/ui/tsconfig.app.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     },
@@ -8,6 +7,7 @@
     "target": "ES2020",
     "useDefineForClassFields": true,
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "types": ["node"],
     "module": "ESNext",
     "skipLibCheck": true,
 

--- a/ui/tsconfig.json
+++ b/ui/tsconfig.json
@@ -5,7 +5,6 @@
     { "path": "./tsconfig.node.json" }
   ],
   "compilerOptions": {
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     }


### PR DESCRIPTION
## Summary
- Add Helm install and upgrade dry-run preview APIs and UI flows.
- Show rendered Helm manifests/templates as navigable YAML file trees.
- Record Helm release action history and improve chart/repository caching and version metadata.

## Validation
- Pre-commit hook ran formatting, go vet, golangci-lint, and frontend lint successfully.