### PR TITLE
fix: add cluster access checks for protected endpoints

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -54,6 +54,7 @@ jobs:
       E2E_PORT: "38080"
       KITE_E2E_LDAP_URL: ldap://127.0.0.1:3389
       KITE_E2E_OAUTH_ISSUER: http://127.0.0.1:5556
+      KITE_E2E_USE_SYSTEM_CHROME: "true"
 
     steps:
       - name: Checkout code
@@ -85,17 +86,8 @@ jobs:
       - name: Install E2E deps
         run: make e2e-install
 
-      - name: Cache Playwright browsers
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-chromium-${{ hashFiles('e2e/pnpm-lock.yaml') }}
-          restore-keys: |
-            playwright-${{ runner.os }}-chromium-
-
-      - name: Install Playwright Chromium
-        timeout-minutes: 5
-        run: make e2e-install-browser
+      - name: Verify Chrome
+        run: google-chrome --version
 
       - name: Install kind
         run: |
@@ -115,7 +107,12 @@ jobs:
 
       - name: Export kind logs
         if: always()
-        run: kind export logs "${KIND_LOGS_DIR}" --name "${E2E_KIND_NAME}"
+        run: |
+          if command -v kind >/dev/null 2>&1 && kind get clusters | grep -qx "${E2E_KIND_NAME}"; then
+            kind export logs "${KIND_LOGS_DIR}" --name "${E2E_KIND_NAME}"
+          else
+            echo "kind cluster ${E2E_KIND_NAME} does not exist"
+          fi
 
       - name: Collect external auth logs
         if: always()

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -82,6 +82,21 @@ jobs:
       - name: Install deps
         run: make deps
 
+      - name: Install E2E deps
+        run: make e2e-install
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-chromium-${{ hashFiles('e2e/pnpm-lock.yaml') }}
+          restore-keys: |
+            playwright-${{ runner.os }}-chromium-
+
+      - name: Install Playwright Chromium
+        timeout-minutes: 5
+        run: make e2e-install-browser
+
       - name: Install kind
         run: |
           [ "$(uname -m)" = "x86_64" ] && curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.31.0/kind-linux-amd64
@@ -96,7 +111,7 @@ jobs:
         run: make e2e-setup-dex
 
       - name: Run E2E tests
-        run: make e2e-test
+        run: make e2e-run
 
       - name: Export kind logs
         if: always()

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Makefile for Kite project
-.PHONY: help dev build clean test docker-build docker-run frontend backend install deps e2e-install e2e-kind-up e2e-kind-down e2e-stop-app e2e-setup-ldap e2e-setup-dex e2e-test e2e-test-headed
+.PHONY: help dev build clean test docker-build docker-run frontend backend install deps e2e-install e2e-install-browser e2e-kind-up e2e-kind-down e2e-stop-app e2e-setup-ldap e2e-setup-dex e2e-run e2e-run-headed e2e-test e2e-test-headed
 
 # Variables
 BINARY_NAME=kite
@@ -146,9 +146,12 @@ test: ## Run tests
 	go test -v ./...
 	cd $(UI_DIR) && pnpm run test
 
-e2e-install: ## Install e2e dependencies and Playwright browser
+e2e-install: ## Install e2e dependencies
 	@echo "📦 Installing e2e dependencies..."
 	cd $(E2E_DIR) && pnpm install
+
+e2e-install-browser: ## Install Playwright Chromium browser
+	@echo "🌐 Installing Playwright Chromium..."
 	cd $(E2E_DIR) && pnpm exec playwright install chromium
 
 e2e-kind-up: ## Create or reuse the local kind cluster for e2e
@@ -215,13 +218,17 @@ e2e-setup-dex: ## Start the Dex service used by external-auth e2e
 	done
 	curl -fsS "http://127.0.0.1:$(E2E_OAUTH_PORT)/.well-known/openid-configuration" >/dev/null
 
-e2e-test: e2e-install e2e-kind-up e2e-stop-app ## Run e2e tests against the local kind cluster
+e2e-run: e2e-kind-up e2e-stop-app ## Run e2e tests against the local kind cluster
 	@echo "🧪 Running e2e tests..."
 	cd $(E2E_DIR) && KUBECONFIG="$(E2E_KUBECONFIG)" KITE_E2E_CLUSTER_NAME="$(E2E_KIND_NAME)" KITE_E2E_PORT="$(E2E_PORT)" pnpm exec playwright test $(SPEC)
 
-e2e-test-headed: e2e-install e2e-kind-up e2e-stop-app ## Run e2e tests in headed mode against the local kind cluster
+e2e-run-headed: e2e-kind-up e2e-stop-app ## Run e2e tests in headed mode against the local kind cluster
 	@echo "🧪 Running headed e2e tests..."
 	cd $(E2E_DIR) && KUBECONFIG="$(E2E_KUBECONFIG)" KITE_E2E_CLUSTER_NAME="$(E2E_KIND_NAME)" KITE_E2E_PORT="$(E2E_PORT)" pnpm exec playwright test --headed $(SPEC)
+
+e2e-test: e2e-install e2e-install-browser e2e-run ## Run e2e tests against the local kind cluster
+
+e2e-test-headed: e2e-install e2e-install-browser e2e-run-headed ## Run e2e tests in headed mode against the local kind cluster
 
 docs-dev: ## Start documentation server in development mode
 	@echo "📚 Starting documentation server..."

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -30,7 +30,7 @@ export default defineConfig({
     locale: 'en-US',
     trace: 'retain-on-failure',
     screenshot: 'only-on-failure',
-    video: 'retain-on-failure',
+    video: useSystemChrome ? 'off' : 'retain-on-failure',
   },
   webServer: process.env.KITE_E2E_BASE_URL
     ? undefined

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -8,6 +8,7 @@ const e2eDir = dirname(fileURLToPath(import.meta.url))
 const repoRoot = resolve(e2eDir, '..')
 const port = process.env.KITE_E2E_PORT || '38080'
 const baseURL = process.env.KITE_E2E_BASE_URL || `http://127.0.0.1:${port}`
+const useSystemChrome = process.env.KITE_E2E_USE_SYSTEM_CHROME === 'true'
 
 export default defineConfig({
   testDir: '.',
@@ -25,6 +26,7 @@ export default defineConfig({
   outputDir: 'test-results',
   use: {
     baseURL,
+    ...(useSystemChrome ? { channel: 'chrome' as const } : {}),
     locale: 'en-US',
     trace: 'retain-on-failure',
     screenshot: 'only-on-failure',

--- a/pkg/metrics/handler.go
+++ b/pkg/metrics/handler.go
@@ -9,7 +9,9 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/zxh326/kite/pkg/cluster"
+	"github.com/zxh326/kite/pkg/model"
 	"github.com/zxh326/kite/pkg/prometheus"
+	"github.com/zxh326/kite/pkg/rbac"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	metricsv1beta1 "k8s.io/metrics/pkg/apis/metrics/v1beta1"
 )
@@ -58,6 +60,12 @@ func (h *Handler) GetResourceUsageHistory(c *gin.Context) {
 	ctx := c.Request.Context()
 
 	cs := c.MustGet("cluster").(*cluster.ClientSet)
+	user := c.MustGet("user").(model.User)
+	if !rbac.CanAccessCluster(user, cs.Name) {
+		c.JSON(http.StatusForbidden, gin.H{"error": "Access denied"})
+		return
+	}
+
 	// Get query parameter for time range
 	duration := c.DefaultQuery("duration", "1h")
 
@@ -90,6 +98,12 @@ func (h *Handler) GetResourceUsageHistory(c *gin.Context) {
 func (h *Handler) GetPodMetrics(c *gin.Context) {
 	ctx := c.Request.Context()
 	cs := c.MustGet("cluster").(*cluster.ClientSet)
+	user := c.MustGet("user").(model.User)
+	if !rbac.CanAccessCluster(user, cs.Name) {
+		c.JSON(http.StatusForbidden, gin.H{"error": "Access denied"})
+		return
+	}
+
 	// Get path parameters
 	namespace := c.Param("namespace")
 	podName := c.Param("podName")

--- a/pkg/search/handler.go
+++ b/pkg/search/handler.go
@@ -15,6 +15,7 @@ import (
 	"github.com/zxh326/kite/pkg/common"
 	"github.com/zxh326/kite/pkg/middleware"
 	"github.com/zxh326/kite/pkg/model"
+	"github.com/zxh326/kite/pkg/rbac"
 	"github.com/zxh326/kite/pkg/resources"
 	"github.com/zxh326/kite/pkg/utils"
 	"golang.org/x/sync/errgroup"
@@ -139,6 +140,13 @@ func (h *SearchHandler) Search(c *gin.Context, query string, limit int) ([]commo
 
 // GlobalSearch handles global search across multiple resource types
 func (h *SearchHandler) GlobalSearch(c *gin.Context) {
+	user := c.MustGet("user").(model.User)
+	clusterName := getSearchClusterName(c)
+	if !rbac.CanAccessCluster(user, clusterName) {
+		c.JSON(http.StatusForbidden, gin.H{"error": "Access denied"})
+		return
+	}
+
 	query := normalizeSearchQuery(c.Query("q"))
 	if query == "" {
 		c.JSON(http.StatusOK, SearchResponse{})
@@ -153,8 +161,7 @@ func (h *SearchHandler) GlobalSearch(c *gin.Context) {
 	}
 	limit = normalizeSearchLimit(limit)
 
-	user := c.MustGet("user").(model.User)
-	cacheKey := h.createCacheKey(getSearchClusterName(c), user.Key(), query, limit)
+	cacheKey := h.createCacheKey(clusterName, user.Key(), query, limit)
 
 	if cachedResults, found := h.cache.Get(cacheKey); found {
 		klog.V(4).Infof("search: query=%q cache=exact results=%d", query, len(cachedResults))
@@ -166,7 +173,7 @@ func (h *SearchHandler) GlobalSearch(c *gin.Context) {
 		return
 	}
 
-	if cachedResults, found := h.searchCachedPrefix(getSearchClusterName(c), user.Key(), query, limit); found {
+	if cachedResults, found := h.searchCachedPrefix(clusterName, user.Key(), query, limit); found {
 		klog.V(4).Infof("search: query=%q cache=prefix results=%d", query, len(cachedResults))
 		h.cache.Add(cacheKey, cachedResults)
 		response := SearchResponse{

--- a/pkg/system/handler.go
+++ b/pkg/system/handler.go
@@ -7,6 +7,7 @@ import (
 	"github.com/zxh326/kite/pkg/cluster"
 	"github.com/zxh326/kite/pkg/common"
 	"github.com/zxh326/kite/pkg/model"
+	"github.com/zxh326/kite/pkg/rbac"
 	"github.com/zxh326/kite/pkg/utils"
 	"golang.org/x/sync/errgroup"
 	v1 "k8s.io/api/core/v1"
@@ -46,9 +47,9 @@ func GetOverview(c *gin.Context) {
 
 	cs := c.MustGet("cluster").(*cluster.ClientSet)
 	user := c.MustGet("user").(model.User)
-	if len(user.Roles) == 0 {
+	if !rbac.CanAccessCluster(user, cs.Name) {
 		c.JSON(http.StatusForbidden, gin.H{"error": "Access denied"})
-		return // Fix: was missing, caused 4 queries to run for unauthorized users
+		return
 	}
 
 	// Solution : Fetch and compute all 4 resource types in parallel.


### PR DESCRIPTION
## Summary

Adds cluster-level RBAC checks to protected endpoints that are registered before the generic RBAC middleware:

- `/api/v1/overview`
- `/api/v1/prometheus/resource-usage-history`
- `/api/v1/prometheus/pods/:namespace/:podName/metrics`
- `/api/v1/search`

Updates the E2E workflow so CI uses the GitHub runner's system Chrome instead of installing Playwright Chromium during the job. CI also verifies Chrome explicitly and skips Playwright video capture in that mode so it does not require Playwright's cached ffmpeg binary.

## Why

These routes run after authentication and cluster selection, but before `RBACMiddleware()`. Without an explicit cluster check, an authenticated user could select a cluster outside their allowed RBAC scope via `x-cluster-name` and read cluster overview, metrics, or search metadata.

The E2E failures were caused by Playwright browser installation hanging after the Chromium download reached 100%. Splitting the step exposed the real failure; using system Chrome removes that flaky install path from CI.

## Validation

- `go test ./pkg/metrics ./pkg/search ./pkg/system`
- `git diff --check`
- `make -n e2e-test`
- YAML parse check for `.github/workflows/e2e.yml`
- `cd e2e && KITE_E2E_BASE_URL=http://127.0.0.1:1 KITE_E2E_USE_SYSTEM_CHROME=true pnpm exec playwright test --list`
- PR checks passing: Build, E2E, CodeQL Go, CodeQL JavaScript/TypeScript
