### PR TITLE
fix(ui): preserve historical pod logs on websocket connect

### DIFF
--- a/ui/src/components/log-viewer-content.tsx
+++ b/ui/src/components/log-viewer-content.tsx
@@ -407,6 +407,12 @@ export function LogViewer({
 
   // Stop previous stream when critical parameters change
   useEffect(() => {
+    // Clear the editor BEFORE the new stream starts. We deliberately
+    // clear here (in response to a real parameter change) instead of on
+    // every WebSocket onopen, so that the historical tail buffer delivered
+    // by the server immediately after connect is preserved.
+    cleanLog()
+
     // Show reconnecting state when parameters change
     setIsReconnecting(true)
 
@@ -425,6 +431,7 @@ export function LogViewer({
     timestamps,
     previous,
     isLoading,
+    cleanLog,
   ])
 
   // Hide reconnecting state when loading completes

--- a/ui/src/lib/api/observability.ts
+++ b/ui/src/lib/api/observability.ts
@@ -520,10 +520,13 @@ export const useLogsWebSocket = (
 
   const handleOpen = useCallback(() => {
     console.debug('WebSocket connection opened')
-    if (options?.onClear) {
-      options.onClear()
-    }
-  }, [options])
+    // Intentionally do NOT call options.onClear here.
+    // The historical log buffer (tailLines) is delivered by the server right
+    // after the WebSocket opens. Clearing on every onopen races with that
+    // delivery and wipes out the tail history (especially on reconnects).
+    // The component is responsible for explicitly clearing the editor when
+    // the user changes pod / container / tailLines parameters.
+  }, [])
 
   const handleClose = useCallback(() => {
     console.debug('WebSocket connection closed')


### PR DESCRIPTION
## Summary

Selecting a single pod in the pod detail Logs tab failed to display the historical tail buffer (the most recent ~100 lines). The backend correctly streams the historical tail right after the WebSocket opens (client-go behavior of Follow=true + TailLines=N), but the frontend was clearing the editor inside the WebSocket onopen handler. The clear raced with the historical buffer delivery and, on reconnects, always wiped out the tail that had just been re-streamed.

## Changes:

- ui/src/lib/api/observability.ts: remove options.onClear() invocation from useLogsWebSocket's handleOpen. The hook should not unilaterally clear the consumer's view on every (re)connect; the historical buffer is delivered immediately after onopen and must not be discarded.

- ui/src/components/log-viewer-content.tsx: move the clear to the parameter-change effect. The editor is now cleared only when the user changes pod, container, tailLines, timestamps, or previous, i.e. when a fresh stream is genuinely starting. Transient WebSocket reconnects no longer drop history.

## Result:
- Initial pod selection: editor empty -> server streams last N lines -> history visible, then live tail continues.
- Parameter change: editor cleared first, then new history loaded.
- Network blip / reconnect: existing logs preserved; re-streamed tail is appended.
- Manually click "clearing logs" is unaffected.