### PR TITLE
fix: cluster name with non-ASCII characters breaks frontend requests

### DIFF
--- a/pkg/middleware/cluster.go
+++ b/pkg/middleware/cluster.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"net/http"
+	"net/url"
 
 	"github.com/gin-gonic/gin"
 	"github.com/zxh326/kite/pkg/cluster"
@@ -25,6 +26,9 @@ func ClusterMiddleware(cm *cluster.ClusterManager) gin.HandlerFunc {
 			if clusterName == "" {
 				clusterName, _ = c.Cookie(ClusterNameHeader)
 			}
+		}
+		if decoded, err := url.QueryUnescape(clusterName); err == nil {
+			clusterName = decoded
 		}
 		cluster, err := cm.GetClientSet(clusterName)
 		if err != nil {

--- a/ui/src/lib/current-cluster.ts
+++ b/ui/src/lib/current-cluster.ts
@@ -26,7 +26,7 @@ export function appendCurrentClusterParam(params: URLSearchParams) {
 export function appendCurrentClusterHeader(headers: Record<string, string>) {
   const currentCluster = getCurrentCluster()
   if (currentCluster) {
-    headers[CURRENT_CLUSTER_HEADER_KEY] = currentCluster
+    headers[CURRENT_CLUSTER_HEADER_KEY] = encodeURIComponent(currentCluster)
   }
 }
 


### PR DESCRIPTION
When the cluster name contains non-ASCII characters (e.g. Chinese), the frontend fails to load data with the following browser error:

```
Failed to execute 'fetch' on 'Window': Failed to read the 'headers' property from 'RequestInit': String contains non ISO-8859-1 code point
```

HTTP headers only support ISO-8859-1 encoding. This PR encodes the cluster name via `encodeURIComponent` on the frontend and decodes it via `url.QueryUnescape` on the backend.