### PR TITLE
fix: preserve custom values during Helm auto upgrades

### DIFF
--- a/pkg/helmutil/release_upgrade.go
+++ b/pkg/helmutil/release_upgrade.go
@@ -11,14 +11,15 @@ import (
 )
 
 type UpgradeReleaseOptions struct {
-	Namespace         string
-	Timeout           time.Duration
-	ReuseValues       bool
-	Description       string
-	ForceConflicts    bool
-	RollbackOnFailure bool
-	DryRun            bool
-	Wait              bool
+	Namespace            string
+	Timeout              time.Duration
+	ReuseValues          bool
+	ResetThenReuseValues bool
+	Description          string
+	ForceConflicts       bool
+	RollbackOnFailure    bool
+	DryRun               bool
+	Wait                 bool
 }
 
 func UpgradeRelease(ctx context.Context, cfg *action.Configuration, name string, chartToUpgrade *chart.Chart, values map[string]interface{}, opts UpgradeReleaseOptions) (*release.Release, error) {
@@ -26,6 +27,7 @@ func UpgradeRelease(ctx context.Context, cfg *action.Configuration, name string,
 	upgrade.Namespace = opts.Namespace
 	upgrade.Timeout = opts.Timeout
 	upgrade.ReuseValues = opts.ReuseValues
+	upgrade.ResetThenReuseValues = opts.ResetThenReuseValues
 	upgrade.Description = opts.Description
 	upgrade.ForceConflicts = opts.ForceConflicts
 	upgrade.RollbackOnFailure = opts.RollbackOnFailure

--- a/pkg/scheduler/helmrelease_auto_upgrade.go
+++ b/pkg/scheduler/helmrelease_auto_upgrade.go
@@ -94,11 +94,11 @@ func (e *helmReleaseAutoUpgradeExecutor) Run(ctx context.Context, task model.Sch
 	}()
 
 	next, err = helmutil.UpgradeRelease(ctx, cfg, releaseName, loadedChart, map[string]interface{}{}, helmutil.UpgradeReleaseOptions{
-		Namespace:         payload.Namespace,
-		Timeout:           time.Duration(payload.TimeoutMinutes) * time.Minute,
-		ReuseValues:       true,
-		Description:       "Auto upgrade requested from Kite",
-		RollbackOnFailure: payload.RollbackOnFailure,
+		Namespace:            payload.Namespace,
+		Timeout:              time.Duration(payload.TimeoutMinutes) * time.Minute,
+		ResetThenReuseValues: true,
+		Description:          "Auto upgrade requested from Kite",
+		RollbackOnFailure:    payload.RollbackOnFailure,
 	})
 	if err != nil {
 		runErr = err


### PR DESCRIPTION
## Summary

- Add a `ResetThenReuseValues` option to the shared Helm upgrade wrapper.
- Use that option for scheduled Helm release auto upgrades instead of `ReuseValues`.

## Why

Auto upgrades previously reused the old release's fully coalesced values. That could preserve old chart defaults and cause the release chart version to advance while rendered Kubernetes objects stayed unchanged. The new behavior starts from the upgraded chart defaults, then reapplies user-provided release values.

## Validation

- `go test ./pkg/helmutil ./pkg/scheduler`
- pre-commit hook: `go fmt ./...`, `pnpm run format`, `go vet ./...`, `golangci-lint run`, `pnpm run lint`