### PR TITLE
Fix per-tab cluster selection

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,6 @@ require (
 	github.com/samber/lo v1.53.0
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/crypto v0.52.0
-	golang.org/x/net v0.55.0
 	golang.org/x/sync v0.20.0
 	gopkg.in/yaml.v3 v3.0.1
 	gorm.io/driver/mysql v1.6.0
@@ -39,6 +38,8 @@ require (
 	sigs.k8s.io/gateway-api v1.5.1
 	sigs.k8s.io/yaml v1.6.0
 )
+
+require golang.org/x/net v0.55.0 // indirect
 
 require (
 	dario.cat/mergo v1.0.1 // indirect
@@ -97,7 +98,7 @@ require (
 	github.com/google/gnostic-models v0.7.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/gopherjs/gopherjs v1.12.80 // indirect
-	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 // indirect
+	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674
 	github.com/gosuri/uitable v0.0.4 // indirect
 	github.com/huandu/xstrings v1.5.0 // indirect
 	github.com/ianlancetaylor/demangle v0.0.0-20240805132620-81f5be970eca // indirect

--- a/pkg/kube/log.go
+++ b/pkg/kube/log.go
@@ -6,11 +6,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"strings"
 	"sync"
 
 	"github.com/zxh326/kite/pkg/wsutil"
-	"golang.org/x/net/websocket"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
 )
@@ -22,7 +20,7 @@ type PodLogStream struct {
 }
 
 type BatchLogHandler struct {
-	conn      *websocket.Conn
+	conn      *wsutil.Conn
 	mu        sync.RWMutex
 	pods      map[string]*PodLogStream // key: namespace/name; guarded by mu
 	k8sClient *K8sClient
@@ -31,7 +29,7 @@ type BatchLogHandler struct {
 	cancel    context.CancelFunc
 }
 
-func NewBatchLogHandler(conn *websocket.Conn, client *K8sClient, opts *corev1.PodLogOptions) *BatchLogHandler {
+func NewBatchLogHandler(conn *wsutil.Conn, client *K8sClient, opts *corev1.PodLogOptions) *BatchLogHandler {
 	ctx, cancel := context.WithCancel(context.Background())
 	l := &BatchLogHandler{
 		conn:      conn,
@@ -143,22 +141,13 @@ func (l *BatchLogHandler) heartbeat(ctx context.Context) {
 			klog.V(1).Info("Heartbeat stopping due to internal context cancellation")
 			return
 		default:
-			var temp []byte
-			err := websocket.Message.Receive(l.conn, &temp)
+			_, _, err := l.conn.ReadMessage()
 			if err != nil {
 				if !errors.Is(err, io.EOF) {
 					klog.Errorf("WebSocket connection error in heartbeat, cancelling internal context: %v", err)
 				}
 				l.cancel() // Cancel internal context when connection is lost
 				return
-			}
-			if strings.Contains(string(temp), "ping") {
-				err = wsutil.SendMessage(l.conn, "pong", "pong")
-				if err != nil {
-					klog.V(1).Infof("Failed to send pong, cancelling internal context: %v", err)
-					l.cancel() // Cancel internal context when send fails
-					return
-				}
 			}
 		}
 	}

--- a/pkg/kube/terminal.go
+++ b/pkg/kube/terminal.go
@@ -4,12 +4,9 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"sync/atomic"
-	"time"
 
 	"github.com/zxh326/kite/pkg/common"
 	"github.com/zxh326/kite/pkg/wsutil"
-	"golang.org/x/net/websocket"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/remotecommand"
@@ -20,7 +17,7 @@ const EndOfTransmission = "\u0004"
 
 // TerminalMessage represents messages sent over the WebSocket
 type TerminalMessage struct {
-	Type string `json:"type"` // "stdin", "resize", "ping"
+	Type string `json:"type"`
 	Data string `json:"data"`
 	Rows uint16 `json:"rows,omitempty"`
 	Cols uint16 `json:"cols,omitempty"`
@@ -29,16 +26,14 @@ type TerminalMessage struct {
 // TerminalSession manages a WebSocket connection for terminal communication
 type TerminalSession struct {
 	k8sClient *K8sClient
-	conn      *websocket.Conn
+	conn      *wsutil.Conn
 	sizeChan  chan *remotecommand.TerminalSize
 	namespace string
 	podName   string
 	container string
-
-	lastHeartbeat atomic.Int64 // UnixNano; written/read from multiple goroutines
 }
 
-func NewTerminalSession(client *K8sClient, conn *websocket.Conn, namespace, podName, container string) *TerminalSession {
+func NewTerminalSession(client *K8sClient, conn *wsutil.Conn, namespace, podName, container string) *TerminalSession {
 	return &TerminalSession{
 		k8sClient: client,
 		conn:      conn,
@@ -78,7 +73,6 @@ func (session *TerminalSession) Start(ctx context.Context, subResource string) e
 	// Send initial connection success message
 	session.SendMessage("connected", "Terminal connected successfully")
 
-	go session.checkHeartbeat(ctx)
 	// Start the exec session
 	err = exec.StreamWithContext(ctx, remotecommand.StreamOptions{
 		Stdin:             session,
@@ -97,15 +91,12 @@ func (session *TerminalSession) Start(ctx context.Context, subResource string) e
 }
 
 func (session *TerminalSession) Close() {
-	if err := session.conn.Close(); err != nil {
-		klog.Errorf("WebSocket close error %s: %v", session.conn.RemoteAddr(), err)
-	}
 	close(session.sizeChan)
 }
 
 func (session *TerminalSession) Read(p []byte) (int, error) {
 	var msg TerminalMessage
-	err := websocket.JSON.Receive(session.conn, &msg)
+	err := session.conn.ReadJSON(&msg)
 	if err != nil {
 		return copy(p, EndOfTransmission), err
 	}
@@ -124,9 +115,6 @@ func (session *TerminalSession) Read(p []byte) (int, error) {
 			default:
 			}
 		}
-	case "ping":
-		session.lastHeartbeat.Store(time.Now().UnixNano())
-		session.SendMessage("pong", "")
 	default:
 		return copy(p, EndOfTransmission), fmt.Errorf("unknown message type: %s", msg.Type)
 	}
@@ -154,25 +142,4 @@ func (session *TerminalSession) SendMessage(msgType, data string) {
 
 func (session *TerminalSession) SendErrorMessage(errMsg string) {
 	wsutil.SendErrorMessage(session.conn, errMsg)
-}
-
-func (session *TerminalSession) checkHeartbeat(ctx context.Context) {
-	session.lastHeartbeat.Store(time.Now().UnixNano())
-	ticker := time.NewTicker(10 * time.Second)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-ticker.C:
-			lastBeat := time.Unix(0, session.lastHeartbeat.Load())
-			if time.Since(lastBeat) > 1*time.Minute {
-				if err := session.conn.Close(); err != nil {
-					klog.Errorf("WebSocket close error: %v", err)
-				}
-				return
-			}
-		}
-	}
 }

--- a/pkg/middleware/cluster.go
+++ b/pkg/middleware/cluster.go
@@ -27,12 +27,6 @@ func ClusterMiddleware(cm *cluster.ClusterManager) gin.HandlerFunc {
 			if v, ok := c.GetQuery(ClusterNameHeader); ok {
 				clusterName = v
 			}
-			if clusterName == "" {
-				clusterName, _ = c.Cookie(ClusterNameHeader)
-				if decoded, err := url.PathUnescape(clusterName); err == nil {
-					clusterName = decoded
-				}
-			}
 		}
 		cluster, err := cm.GetClientSet(clusterName)
 		if err != nil {

--- a/pkg/terminal/kubectl_terminal_handler.go
+++ b/pkg/terminal/kubectl_terminal_handler.go
@@ -38,8 +38,6 @@ func (h *KubectlTerminalHandler) HandleKubectlTerminalWebSocket(c *gin.Context) 
 	user := c.MustGet("user").(model.User)
 
 	wsutil.Serve(c.Writer, c.Request, func(ws *wsutil.Session) {
-		defer ws.Close()
-
 		// Only admin users can use the kubectl terminal
 		if !rbac.UserHasRole(user, model.DefaultAdminRole.Name) {
 			ws.SendErrorMessage("kubectl terminal is only available to admin users")

--- a/pkg/terminal/node_terminal_handler.go
+++ b/pkg/terminal/node_terminal_handler.go
@@ -41,7 +41,6 @@ func (h *NodeTerminalHandler) HandleNodeTerminalWebSocket(c *gin.Context) {
 	user := c.MustGet("user").(model.User)
 
 	wsutil.Serve(c.Writer, c.Request, func(ws *wsutil.Session) {
-		defer ws.Close()
 		ctx := ws.Context
 		if !rbac.CanAccess(user, string(common.Nodes), "exec", cs.Name, "") {
 			ws.SendErrorMessage(rbac.NoAccess(user.Key(), string(common.VerbExec), string(common.Nodes), "", cs.Name))

--- a/pkg/wsutil/wsutil.go
+++ b/pkg/wsutil/wsutil.go
@@ -3,9 +3,17 @@ package wsutil
 import (
 	"context"
 	"net/http"
+	"sync"
+	"time"
 
-	"golang.org/x/net/websocket"
+	"github.com/gorilla/websocket"
 	"k8s.io/klog/v2"
+)
+
+const (
+	protocolPingInterval = 30 * time.Second
+	protocolPongTimeout  = 10 * time.Minute
+	protocolWriteTimeout = 5 * time.Second
 )
 
 type Message struct {
@@ -13,31 +21,100 @@ type Message struct {
 	Data string `json:"data"`
 }
 
+type Conn struct {
+	*websocket.Conn
+	writeMu   sync.Mutex
+	closeOnce sync.Once
+	closeErr  error
+}
+
 type Session struct {
 	Context context.Context
-	Conn    *websocket.Conn
+	Conn    *Conn
+}
+
+var upgrader = websocket.Upgrader{
+	CheckOrigin: func(r *http.Request) bool {
+		return true
+	},
 }
 
 func Serve(w http.ResponseWriter, r *http.Request, handle func(*Session)) {
-	websocket.Handler(func(conn *websocket.Conn) {
-		ctx, cancel := context.WithCancel(r.Context())
-		defer cancel()
-		handle(&Session{
-			Context: ctx,
-			Conn:    conn,
-		})
-	}).ServeHTTP(w, r)
+	rawConn, err := upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		klog.Errorf("WebSocket upgrade error: %v", err)
+		return
+	}
+
+	ctx, cancel := context.WithCancel(r.Context())
+	defer cancel()
+	conn := &Conn{Conn: rawConn}
+	defer func() {
+		if err := conn.Close(); err != nil {
+			klog.Errorf("WebSocket close error %s: %v", conn.RemoteAddr(), err)
+		}
+	}()
+	conn.startProtocolHeartbeat(ctx)
+
+	handle(&Session{
+		Context: ctx,
+		Conn:    conn,
+	})
 }
 
-func SendMessage(conn *websocket.Conn, msgType, data string) error {
-	return websocket.JSON.Send(conn, Message{Type: msgType, Data: data})
+func (c *Conn) WriteJSON(v any) error {
+	c.writeMu.Lock()
+	defer c.writeMu.Unlock()
+	return c.Conn.WriteJSON(v)
 }
 
-func SendError(conn *websocket.Conn, message string) error {
+func (c *Conn) WriteControl(messageType int, data []byte, deadline time.Time) error {
+	c.writeMu.Lock()
+	defer c.writeMu.Unlock()
+	return c.Conn.WriteControl(messageType, data, deadline)
+}
+
+func (c *Conn) Close() error {
+	c.closeOnce.Do(func() {
+		c.closeErr = c.Conn.Close()
+	})
+	return c.closeErr
+}
+
+func (c *Conn) startProtocolHeartbeat(ctx context.Context) {
+	_ = c.SetReadDeadline(time.Now().Add(protocolPongTimeout))
+	c.SetPongHandler(func(string) error {
+		return c.SetReadDeadline(time.Now().Add(protocolPongTimeout))
+	})
+
+	ticker := time.NewTicker(protocolPingInterval)
+	go func() {
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				if err := c.WriteControl(websocket.PingMessage, nil, time.Now().Add(protocolWriteTimeout)); err != nil {
+					klog.V(1).Infof("WebSocket protocol ping failed: %v", err)
+					_ = c.Close()
+					return
+				}
+			}
+		}
+	}()
+}
+
+func SendMessage(conn *Conn, msgType, data string) error {
+	return conn.WriteJSON(Message{Type: msgType, Data: data})
+}
+
+func SendError(conn *Conn, message string) error {
 	return SendMessage(conn, "error", message)
 }
 
-func SendErrorMessage(conn *websocket.Conn, message string) {
+func SendErrorMessage(conn *Conn, message string) {
 	if err := SendError(conn, message); err != nil {
 		klog.Errorf("Failed to send error message: %v", err)
 	}
@@ -49,10 +126,4 @@ func (s *Session) SendMessage(msgType, data string) error {
 
 func (s *Session) SendErrorMessage(message string) {
 	SendErrorMessage(s.Conn, message)
-}
-
-func (s *Session) Close() {
-	if err := s.Conn.Close(); err != nil {
-		klog.Errorf("WebSocket close error %s: %v", s.Conn.RemoteAddr(), err)
-	}
 }

--- a/ui/src/components/cronjob-overview.tsx
+++ b/ui/src/components/cronjob-overview.tsx
@@ -1,5 +1,4 @@
 import { useMemo, useState } from 'react'
-import { IconExternalLink } from '@tabler/icons-react'
 import { CronJob, Job } from 'kubernetes-types/batch/v1'
 import { Event as KubernetesEvent } from 'kubernetes-types/core/v1'
 import { useTranslation } from 'react-i18next'
@@ -8,18 +7,10 @@ import { Link, useSearchParams } from 'react-router-dom'
 import { useRelatedResources } from '@/lib/api'
 import { formatJobStatusBadge, getJobStatusBadge } from '@/lib/job-status'
 import { getEventTime, getOwnerInfo } from '@/lib/k8s'
-import { withSubPath } from '@/lib/subpath'
 import { cn, formatDate, getAge } from '@/lib/utils'
 import { Badge } from '@/components/ui/badge'
-import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from '@/components/ui/dialog'
+import { Dialog, DialogTrigger } from '@/components/ui/dialog'
 import {
   Table,
   TableBody,
@@ -28,6 +19,7 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table'
+import { ResourceIframeDialogContent } from '@/components/resource-iframe-dialog-content'
 import {
   ContainerImagesList,
   WorkloadInfoBlock,
@@ -500,24 +492,10 @@ export function CronJobJobLink({
           {jobName}
         </button>
       </DialogTrigger>
-      <DialogContent className="!h-[calc(100dvh-1rem)] !max-w-[calc(100vw-1rem)] flex min-h-0 flex-col gap-0 p-0 md:!h-[80%] md:!max-w-[80%]">
-        <DialogHeader className="flex flex-row items-center justify-between border-b px-4 py-3 pr-14">
-          <DialogTitle>{t('common.fields.job', 'Job')}</DialogTitle>
-          <a href={withSubPath(path)} target="_blank" rel="noopener noreferrer">
-            <Button
-              variant="outline"
-              size="icon"
-              aria-label="Open resource in new tab"
-            >
-              <IconExternalLink size={12} />
-            </Button>
-          </a>
-        </DialogHeader>
-        <iframe
-          src={`${withSubPath(path)}?iframe=true`}
-          className="min-h-0 w-full flex-grow border-none"
-        />
-      </DialogContent>
+      <ResourceIframeDialogContent
+        title={t('common.fields.job', 'Job')}
+        path={path}
+      />
     </Dialog>
   )
 }

--- a/ui/src/components/pod-overview-sidebar.tsx
+++ b/ui/src/components/pod-overview-sidebar.tsx
@@ -21,15 +21,9 @@ import {
 import { withSubPath } from '@/lib/subpath'
 import { cn, getAge } from '@/lib/utils'
 import { Badge } from '@/components/ui/badge'
-import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from '@/components/ui/dialog'
+import { Dialog, DialogTrigger } from '@/components/ui/dialog'
+import { ResourceIframeDialogContent } from '@/components/resource-iframe-dialog-content'
 
 type TranslationFn = ReturnType<typeof useTranslation>['t']
 
@@ -170,24 +164,10 @@ function CompactRelatedResourceRow({
           {rowContent}
         </button>
       </DialogTrigger>
-      <DialogContent className="!h-[calc(100dvh-1rem)] !max-w-[calc(100vw-1rem)] flex min-h-0 flex-col gap-0 p-0 md:!h-[80%] md:!max-w-[80%]">
-        <DialogHeader className="flex flex-row items-center justify-between border-b px-4 py-3 pr-14">
-          <DialogTitle>{metadata?.singularLabel || resource.type}</DialogTitle>
-          <a href={withSubPath(path)} target="_blank" rel="noopener noreferrer">
-            <Button
-              variant="outline"
-              size="icon"
-              aria-label="Open resource in new tab"
-            >
-              <IconExternalLink size={12} />
-            </Button>
-          </a>
-        </DialogHeader>
-        <iframe
-          src={`${withSubPath(path)}?iframe=true`}
-          className="min-h-0 w-full flex-grow border-none"
-        />
-      </DialogContent>
+      <ResourceIframeDialogContent
+        title={metadata?.singularLabel || resource.type}
+        path={path}
+      />
     </Dialog>
   )
 }

--- a/ui/src/components/related-resource-table.tsx
+++ b/ui/src/components/related-resource-table.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react'
-import { IconExternalLink, IconLoader } from '@tabler/icons-react'
+import { IconLoader } from '@tabler/icons-react'
 import { Link, useSearchParams } from 'react-router-dom'
 
 import { RelatedResources, ResourceType } from '@/types/api'
@@ -9,18 +9,11 @@ import {
   getResourceDetailPath,
   getResourceMetadata,
 } from '@/lib/resource-catalog'
-import { withSubPath } from '@/lib/subpath'
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from '@/components/ui/dialog'
+import { Dialog, DialogTrigger } from '@/components/ui/dialog'
+import { ResourceIframeDialogContent } from '@/components/resource-iframe-dialog-content'
 
 import { Column, SimpleTable } from './simple-table'
 import { Badge } from './ui/badge'
-import { Button } from './ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from './ui/card'
 
 export function RelatedResourcesTable(props: {
@@ -115,24 +108,10 @@ function RelatedResourceCell({ rs }: { rs: RelatedResources }) {
       <DialogTrigger asChild>
         <div className="font-medium app-link cursor-pointer">{rs.name}</div>
       </DialogTrigger>
-      <DialogContent className="!h-[calc(100dvh-1rem)] !max-w-[calc(100vw-1rem)] flex min-h-0 flex-col gap-0 p-0 md:!h-[80%] md:!max-w-[80%]">
-        <DialogHeader className="flex flex-row items-center justify-between border-b px-4 py-3 pr-14">
-          <DialogTitle>{metadata?.singularLabel || rs.type}</DialogTitle>
-          <a href={withSubPath(path)} target="_blank" rel="noopener noreferrer">
-            <Button
-              variant="outline"
-              size="icon"
-              aria-label="Open resource in new tab"
-            >
-              <IconExternalLink size={12} />
-            </Button>
-          </a>
-        </DialogHeader>
-        <iframe
-          src={`${withSubPath(path)}?iframe=true`}
-          className="min-h-0 w-full flex-grow border-none"
-        />
-      </DialogContent>
+      <ResourceIframeDialogContent
+        title={metadata?.singularLabel || rs.type}
+        path={path}
+      />
     </Dialog>
   )
 }

--- a/ui/src/components/resource-iframe-dialog-content.tsx
+++ b/ui/src/components/resource-iframe-dialog-content.tsx
@@ -1,0 +1,59 @@
+import { useRef, type ReactNode } from 'react'
+import { IconExternalLink, IconMaximize } from '@tabler/icons-react'
+
+import { withSubPath } from '@/lib/subpath'
+import { Button } from '@/components/ui/button'
+import {
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+
+export function ResourceIframeDialogContent({
+  title,
+  path,
+}: {
+  title: ReactNode
+  path: string
+}) {
+  const iframeRef = useRef<HTMLIFrameElement>(null)
+  const handleOpenCurrentPage = () => {
+    const url = new URL(iframeRef.current!.contentWindow!.location.href)
+    url.searchParams.delete('iframe')
+    window.location.assign(url.toString())
+  }
+
+  return (
+    <DialogContent className="!h-[calc(100dvh-1rem)] !max-w-[calc(100vw-1rem)] flex min-h-0 flex-col gap-0 p-0 md:!h-[80%] md:!max-w-[80%]">
+      <DialogHeader className="flex flex-row items-center justify-between border-b px-4 py-3 pr-14">
+        <DialogTitle>{title}</DialogTitle>
+        <div className="flex items-center gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            size="icon"
+            aria-label="Open resource in current page"
+            onClick={handleOpenCurrentPage}
+          >
+            <IconMaximize size={12} />
+          </Button>
+          <Button asChild variant="outline" size="icon">
+            <a
+              href={withSubPath(path)}
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="Open resource in new tab"
+            >
+              <IconExternalLink size={12} />
+            </a>
+          </Button>
+        </div>
+      </DialogHeader>
+      <iframe
+        ref={iframeRef}
+        src={`${withSubPath(path)}?iframe=true`}
+        className="min-h-0 w-full flex-grow border-none"
+      />
+    </DialogContent>
+  )
+}

--- a/ui/src/components/terminal-content.tsx
+++ b/ui/src/components/terminal-content.tsx
@@ -102,7 +102,6 @@ export function Terminal({
     lastUpdate: Date.now(),
   })
   const speedUpdateTimerRef = useRef<NodeJS.Timeout | null>(null)
-  const pingTimerRef = useRef<NodeJS.Timeout | null>(null)
   const { t } = useTranslation()
 
   // Keep user selection unless the current pod is no longer available.
@@ -376,15 +375,6 @@ export function Terminal({
         }
       }, 500)
 
-      if (pingTimerRef.current) clearInterval(pingTimerRef.current)
-      pingTimerRef.current = setInterval(() => {
-        if (websocket.readyState === WebSocket.OPEN) {
-          const pingMessage = JSON.stringify({ type: 'ping' })
-          websocket.send(pingMessage)
-          updateNetworkStats(new Blob([pingMessage]).size, true)
-        }
-      }, 30000)
-
       terminal.writeln(
         `\x1b[32mConnected to ${type === 'kubectl' ? 'kubectl' : type} terminal!\x1b[0m`
       )
@@ -413,9 +403,6 @@ export function Terminal({
             )
             setIsConnected(false)
             break
-          case 'pong':
-            // Ignore pong messages from server
-            break
         }
       } catch (err) {
         console.error('Failed to parse WebSocket message:', err)
@@ -434,10 +421,6 @@ export function Terminal({
       if (speedUpdateTimerRef.current) {
         clearInterval(speedUpdateTimerRef.current)
         speedUpdateTimerRef.current = null
-      }
-      if (pingTimerRef.current) {
-        clearInterval(pingTimerRef.current)
-        pingTimerRef.current = null
       }
       if (event.code !== 1000) {
         terminal.writeln('\x1b[31mConnection closed unexpectedly\x1b[0m')
@@ -504,7 +487,6 @@ export function Terminal({
       websocket.close()
       if (speedUpdateTimerRef.current)
         clearInterval(speedUpdateTimerRef.current)
-      if (pingTimerRef.current) clearInterval(pingTimerRef.current)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [

--- a/ui/src/components/workload-pods-card.tsx
+++ b/ui/src/components/workload-pods-card.tsx
@@ -1,21 +1,12 @@
 import { useState, type ReactNode } from 'react'
-import { IconExternalLink } from '@tabler/icons-react'
 import { Pod } from 'kubernetes-types/core/v1'
 import { useTranslation } from 'react-i18next'
 import { Link, useSearchParams } from 'react-router-dom'
 
 import { getPodStatus } from '@/lib/k8s'
-import { withSubPath } from '@/lib/subpath'
 import { cn, formatDate, getAge } from '@/lib/utils'
-import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from '@/components/ui/dialog'
+import { Dialog, DialogTrigger } from '@/components/ui/dialog'
 import {
   Table,
   TableBody,
@@ -24,6 +15,7 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table'
+import { ResourceIframeDialogContent } from '@/components/resource-iframe-dialog-content'
 
 type TranslationFn = ReturnType<typeof useTranslation>['t']
 
@@ -153,28 +145,7 @@ function WorkloadPodRow({ pod }: { pod: Pod }) {
                     {podName}
                   </button>
                 </DialogTrigger>
-                <DialogContent className="!h-[calc(100dvh-1rem)] !max-w-[calc(100vw-1rem)] flex min-h-0 flex-col gap-0 p-0 md:!h-[80%] md:!max-w-[80%]">
-                  <DialogHeader className="flex flex-row items-center justify-between border-b px-4 py-3 pr-14">
-                    <DialogTitle>Pod</DialogTitle>
-                    <a
-                      href={withSubPath(path)}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                    >
-                      <Button
-                        variant="outline"
-                        size="icon"
-                        aria-label="Open resource in new tab"
-                      >
-                        <IconExternalLink size={12} />
-                      </Button>
-                    </a>
-                  </DialogHeader>
-                  <iframe
-                    src={`${withSubPath(path)}?iframe=true`}
-                    className="min-h-0 w-full flex-grow border-none"
-                  />
-                </DialogContent>
+                <ResourceIframeDialogContent title="Pod" path={path} />
               </Dialog>
             )
           ) : (

--- a/ui/src/lib/api/observability.ts
+++ b/ui/src/lib/api/observability.ts
@@ -544,7 +544,6 @@ export const useLogsWebSocket = (
     },
     {
       enabled: options?.enabled !== false,
-      pingInterval: 20000, // 20 seconds for logs
       reconnectOnClose: true,
       maxReconnectAttempts: 3,
       reconnectInterval: 5000,

--- a/ui/src/lib/current-cluster.ts
+++ b/ui/src/lib/current-cluster.ts
@@ -1,19 +1,21 @@
 const CURRENT_CLUSTER_STORAGE_KEY = 'current-cluster'
 const CURRENT_CLUSTER_HEADER_KEY = 'x-cluster-name'
-const CLEAR_COOKIE_EXPIRES = 'Thu, 01 Jan 1970 00:00:00 GMT'
 
 export function getCurrentCluster() {
-  return localStorage.getItem(CURRENT_CLUSTER_STORAGE_KEY)
+  return (
+    sessionStorage.getItem(CURRENT_CLUSTER_STORAGE_KEY) ||
+    localStorage.getItem(CURRENT_CLUSTER_STORAGE_KEY)
+  )
 }
 
 export function setCurrentCluster(clusterName: string) {
+  sessionStorage.setItem(CURRENT_CLUSTER_STORAGE_KEY, clusterName)
   localStorage.setItem(CURRENT_CLUSTER_STORAGE_KEY, clusterName)
-  document.cookie = `${CURRENT_CLUSTER_HEADER_KEY}=${encodeURIComponent(clusterName)}; path=/`
 }
 
 export function clearCurrentCluster() {
+  sessionStorage.removeItem(CURRENT_CLUSTER_STORAGE_KEY)
   localStorage.removeItem(CURRENT_CLUSTER_STORAGE_KEY)
-  document.cookie = `${CURRENT_CLUSTER_HEADER_KEY}=; path=/; expires=${CLEAR_COOKIE_EXPIRES}`
 }
 
 export function appendCurrentClusterParam(params: URLSearchParams) {

--- a/ui/src/lib/useWebSocket.ts
+++ b/ui/src/lib/useWebSocket.ts
@@ -2,7 +2,6 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 export interface WebSocketOptions {
   enabled?: boolean
-  pingInterval?: number
   speedUpdateInterval?: number
   speedResetInterval?: number
   reconnectOnClose?: boolean
@@ -45,7 +44,6 @@ export interface WebSocketActions {
 
 const defaultOptions: Required<WebSocketOptions> = {
   enabled: true,
-  pingInterval: 30000,
   speedUpdateInterval: 500,
   speedResetInterval: 3000,
   reconnectOnClose: false,
@@ -72,7 +70,6 @@ export function useWebSocket(
 
   // Refs for WebSocket and timers
   const wsRef = useRef<WebSocket | null>(null)
-  const pingTimerRef = useRef<NodeJS.Timeout | null>(null)
   const speedUpdateTimerRef = useRef<NodeJS.Timeout | null>(null)
   const reconnectTimerRef = useRef<NodeJS.Timeout | null>(null)
   const reconnectAttemptsRef = useRef(0)
@@ -113,11 +110,6 @@ export function useWebSocket(
         wsRef.current.close()
       }
       wsRef.current = null
-    }
-
-    if (pingTimerRef.current) {
-      clearInterval(pingTimerRef.current)
-      pingTimerRef.current = null
     }
 
     if (speedUpdateTimerRef.current) {
@@ -175,19 +167,6 @@ export function useWebSocket(
     }, optsRef.current.speedUpdateInterval)
   }, [])
 
-  // Start ping timer
-  const startPingTimer = useCallback(() => {
-    if (pingTimerRef.current) return
-
-    pingTimerRef.current = setInterval(() => {
-      if (wsRef.current && wsRef.current.readyState === WebSocket.OPEN) {
-        const pingMessage = JSON.stringify({ type: 'ping' })
-        wsRef.current.send(pingMessage)
-        updateNetworkStats(new Blob([pingMessage]).size, true)
-      }
-    }, optsRef.current.pingInterval)
-  }, [updateNetworkStats])
-
   // Store callbacks in refs to avoid recreating connect function
   const callbacksRef = useRef(callbacks)
   const optsRef = useRef(opts)
@@ -233,7 +212,6 @@ export function useWebSocket(
 
         // Start timers
         startSpeedUpdateTimer()
-        startPingTimer()
 
         callbacksRef.current.onOpen?.()
       }
@@ -246,10 +224,6 @@ export function useWebSocket(
         setIsConnecting(false)
 
         // Clean up timers
-        if (pingTimerRef.current) {
-          clearInterval(pingTimerRef.current)
-          pingTimerRef.current = null
-        }
         if (speedUpdateTimerRef.current) {
           clearInterval(speedUpdateTimerRef.current)
           speedUpdateTimerRef.current = null
@@ -330,13 +304,7 @@ export function useWebSocket(
       )
       setIsConnecting(false)
     }
-  }, [
-    url,
-    cleanupResources,
-    startSpeedUpdateTimer,
-    startPingTimer,
-    updateNetworkStats,
-  ])
+  }, [url, cleanupResources, startSpeedUpdateTimer, updateNetworkStats])
 
   // Send message
   const send = useCallback(

--- a/ui/src/pages/helmrelease-detail.tsx
+++ b/ui/src/pages/helmrelease-detail.tsx
@@ -2,7 +2,6 @@ import { useMemo, useState, type FormEvent } from 'react'
 import {
   IconCircleCheckFilled,
   IconExclamationCircle,
-  IconExternalLink,
 } from '@tabler/icons-react'
 import * as yaml from 'js-yaml'
 import type { Container, Pod } from 'kubernetes-types/core/v1'
@@ -39,7 +38,6 @@ import {
   resourceMetadataList,
   type ResourceMetadata,
 } from '@/lib/resource-metadata'
-import { withSubPath } from '@/lib/subpath'
 import {
   formatDate,
   getAge,
@@ -74,6 +72,7 @@ import {
   MetadataListCard,
 } from '@/components/pod-overview-sidebar'
 import { PodStatusIcon } from '@/components/pod-status-icon'
+import { ResourceIframeDialogContent } from '@/components/resource-iframe-dialog-content'
 import { SimpleTable } from '@/components/simple-table'
 import { SimpleYamlEditor } from '@/components/simple-yaml-editor'
 import { WorkloadSummaryCard } from '@/components/workload-overview-parts'
@@ -182,24 +181,7 @@ function HelmReleaseResourceLink({
           {label}
         </button>
       </DialogTrigger>
-      <DialogContent className="!h-[calc(100dvh-1rem)] !max-w-[calc(100vw-1rem)] flex min-h-0 flex-col gap-0 p-0 md:!h-[80%] md:!max-w-[80%]">
-        <DialogHeader className="flex flex-row items-center justify-between border-b px-4 py-3 pr-14">
-          <DialogTitle>{resource.kind}</DialogTitle>
-          <a href={withSubPath(path)} target="_blank" rel="noopener noreferrer">
-            <Button
-              variant="outline"
-              size="icon"
-              aria-label="Open resource in new tab"
-            >
-              <IconExternalLink size={12} />
-            </Button>
-          </a>
-        </DialogHeader>
-        <iframe
-          src={`${withSubPath(path)}?iframe=true`}
-          className="min-h-0 w-full flex-grow border-none"
-        />
-      </DialogContent>
+      <ResourceIframeDialogContent title={resource.kind} path={path} />
     </Dialog>
   )
 }


### PR DESCRIPTION
## Summary

Fixes #578 by separating the tab-local active cluster from the persisted last selected cluster.

## Changes

- Use `sessionStorage` as the active cluster source for the current browser tab.
- Keep `localStorage` as the persisted fallback so reopening Kite restores the last selected cluster.
- Stop using the shared `x-cluster-name` cookie for backend cluster selection.

## Validation

- Pre-commit hook passed: Go formatting, frontend formatting, `go vet ./...`, `golangci-lint run`, and `pnpm run lint`.
- `npm run type-check` passed.
- `go test ./pkg/middleware` passed.