### PR TITLE
Fix resource API version fallback

### DIFF
--- a/pkg/handlers/resources/handler.go
+++ b/pkg/handlers/resources/handler.go
@@ -9,8 +9,10 @@ import (
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	apiserverinternalv1alpha1 "k8s.io/api/apiserverinternal/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	batchv1 "k8s.io/api/batch/v1"
+	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	certificatesv1 "k8s.io/api/certificates/v1"
 	certificatesv1alpha1 "k8s.io/api/certificates/v1alpha1"
 	certificatesv1beta1 "k8s.io/api/certificates/v1beta1"
@@ -18,16 +20,24 @@ import (
 	coordinationv1alpha2 "k8s.io/api/coordination/v1alpha2"
 	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
+	discoveryv1beta1 "k8s.io/api/discovery/v1beta1"
+	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
 	flowcontrolv1 "k8s.io/api/flowcontrol/v1"
+	flowcontrolv1beta1 "k8s.io/api/flowcontrol/v1beta1"
+	flowcontrolv1beta2 "k8s.io/api/flowcontrol/v1beta2"
+	flowcontrolv1beta3 "k8s.io/api/flowcontrol/v1beta3"
 	networkingv1 "k8s.io/api/networking/v1"
+	networkingv1beta1 "k8s.io/api/networking/v1beta1"
 	nodev1 "k8s.io/api/node/v1"
 	policyv1 "k8s.io/api/policy/v1"
+	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	resourcev1 "k8s.io/api/resource/v1"
 	resourcev1alpha3 "k8s.io/api/resource/v1alpha3"
 	schedulingv1 "k8s.io/api/scheduling/v1"
 	schedulingv1alpha2 "k8s.io/api/scheduling/v1alpha2"
 	storagev1 "k8s.io/api/storage/v1"
+	storagev1beta1 "k8s.io/api/storage/v1beta1"
 	storagemigrationv1beta1 "k8s.io/api/storagemigration/v1beta1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -65,58 +75,87 @@ var handlers = map[string]resourceHandler{}
 
 func RegisterRoutes(group *gin.RouterGroup) {
 	handlers = map[string]resourceHandler{
-		string(common.Pods):                              NewPodHandler(),
-		string(common.Namespaces):                        NewGenericResourceHandler[*corev1.Namespace, *corev1.NamespaceList](common.Namespaces),
-		string(common.Nodes):                             NewNodeHandler(),
-		string(common.Services):                          NewGenericResourceHandler[*corev1.Service, *corev1.ServiceList](common.Services),
-		string(common.Endpoints):                         NewGenericResourceHandler[*corev1.Endpoints, *corev1.EndpointsList](common.Endpoints),
-		string(common.EndpointSlices):                    NewGenericResourceHandler[*discoveryv1.EndpointSlice, *discoveryv1.EndpointSliceList](common.EndpointSlices),
-		string(common.PodTemplates):                      NewGenericResourceHandler[*corev1.PodTemplate, *corev1.PodTemplateList](common.PodTemplates),
-		string(common.ReplicationControllers):            NewGenericResourceHandler[*corev1.ReplicationController, *corev1.ReplicationControllerList](common.ReplicationControllers),
-		string(common.LimitRanges):                       NewGenericResourceHandler[*corev1.LimitRange, *corev1.LimitRangeList](common.LimitRanges),
-		string(common.ResourceQuotas):                    NewGenericResourceHandler[*corev1.ResourceQuota, *corev1.ResourceQuotaList](common.ResourceQuotas),
-		string(common.ComponentStatuses):                 NewGenericResourceHandler[*corev1.ComponentStatus, *corev1.ComponentStatusList](common.ComponentStatuses),
-		string(common.ConfigMaps):                        NewGenericResourceHandler[*corev1.ConfigMap, *corev1.ConfigMapList](common.ConfigMaps),
-		string(common.Secrets):                           NewGenericResourceHandler[*corev1.Secret, *corev1.SecretList](common.Secrets),
-		string(common.PersistentVolumes):                 NewGenericResourceHandler[*corev1.PersistentVolume, *corev1.PersistentVolumeList](common.PersistentVolumes),
-		string(common.PersistentVolumeClaims):            NewGenericResourceHandler[*corev1.PersistentVolumeClaim, *corev1.PersistentVolumeClaimList](common.PersistentVolumeClaims),
-		string(common.ServiceAccounts):                   NewGenericResourceHandler[*corev1.ServiceAccount, *corev1.ServiceAccountList](common.ServiceAccounts),
-		string(common.CRDs):                              NewGenericResourceHandler[*apiextensionsv1.CustomResourceDefinition, *apiextensionsv1.CustomResourceDefinitionList](common.CRDs),
-		string(common.Events):                            NewEventHandler(),
-		string(common.Deployments):                       NewDeploymentHandler(),
-		string(common.ReplicaSets):                       NewGenericResourceHandler[*appsv1.ReplicaSet, *appsv1.ReplicaSetList](common.ReplicaSets),
-		string(common.ControllerRevisions):               NewGenericResourceHandler[*appsv1.ControllerRevision, *appsv1.ControllerRevisionList](common.ControllerRevisions),
-		string(common.StatefulSets):                      NewGenericResourceHandler[*appsv1.StatefulSet, *appsv1.StatefulSetList](common.StatefulSets),
-		string(common.DaemonSets):                        NewGenericResourceHandler[*appsv1.DaemonSet, *appsv1.DaemonSetList](common.DaemonSets),
-		string(common.PodDisruptionBudgets):              NewGenericResourceHandler[*policyv1.PodDisruptionBudget, *policyv1.PodDisruptionBudgetList](common.PodDisruptionBudgets),
-		string(common.Jobs):                              NewGenericResourceHandler[*batchv1.Job, *batchv1.JobList](common.Jobs),
-		string(common.CronJobs):                          NewGenericResourceHandler[*batchv1.CronJob, *batchv1.CronJobList](common.CronJobs),
-		string(common.Ingresses):                         NewGenericResourceHandler[*networkingv1.Ingress, *networkingv1.IngressList](common.Ingresses),
-		string(common.NetworkPolicies):                   NewGenericResourceHandler[*networkingv1.NetworkPolicy, *networkingv1.NetworkPolicyList](common.NetworkPolicies),
-		string(common.IngressClasses):                    NewGenericResourceHandler[*networkingv1.IngressClass, *networkingv1.IngressClassList](common.IngressClasses),
-		string(common.IPAddresses):                       NewGenericResourceHandler[*networkingv1.IPAddress, *networkingv1.IPAddressList](common.IPAddresses),
-		string(common.ServiceCIDRs):                      NewGenericResourceHandler[*networkingv1.ServiceCIDR, *networkingv1.ServiceCIDRList](common.ServiceCIDRs),
-		string(common.StorageClasses):                    NewGenericResourceHandler[*storagev1.StorageClass, *storagev1.StorageClassList](common.StorageClasses),
-		string(common.VolumeAttachments):                 NewGenericResourceHandler[*storagev1.VolumeAttachment, *storagev1.VolumeAttachmentList](common.VolumeAttachments),
-		string(common.CSIDrivers):                        NewGenericResourceHandler[*storagev1.CSIDriver, *storagev1.CSIDriverList](common.CSIDrivers),
-		string(common.CSINodes):                          NewGenericResourceHandler[*storagev1.CSINode, *storagev1.CSINodeList](common.CSINodes),
-		string(common.CSIStorageCapacities):              NewGenericResourceHandler[*storagev1.CSIStorageCapacity, *storagev1.CSIStorageCapacityList](common.CSIStorageCapacities),
-		string(common.VolumeAttributesClasses):           NewGenericResourceHandler[*storagev1.VolumeAttributesClass, *storagev1.VolumeAttributesClassList](common.VolumeAttributesClasses),
-		string(common.Roles):                             NewGenericResourceHandler[*rbacv1.Role, *rbacv1.RoleList](common.Roles),
-		string(common.RoleBindings):                      NewGenericResourceHandler[*rbacv1.RoleBinding, *rbacv1.RoleBindingList](common.RoleBindings),
-		string(common.ClusterRoles):                      NewGenericResourceHandler[*rbacv1.ClusterRole, *rbacv1.ClusterRoleList](common.ClusterRoles),
-		string(common.ClusterRoleBindings):               NewGenericResourceHandler[*rbacv1.ClusterRoleBinding, *rbacv1.ClusterRoleBindingList](common.ClusterRoleBindings),
-		string(common.CertificateSigningRequests):        NewGenericResourceHandler[*certificatesv1.CertificateSigningRequest, *certificatesv1.CertificateSigningRequestList](common.CertificateSigningRequests),
-		string(common.ClusterTrustBundles):               NewGenericResourceHandler[*certificatesv1alpha1.ClusterTrustBundle, *certificatesv1alpha1.ClusterTrustBundleList](common.ClusterTrustBundles),
-		string(common.PodCertificateRequests):            NewGenericResourceHandler[*certificatesv1beta1.PodCertificateRequest, *certificatesv1beta1.PodCertificateRequestList](common.PodCertificateRequests),
-		string(common.Leases):                            NewGenericResourceHandler[*coordinationv1.Lease, *coordinationv1.LeaseList](common.Leases),
-		string(common.LeaseCandidates):                   NewGenericResourceHandler[*coordinationv1alpha2.LeaseCandidate, *coordinationv1alpha2.LeaseCandidateList](common.LeaseCandidates),
-		string(common.RuntimeClasses):                    NewGenericResourceHandler[*nodev1.RuntimeClass, *nodev1.RuntimeClassList](common.RuntimeClasses),
-		string(common.PriorityClasses):                   NewGenericResourceHandler[*schedulingv1.PriorityClass, *schedulingv1.PriorityClassList](common.PriorityClasses),
-		string(common.Workloads):                         NewGenericResourceHandler[*schedulingv1alpha2.Workload, *schedulingv1alpha2.WorkloadList](common.Workloads),
-		string(common.PodGroups):                         NewGenericResourceHandler[*schedulingv1alpha2.PodGroup, *schedulingv1alpha2.PodGroupList](common.PodGroups),
-		string(common.FlowSchemas):                       NewGenericResourceHandler[*flowcontrolv1.FlowSchema, *flowcontrolv1.FlowSchemaList](common.FlowSchemas),
-		string(common.PriorityLevelConfigurations):       NewGenericResourceHandler[*flowcontrolv1.PriorityLevelConfiguration, *flowcontrolv1.PriorityLevelConfigurationList](common.PriorityLevelConfigurations),
+		string(common.Pods):       NewPodHandler(),
+		string(common.Namespaces): NewGenericResourceHandler[*corev1.Namespace, *corev1.NamespaceList](common.Namespaces),
+		string(common.Nodes):      NewNodeHandler(),
+		string(common.Services):   NewGenericResourceHandler[*corev1.Service, *corev1.ServiceList](common.Services),
+		string(common.Endpoints):  NewGenericResourceHandler[*corev1.Endpoints, *corev1.EndpointsList](common.Endpoints),
+		string(common.EndpointSlices): newVersionedResourceHandler(
+			newResourceVersionCandidate("discovery.k8s.io/v1", string(common.EndpointSlices), NewGenericResourceHandler[*discoveryv1.EndpointSlice, *discoveryv1.EndpointSliceList](common.EndpointSlices)),
+			newResourceVersionCandidate("discovery.k8s.io/v1beta1", string(common.EndpointSlices), NewGenericResourceHandler[*discoveryv1beta1.EndpointSlice, *discoveryv1beta1.EndpointSliceList](common.EndpointSlices)),
+		),
+		string(common.PodTemplates):           NewGenericResourceHandler[*corev1.PodTemplate, *corev1.PodTemplateList](common.PodTemplates),
+		string(common.ReplicationControllers): NewGenericResourceHandler[*corev1.ReplicationController, *corev1.ReplicationControllerList](common.ReplicationControllers),
+		string(common.LimitRanges):            NewGenericResourceHandler[*corev1.LimitRange, *corev1.LimitRangeList](common.LimitRanges),
+		string(common.ResourceQuotas):         NewGenericResourceHandler[*corev1.ResourceQuota, *corev1.ResourceQuotaList](common.ResourceQuotas),
+		string(common.ComponentStatuses):      NewGenericResourceHandler[*corev1.ComponentStatus, *corev1.ComponentStatusList](common.ComponentStatuses),
+		string(common.ConfigMaps):             NewGenericResourceHandler[*corev1.ConfigMap, *corev1.ConfigMapList](common.ConfigMaps),
+		string(common.Secrets):                NewGenericResourceHandler[*corev1.Secret, *corev1.SecretList](common.Secrets),
+		string(common.PersistentVolumes):      NewGenericResourceHandler[*corev1.PersistentVolume, *corev1.PersistentVolumeList](common.PersistentVolumes),
+		string(common.PersistentVolumeClaims): NewGenericResourceHandler[*corev1.PersistentVolumeClaim, *corev1.PersistentVolumeClaimList](common.PersistentVolumeClaims),
+		string(common.ServiceAccounts):        NewGenericResourceHandler[*corev1.ServiceAccount, *corev1.ServiceAccountList](common.ServiceAccounts),
+		string(common.CRDs):                   NewGenericResourceHandler[*apiextensionsv1.CustomResourceDefinition, *apiextensionsv1.CustomResourceDefinitionList](common.CRDs),
+		string(common.Events):                 NewEventHandler(),
+		string(common.Deployments):            NewDeploymentHandler(),
+		string(common.ReplicaSets):            NewGenericResourceHandler[*appsv1.ReplicaSet, *appsv1.ReplicaSetList](common.ReplicaSets),
+		string(common.ControllerRevisions):    NewGenericResourceHandler[*appsv1.ControllerRevision, *appsv1.ControllerRevisionList](common.ControllerRevisions),
+		string(common.StatefulSets):           NewGenericResourceHandler[*appsv1.StatefulSet, *appsv1.StatefulSetList](common.StatefulSets),
+		string(common.DaemonSets):             NewGenericResourceHandler[*appsv1.DaemonSet, *appsv1.DaemonSetList](common.DaemonSets),
+		string(common.PodDisruptionBudgets): newVersionedResourceHandler(
+			newResourceVersionCandidate("policy/v1", string(common.PodDisruptionBudgets), NewGenericResourceHandler[*policyv1.PodDisruptionBudget, *policyv1.PodDisruptionBudgetList](common.PodDisruptionBudgets)),
+			newResourceVersionCandidate("policy/v1beta1", string(common.PodDisruptionBudgets), NewGenericResourceHandler[*policyv1beta1.PodDisruptionBudget, *policyv1beta1.PodDisruptionBudgetList](common.PodDisruptionBudgets)),
+		),
+		string(common.Jobs): NewGenericResourceHandler[*batchv1.Job, *batchv1.JobList](common.Jobs),
+		string(common.CronJobs): newVersionedResourceHandler(
+			newResourceVersionCandidate("batch/v1", string(common.CronJobs), NewGenericResourceHandler[*batchv1.CronJob, *batchv1.CronJobList](common.CronJobs)),
+			newResourceVersionCandidate("batch/v1beta1", string(common.CronJobs), NewGenericResourceHandler[*batchv1beta1.CronJob, *batchv1beta1.CronJobList](common.CronJobs)),
+		),
+		string(common.Ingresses): newVersionedResourceHandler(
+			newResourceVersionCandidate("networking.k8s.io/v1", string(common.Ingresses), NewGenericResourceHandler[*networkingv1.Ingress, *networkingv1.IngressList](common.Ingresses)),
+			newResourceVersionCandidate("networking.k8s.io/v1beta1", string(common.Ingresses), NewGenericResourceHandler[*networkingv1beta1.Ingress, *networkingv1beta1.IngressList](common.Ingresses)),
+			newResourceVersionCandidate("extensions/v1beta1", string(common.Ingresses), NewGenericResourceHandler[*extensionsv1beta1.Ingress, *extensionsv1beta1.IngressList](common.Ingresses)),
+		),
+		string(common.NetworkPolicies): NewGenericResourceHandler[*networkingv1.NetworkPolicy, *networkingv1.NetworkPolicyList](common.NetworkPolicies),
+		string(common.IngressClasses): newVersionedResourceHandler(
+			newResourceVersionCandidate("networking.k8s.io/v1", string(common.IngressClasses), NewGenericResourceHandler[*networkingv1.IngressClass, *networkingv1.IngressClassList](common.IngressClasses)),
+			newResourceVersionCandidate("networking.k8s.io/v1beta1", string(common.IngressClasses), NewGenericResourceHandler[*networkingv1beta1.IngressClass, *networkingv1beta1.IngressClassList](common.IngressClasses)),
+		),
+		string(common.IPAddresses):       NewGenericResourceHandler[*networkingv1.IPAddress, *networkingv1.IPAddressList](common.IPAddresses),
+		string(common.ServiceCIDRs):      NewGenericResourceHandler[*networkingv1.ServiceCIDR, *networkingv1.ServiceCIDRList](common.ServiceCIDRs),
+		string(common.StorageClasses):    NewGenericResourceHandler[*storagev1.StorageClass, *storagev1.StorageClassList](common.StorageClasses),
+		string(common.VolumeAttachments): NewGenericResourceHandler[*storagev1.VolumeAttachment, *storagev1.VolumeAttachmentList](common.VolumeAttachments),
+		string(common.CSIDrivers):        NewGenericResourceHandler[*storagev1.CSIDriver, *storagev1.CSIDriverList](common.CSIDrivers),
+		string(common.CSINodes):          NewGenericResourceHandler[*storagev1.CSINode, *storagev1.CSINodeList](common.CSINodes),
+		string(common.CSIStorageCapacities): newVersionedResourceHandler(
+			newResourceVersionCandidate("storage.k8s.io/v1", string(common.CSIStorageCapacities), NewGenericResourceHandler[*storagev1.CSIStorageCapacity, *storagev1.CSIStorageCapacityList](common.CSIStorageCapacities)),
+			newResourceVersionCandidate("storage.k8s.io/v1beta1", string(common.CSIStorageCapacities), NewGenericResourceHandler[*storagev1beta1.CSIStorageCapacity, *storagev1beta1.CSIStorageCapacityList](common.CSIStorageCapacities)),
+		),
+		string(common.VolumeAttributesClasses):    NewGenericResourceHandler[*storagev1.VolumeAttributesClass, *storagev1.VolumeAttributesClassList](common.VolumeAttributesClasses),
+		string(common.Roles):                      NewGenericResourceHandler[*rbacv1.Role, *rbacv1.RoleList](common.Roles),
+		string(common.RoleBindings):               NewGenericResourceHandler[*rbacv1.RoleBinding, *rbacv1.RoleBindingList](common.RoleBindings),
+		string(common.ClusterRoles):               NewGenericResourceHandler[*rbacv1.ClusterRole, *rbacv1.ClusterRoleList](common.ClusterRoles),
+		string(common.ClusterRoleBindings):        NewGenericResourceHandler[*rbacv1.ClusterRoleBinding, *rbacv1.ClusterRoleBindingList](common.ClusterRoleBindings),
+		string(common.CertificateSigningRequests): NewGenericResourceHandler[*certificatesv1.CertificateSigningRequest, *certificatesv1.CertificateSigningRequestList](common.CertificateSigningRequests),
+		string(common.ClusterTrustBundles):        NewGenericResourceHandler[*certificatesv1alpha1.ClusterTrustBundle, *certificatesv1alpha1.ClusterTrustBundleList](common.ClusterTrustBundles),
+		string(common.PodCertificateRequests):     NewGenericResourceHandler[*certificatesv1beta1.PodCertificateRequest, *certificatesv1beta1.PodCertificateRequestList](common.PodCertificateRequests),
+		string(common.Leases):                     NewGenericResourceHandler[*coordinationv1.Lease, *coordinationv1.LeaseList](common.Leases),
+		string(common.LeaseCandidates):            NewGenericResourceHandler[*coordinationv1alpha2.LeaseCandidate, *coordinationv1alpha2.LeaseCandidateList](common.LeaseCandidates),
+		string(common.RuntimeClasses):             NewGenericResourceHandler[*nodev1.RuntimeClass, *nodev1.RuntimeClassList](common.RuntimeClasses),
+		string(common.PriorityClasses):            NewGenericResourceHandler[*schedulingv1.PriorityClass, *schedulingv1.PriorityClassList](common.PriorityClasses),
+		string(common.Workloads):                  NewGenericResourceHandler[*schedulingv1alpha2.Workload, *schedulingv1alpha2.WorkloadList](common.Workloads),
+		string(common.PodGroups):                  NewGenericResourceHandler[*schedulingv1alpha2.PodGroup, *schedulingv1alpha2.PodGroupList](common.PodGroups),
+		string(common.FlowSchemas): newVersionedResourceHandler(
+			newResourceVersionCandidate("flowcontrol.apiserver.k8s.io/v1", string(common.FlowSchemas), NewGenericResourceHandler[*flowcontrolv1.FlowSchema, *flowcontrolv1.FlowSchemaList](common.FlowSchemas)),
+			newResourceVersionCandidate("flowcontrol.apiserver.k8s.io/v1beta3", string(common.FlowSchemas), NewGenericResourceHandler[*flowcontrolv1beta3.FlowSchema, *flowcontrolv1beta3.FlowSchemaList](common.FlowSchemas)),
+			newResourceVersionCandidate("flowcontrol.apiserver.k8s.io/v1beta2", string(common.FlowSchemas), NewGenericResourceHandler[*flowcontrolv1beta2.FlowSchema, *flowcontrolv1beta2.FlowSchemaList](common.FlowSchemas)),
+			newResourceVersionCandidate("flowcontrol.apiserver.k8s.io/v1beta1", string(common.FlowSchemas), NewGenericResourceHandler[*flowcontrolv1beta1.FlowSchema, *flowcontrolv1beta1.FlowSchemaList](common.FlowSchemas)),
+		),
+		string(common.PriorityLevelConfigurations): newVersionedResourceHandler(
+			newResourceVersionCandidate("flowcontrol.apiserver.k8s.io/v1", string(common.PriorityLevelConfigurations), NewGenericResourceHandler[*flowcontrolv1.PriorityLevelConfiguration, *flowcontrolv1.PriorityLevelConfigurationList](common.PriorityLevelConfigurations)),
+			newResourceVersionCandidate("flowcontrol.apiserver.k8s.io/v1beta3", string(common.PriorityLevelConfigurations), NewGenericResourceHandler[*flowcontrolv1beta3.PriorityLevelConfiguration, *flowcontrolv1beta3.PriorityLevelConfigurationList](common.PriorityLevelConfigurations)),
+			newResourceVersionCandidate("flowcontrol.apiserver.k8s.io/v1beta2", string(common.PriorityLevelConfigurations), NewGenericResourceHandler[*flowcontrolv1beta2.PriorityLevelConfiguration, *flowcontrolv1beta2.PriorityLevelConfigurationList](common.PriorityLevelConfigurations)),
+			newResourceVersionCandidate("flowcontrol.apiserver.k8s.io/v1beta1", string(common.PriorityLevelConfigurations), NewGenericResourceHandler[*flowcontrolv1beta1.PriorityLevelConfiguration, *flowcontrolv1beta1.PriorityLevelConfigurationList](common.PriorityLevelConfigurations)),
+		),
 		string(common.ValidatingAdmissionPolicies):       NewGenericResourceHandler[*admissionregistrationv1.ValidatingAdmissionPolicy, *admissionregistrationv1.ValidatingAdmissionPolicyList](common.ValidatingAdmissionPolicies),
 		string(common.ValidatingAdmissionPolicyBindings): NewGenericResourceHandler[*admissionregistrationv1.ValidatingAdmissionPolicyBinding, *admissionregistrationv1.ValidatingAdmissionPolicyBindingList](common.ValidatingAdmissionPolicyBindings),
 		string(common.ValidatingWebhookConfigurations):   NewGenericResourceHandler[*admissionregistrationv1.ValidatingWebhookConfiguration, *admissionregistrationv1.ValidatingWebhookConfigurationList](common.ValidatingWebhookConfigurations),
@@ -135,8 +174,11 @@ func RegisterRoutes(group *gin.RouterGroup) {
 		string(common.NodeMetrics):                       NewGenericResourceHandler[*metricsv1.NodeMetrics, *metricsv1.NodeMetricsList](common.NodeMetrics),
 		string(common.Gateways):                          NewGenericResourceHandler[*gatewayapiv1.Gateway, *gatewayapiv1.GatewayList](common.Gateways),
 		string(common.HTTPRoutes):                        NewGenericResourceHandler[*gatewayapiv1.HTTPRoute, *gatewayapiv1.HTTPRouteList](common.HTTPRoutes),
-		string(common.HorizontalPodAutoscalers):          NewGenericResourceHandler[*autoscalingv2.HorizontalPodAutoscaler, *autoscalingv2.HorizontalPodAutoscalerList](common.HorizontalPodAutoscalers),
-		string(common.HelmReleases):                      NewHelmReleaseHandler(),
+		string(common.HorizontalPodAutoscalers): newVersionedResourceHandler(
+			newResourceVersionCandidate("autoscaling/v2", string(common.HorizontalPodAutoscalers), NewGenericResourceHandler[*autoscalingv2.HorizontalPodAutoscaler, *autoscalingv2.HorizontalPodAutoscalerList](common.HorizontalPodAutoscalers)),
+			newResourceVersionCandidate("autoscaling/v1", string(common.HorizontalPodAutoscalers), NewGenericResourceHandler[*autoscalingv1.HorizontalPodAutoscaler, *autoscalingv1.HorizontalPodAutoscalerList](common.HorizontalPodAutoscalers)),
+		),
+		string(common.HelmReleases): NewHelmReleaseHandler(),
 	}
 
 	for name, handler := range handlers {

--- a/pkg/handlers/resources/related_resources.go
+++ b/pkg/handlers/resources/related_resources.go
@@ -12,10 +12,12 @@ import (
 	"github.com/zxh326/kite/pkg/kube"
 	"golang.org/x/sync/errgroup"
 	appsv1 "k8s.io/api/apps/v1"
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/networking/v1"
 	policyv1 "k8s.io/api/policy/v1"
+	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -298,37 +300,72 @@ func discoverPodsByPodDisruptionBudget(ctx context.Context, k8sClient *kube.K8sC
 	return relatedPods, nil
 }
 
+func discoverPodsByPodDisruptionBudgetV1Beta1(ctx context.Context, k8sClient *kube.K8sClient, namespace string, selector *metav1.LabelSelector) ([]common.RelatedResource, error) {
+	if selector == nil || isEmptyLabelSelector(selector) {
+		return []common.RelatedResource{}, nil
+	}
+	return discoverPodsByPodDisruptionBudget(ctx, k8sClient, namespace, selector)
+}
+
 func discoverPodDisruptionBudgetsByPod(ctx context.Context, k8sClient *kube.K8sClient, namespace string, podLabels map[string]string) ([]common.RelatedResource, error) {
 	if len(podLabels) == 0 {
 		return []common.RelatedResource{}, nil
 	}
 
 	var pdbList policyv1.PodDisruptionBudgetList
-	if err := k8sClient.List(ctx, &pdbList, client.InNamespace(namespace)); err != nil {
+	if err := k8sClient.List(ctx, &pdbList, client.InNamespace(namespace)); err == nil {
+		return matchingPodDisruptionBudgetsByPod(pdbList.Items, podLabels), nil
+	}
+
+	var betaPDBList policyv1beta1.PodDisruptionBudgetList
+	if err := k8sClient.List(ctx, &betaPDBList, client.InNamespace(namespace)); err != nil {
 		return nil, err
 	}
 
+	return matchingBetaPodDisruptionBudgetsByPod(betaPDBList.Items, podLabels), nil
+}
+
+func matchingPodDisruptionBudgetsByPod(items []policyv1.PodDisruptionBudget, podLabels map[string]string) []common.RelatedResource {
 	relatedPDBs := make([]common.RelatedResource, 0)
-	for _, pdb := range pdbList.Items {
-		if pdb.Spec.Selector == nil {
-			continue
-		}
-
-		selector, err := metav1.LabelSelectorAsSelector(pdb.Spec.Selector)
-		if err != nil {
-			continue
-		}
-
-		if selector.Matches(labels.Set(podLabels)) {
-			relatedPDBs = append(relatedPDBs, common.RelatedResource{
-				Type:      "poddisruptionbudgets",
-				Namespace: pdb.Namespace,
-				Name:      pdb.Name,
-			})
-		}
+	for _, pdb := range items {
+		relatedPDBs = appendMatchingPodDisruptionBudget(relatedPDBs, pdb.Namespace, pdb.Name, pdb.Spec.Selector, podLabels, false)
 	}
 
-	return relatedPDBs, nil
+	return relatedPDBs
+}
+
+func matchingBetaPodDisruptionBudgetsByPod(items []policyv1beta1.PodDisruptionBudget, podLabels map[string]string) []common.RelatedResource {
+	relatedPDBs := make([]common.RelatedResource, 0)
+	for _, pdb := range items {
+		relatedPDBs = appendMatchingPodDisruptionBudget(relatedPDBs, pdb.Namespace, pdb.Name, pdb.Spec.Selector, podLabels, true)
+	}
+
+	return relatedPDBs
+}
+
+func appendMatchingPodDisruptionBudget(relatedPDBs []common.RelatedResource, namespace, name string, selector *metav1.LabelSelector, podLabels map[string]string, beta bool) []common.RelatedResource {
+	if selector == nil || beta && isEmptyLabelSelector(selector) {
+		return relatedPDBs
+	}
+
+	labelSelector, err := metav1.LabelSelectorAsSelector(selector)
+	if err != nil {
+		return relatedPDBs
+	}
+
+	if !labelSelector.Matches(labels.Set(podLabels)) {
+		return relatedPDBs
+	}
+
+	return append(relatedPDBs, common.RelatedResource{
+		Type:      "poddisruptionbudgets",
+		Namespace: namespace,
+		Name:      name,
+	})
+}
+
+func isEmptyLabelSelector(selector *metav1.LabelSelector) bool {
+	return len(selector.MatchLabels) == 0 && len(selector.MatchExpressions) == 0
 }
 
 func GetRelatedResources(c *gin.Context) {
@@ -390,11 +427,17 @@ func GetRelatedResources(c *gin.Context) {
 		result = getHTTPRouteRelatedResouces(res, namespace)
 	case *autoscalingv2.HorizontalPodAutoscaler:
 		result = getAutoScalingRelatedResources(res, namespace)
+	case *autoscalingv1.HorizontalPodAutoscaler:
+		result = getScaleTargetRelatedResources(res.Spec.ScaleTargetRef.Kind, res.Spec.ScaleTargetRef.APIVersion, res.Spec.ScaleTargetRef.Name, namespace)
 	case *v1.Ingress:
 		services := discoverIngressServices(namespace, res)
 		result = append(result, services...)
 	case *policyv1.PodDisruptionBudget:
 		if relatedPods, err := discoverPodsByPodDisruptionBudget(ctx, cs.K8sClient, namespace, res.Spec.Selector); err == nil {
+			result = append(result, relatedPods...)
+		}
+	case *policyv1beta1.PodDisruptionBudget:
+		if relatedPods, err := discoverPodsByPodDisruptionBudgetV1Beta1(ctx, cs.K8sClient, namespace, res.Spec.Selector); err == nil {
 			result = append(result, relatedPods...)
 		}
 	}
@@ -507,12 +550,16 @@ func getHTTPRouteRelatedResouces(res *gatewayapiv1.HTTPRoute, namespace string) 
 }
 
 func getAutoScalingRelatedResources(res *autoscalingv2.HorizontalPodAutoscaler, namespace string) []common.RelatedResource {
-	var result []common.RelatedResource
 	scaleTarget := res.Spec.ScaleTargetRef
+	return getScaleTargetRelatedResources(scaleTarget.Kind, scaleTarget.APIVersion, scaleTarget.Name, namespace)
+}
+
+func getScaleTargetRelatedResources(kind, apiVersion, name, namespace string) []common.RelatedResource {
+	var result []common.RelatedResource
 	result = append(result, common.RelatedResource{
-		Type:       strings.ToLower(scaleTarget.Kind) + "s",
-		APIVersion: scaleTarget.APIVersion,
-		Name:       scaleTarget.Name,
+		Type:       strings.ToLower(kind) + "s",
+		APIVersion: apiVersion,
+		Name:       name,
 		Namespace:  namespace,
 	})
 	return result

--- a/pkg/handlers/resources/versioned_resource_handler.go
+++ b/pkg/handlers/resources/versioned_resource_handler.go
@@ -1,0 +1,104 @@
+package resources
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/zxh326/kite/pkg/cluster"
+	"github.com/zxh326/kite/pkg/common"
+)
+
+type resourceVersionCandidate struct {
+	groupVersion string
+	resource     string
+	handler      resourceHandler
+}
+
+type versionedResourceHandler struct {
+	candidates []resourceVersionCandidate
+}
+
+func newVersionedResourceHandler(candidates ...resourceVersionCandidate) *versionedResourceHandler {
+	return &versionedResourceHandler{candidates: candidates}
+}
+
+func newResourceVersionCandidate(groupVersion, resource string, handler resourceHandler) resourceVersionCandidate {
+	return resourceVersionCandidate{
+		groupVersion: groupVersion,
+		resource:     resource,
+		handler:      handler,
+	}
+}
+
+func (h *versionedResourceHandler) resolve(c *gin.Context) resourceHandler {
+	if len(h.candidates) == 1 {
+		return h.candidates[0].handler
+	}
+
+	cs := c.MustGet("cluster").(*cluster.ClientSet)
+	for _, candidate := range h.candidates {
+		list, err := cs.K8sClient.ClientSet.Discovery().ServerResourcesForGroupVersion(candidate.groupVersion)
+		if list == nil {
+			if err != nil {
+				continue
+			}
+			continue
+		}
+		for _, resource := range list.APIResources {
+			if resource.Name == candidate.resource {
+				return candidate.handler
+			}
+		}
+	}
+
+	return h.candidates[0].handler
+}
+
+func (h *versionedResourceHandler) List(c *gin.Context) {
+	h.resolve(c).List(c)
+}
+
+func (h *versionedResourceHandler) Get(c *gin.Context) {
+	h.resolve(c).Get(c)
+}
+
+func (h *versionedResourceHandler) Create(c *gin.Context) {
+	h.resolve(c).Create(c)
+}
+
+func (h *versionedResourceHandler) Update(c *gin.Context) {
+	h.resolve(c).Update(c)
+}
+
+func (h *versionedResourceHandler) Delete(c *gin.Context) {
+	h.resolve(c).Delete(c)
+}
+
+func (h *versionedResourceHandler) Patch(c *gin.Context) {
+	h.resolve(c).Patch(c)
+}
+
+func (h *versionedResourceHandler) IsClusterScoped() bool {
+	return h.candidates[0].handler.IsClusterScoped()
+}
+
+func (h *versionedResourceHandler) Searchable() bool {
+	return h.candidates[0].handler.Searchable()
+}
+
+func (h *versionedResourceHandler) Search(c *gin.Context, query string, limit int64) ([]common.SearchResult, error) {
+	return h.resolve(c).Search(c, query, limit)
+}
+
+func (h *versionedResourceHandler) GetResource(c *gin.Context, namespace, name string) (interface{}, error) {
+	return h.resolve(c).GetResource(c, namespace, name)
+}
+
+func (h *versionedResourceHandler) registerCustomRoutes(group *gin.RouterGroup) {
+}
+
+func (h *versionedResourceHandler) ListHistory(c *gin.Context) {
+	h.resolve(c).ListHistory(c)
+}
+
+func (h *versionedResourceHandler) Describe(c *gin.Context) {
+	h.resolve(c).Describe(c)
+}

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -19,7 +19,6 @@ import (
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 
-	policyv1 "k8s.io/api/policy/v1"
 	metricsv1 "k8s.io/metrics/pkg/apis/metrics/v1beta1"
 	metricsclient "k8s.io/metrics/pkg/client/clientset/versioned"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -37,7 +36,6 @@ func init() {
 	_ = apiextensionsv1.AddToScheme(runtimeScheme)
 	_ = gatewayapiv1.Install(runtimeScheme)
 	_ = metricsv1.AddToScheme(runtimeScheme)
-	_ = policyv1.AddToScheme(runtimeScheme)
 }
 
 func controllerRuntimeLogger(logger logr.Logger) logr.Logger {


### PR DESCRIPTION
## Summary
- add internal API version fallback for resources whose Kubernetes APIs moved from beta to stable
- support policy/v1beta1 PodDisruptionBudget on legacy clusters while preferring policy/v1 when available
- keep related-resource discovery working for beta PDB and autoscaling/v1 HPA

Fixes #543
