### PR TITLE
fix: store user avatar_url as text to avoid PostgreSQL length overflow

### DIFF
--- a/pkg/model/user.go
+++ b/pkg/model/user.go
@@ -17,7 +17,7 @@ type User struct {
 	Username    string       `json:"username" gorm:"type:varchar(50);uniqueIndex;not null"`
 	Password    string       `json:"-" gorm:"type:varchar(255)"`
 	Name        string       `json:"name,omitempty" gorm:"type:varchar(100);index"`
-	AvatarURL   string       `json:"avatar_url,omitempty" gorm:"type:varchar(500)"`
+	AvatarURL   string       `json:"avatar_url,omitempty" gorm:"type:text"`
 	Provider    string       `json:"provider,omitempty" gorm:"type:varchar(50);default:password;index"`
 	OIDCGroups  SliceString  `json:"oidc_groups,omitempty" gorm:"type:text"`
 	LastLoginAt *time.Time   `json:"lastLoginAt,omitempty" gorm:"type:timestamp;index"`


### PR DESCRIPTION
## Summary

Change `User.AvatarURL` from `varchar(500)` to `type:text`.

## Why

OIDC providers (e.g. Tailscale) can return a `picture`/avatar claim longer than 500 characters — long URLs or base64 `data:` URIs. SQLite ignores the `varchar(500)` cap, so this works there, but PostgreSQL enforces it and rejects the `INSERT` in `FindWithSubOrUpsertUser`:

```
pkg/model/user.go:122 ERROR: value too long for type character varying(500) (SQLSTATE 22001)
```

The OAuth callback swallows the error and redirects to `/login?error=user_upsert_failed`, so the user just sees a failed login. Avatar URLs are inherently unbounded, so `text` is the right type. GORM `AutoMigrate` widens the existing column automatically on the next start.

## Related issue

Closes #599

## Validation

- `go build ./pkg/model/...` — passes
- `go test ./pkg/model/...` — 85 tests pass

No new unit test added: the failure is dialect-specific (SQLite, used by the model test suite, does not enforce `varchar` lengths, so it cannot reproduce the overflow). The fix was confirmed against the SQLSTATE 22001 error on a live PostgreSQL instance.

## Checklist

- [x] I reviewed this PR myself before requesting review.
- [x] I understand the changes, including AI-generated parts (if any).
- [x] For new features, a feature request issue is linked.
- [x] I cleaned up AI noise (unnecessary comments, dead code, and unrelated changes).
- [x] This PR is reasonably scoped (or split into smaller PRs).
