### PR TITLE
fix: parse image references with registry ports

### DIFF
--- a/pkg/handlers/image_tags_handler_test.go
+++ b/pkg/handlers/image_tags_handler_test.go
@@ -24,6 +24,7 @@ func TestGetRegistry(t *testing.T) {
 		{name: "implicit docker hub", image: "nginx:latest", wantDocker: true, wantRepo: "library/nginx"},
 		{name: "explicit docker hub", image: "docker.io/library/nginx:latest", wantDocker: true, wantRepo: "library/nginx"},
 		{name: "custom registry", image: "ghcr.io/org/image:1.0", wantDocker: false, wantBase: "ghcr.io", wantRepo: "org/image"},
+		{name: "custom registry with port", image: "localhost:5000/org/image:1.0", wantDocker: false, wantBase: "localhost:5000", wantRepo: "org/image"},
 	}
 
 	for _, tt := range tests {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -45,7 +45,12 @@ func ToEnvName(input string) string {
 }
 
 func GetImageRegistryAndRepo(image string) (string, string) {
-	image = strings.SplitN(image, ":", 2)[0]
+	if digestIndex := strings.Index(image, "@"); digestIndex >= 0 {
+		image = image[:digestIndex]
+	}
+	if tagIndex := strings.LastIndex(image, ":"); tagIndex > strings.LastIndex(image, "/") {
+		image = image[:tagIndex]
+	}
 	parts := strings.Split(image, "/")
 	if len(parts) == 1 {
 		return "", "library/" + parts[0]

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -92,6 +92,8 @@ func TestGetImageRegistryAndRepo(t *testing.T) {
 		{"quay.io/my-org/my-repo", "quay.io", "my-org/my-repo"},
 		{"quay.io/my-org/my-repo:tag", "quay.io", "my-org/my-repo"},
 		{"registry.example.com/my-repo/test", "registry.example.com", "my-repo/test"},
+		{"localhost:5000/team/api:1.2.3", "localhost:5000", "team/api"},
+		{"registry.example.com:5000/team/api@sha256:abcdef", "registry.example.com:5000", "team/api"},
 	}
 	for _, tc := range testcase {
 		registry, repo := GetImageRegistryAndRepo(tc.image)


### PR DESCRIPTION
## What changed
Tiny papercut fix, ngl. Image refs with registry ports now parse right, so the tag picker hits the real registry instead of Docker Hub.

Related: #52 added the image tag selector area.

## Repro
Before this change:

```go
GetImageRegistryAndRepo("localhost:5000/team/api:1.2.3")
// got:  "", "library/localhost"
// want: "localhost:5000", "team/api"
```

That means `/api/image-tags?image=localhost:5000/team/api:1.2.3` could look up Docker Hub, which is not it.

## Fix
Strip digests first. Then strip a tag only when the colon is after the last slash, so registry ports stay intact.

## Tested
```bash
go test ./pkg/utils ./pkg/handlers -count=1
```