### PR TITLE
fix: exclude terminal pods from overview resource request/limit totals

### DIFF
--- a/pkg/handlers/overview_handler.go
+++ b/pkg/handlers/overview_handler.go
@@ -92,17 +92,20 @@ func GetOverview(c *gin.Context) {
 		// Solution : int64 accumulation instead of resource.Quantity.Add()
 		for i := range pods.Items {
 			pod := &pods.Items[i]
-			for j := range pod.Spec.Containers {
-				container := &pod.Spec.Containers[j]
-				pm.cpuRequested += container.Resources.Requests.Cpu().MilliValue()
-				pm.memRequested += container.Resources.Requests.Memory().MilliValue()
+			// Skip terminal pods; leads to over counting
+			if pod.Status.Phase != v1.PodSucceeded && pod.Status.Phase != v1.PodFailed {
+				for j := range pod.Spec.Containers {
+					container := &pod.Spec.Containers[j]
+					pm.cpuRequested += container.Resources.Requests.Cpu().MilliValue()
+					pm.memRequested += container.Resources.Requests.Memory().MilliValue()
 
-				if container.Resources.Limits != nil {
-					if cpu := container.Resources.Limits.Cpu(); cpu != nil {
-						pm.cpuLimited += cpu.MilliValue()
-					}
-					if mem := container.Resources.Limits.Memory(); mem != nil {
-						pm.memLimited += mem.MilliValue()
+					if container.Resources.Limits != nil {
+						if cpu := container.Resources.Limits.Cpu(); cpu != nil {
+							pm.cpuLimited += cpu.MilliValue()
+						}
+						if mem := container.Resources.Limits.Memory(); mem != nil {
+							pm.memLimited += mem.MilliValue()
+						}
 					}
 				}
 			}


### PR DESCRIPTION
The Overview page's CPU/Memory request and limit totals sum every pod returned by the cluster list, including pods in Succeeded and Failed phases. Completed Job and CronJob pods accumulate (kept around for history until the TTL controller reaps them or beyond if no TTL is set), so their requests and limits get added in even though those containers no longer reserve any node resources.

On a busy cluster this makes the percentages on the Overview page exceed 100% and stops matching what `kubectl describe node` reports. Example cluster:

```
Memory Usage
Requests: 84820.0 / Limits: 25835.0 / Total: 40213.0 GiB
Requests: 210.9% of capacity
Limits:    64.2% of capacity
```

The fix skips pods in terminal phases when accumulating cpuRequested/memRequested/cpuLimited/memLimited, mirroring `kubectl describe node`, which only sums non-terminated pods for its "Allocated resources" breakdown. The running-pod count is unchanged (it already handles Succeeded explicitly).