### PR TITLE
feat(ui): filter resources by label selector from search box

### DIFF
--- a/e2e/specs/helm-kite.spec.ts
+++ b/e2e/specs/helm-kite.spec.ts
@@ -404,7 +404,7 @@ test.describe('helm kite lifecycle', () => {
       await expectAppliedPodLabel(page, releaseName, 'upgraded')
 
       await deleteReleaseFromCurrentPage(page, releaseName)
-      await page.getByPlaceholder('Search Helm Release...').fill(releaseName)
+      await page.getByPlaceholder(/^Search Helm Release/).fill(releaseName)
       await expect(page.getByRole('link', { name: releaseName })).toHaveCount(0)
       releaseDeleted = true
 

--- a/e2e/specs/resource-detail.spec.ts
+++ b/e2e/specs/resource-detail.spec.ts
@@ -10,7 +10,7 @@ test.describe('resource detail navigation', () => {
   }) => {
     await page.goto('/services')
 
-    await page.getByPlaceholder('Search services...').fill('kubernetes')
+    await page.getByPlaceholder(/^Search services/i).fill('kubernetes')
     const serviceLink = page.getByRole('link', { name: 'kubernetes' })
     await expect(serviceLink).toBeVisible()
     await serviceLink.click()
@@ -30,7 +30,7 @@ test.describe('resource detail navigation', () => {
     await page.goto('/nodes')
 
     await page
-      .getByPlaceholder('Search nodes...')
+      .getByPlaceholder(/^Search nodes/i)
       .fill(controlPlaneNodeName)
     const nodeLink = page.getByRole('link', { name: controlPlaneNodeName })
     await expect(nodeLink).toBeVisible()
@@ -87,7 +87,7 @@ spec:
     await expect(createDialog).toBeHidden()
 
     await page.goto('/pods')
-    await page.getByPlaceholder('Search pods...').fill(podName)
+    await page.getByPlaceholder(/^Search pods/i).fill(podName)
 
     const row = page.getByRole('row').filter({ hasText: podName })
     await expect(row).toBeVisible()

--- a/pkg/helmutil/release_action.go
+++ b/pkg/helmutil/release_action.go
@@ -39,12 +39,13 @@ func GetRelease(cfg *action.Configuration, name string) (*release.Release, error
 	return ReleaseFromReleaser(releaser)
 }
 
-func ListReleases(cfg *action.Configuration, allNamespaces bool) ([]*release.Release, error) {
+func ListReleases(cfg *action.Configuration, allNamespaces bool, labelSelector string) ([]*release.Release, error) {
 	listAction := action.NewList(cfg)
 	listAction.All = true
 	listAction.AllNamespaces = allNamespaces
 	listAction.StateMask = action.ListAll
 	listAction.Sort = action.ByDateDesc
+	listAction.Selector = labelSelector
 	releasers, err := listAction.Run()
 	if err != nil {
 		return nil, err

--- a/pkg/resources/cr_handler.go
+++ b/pkg/resources/cr_handler.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
@@ -97,6 +98,14 @@ func (h *CRHandler) List(c *gin.Context) {
 		if namespace != "" && namespace != common.AllNamespaces {
 			opts.Namespace = namespace
 		}
+	}
+	if labelSelector := c.Query("labelSelector"); labelSelector != "" {
+		selector, err := labels.Parse(labelSelector)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid labelSelector parameter: " + err.Error()})
+			return
+		}
+		opts.LabelSelector = selector
 	}
 
 	if err := cs.K8sClient.List(ctx, crList, opts); err != nil {

--- a/pkg/resources/helmrelease_handler.go
+++ b/pkg/resources/helmrelease_handler.go
@@ -20,6 +20,7 @@ import (
 	"helm.sh/helm/v4/pkg/action"
 	release "helm.sh/helm/v4/pkg/release/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/klog/v2"
 )
 
@@ -186,6 +187,11 @@ func (h *HelmReleaseHandler) registerCustomRoutes(group *gin.RouterGroup) {
 }
 
 func (h *HelmReleaseHandler) List(c *gin.Context) {
+	labelSelector := c.Query("labelSelector")
+	if _, err := labels.Parse(labelSelector); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid labelSelector parameter: " + err.Error()})
+		return
+	}
 	list, err := h.list(c, c.Param("namespace"), false)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
@@ -428,7 +434,7 @@ func (h *HelmReleaseHandler) list(c *gin.Context, namespace string, details bool
 	if err != nil {
 		return nil, err
 	}
-	releases, err := helmutil.ListReleases(cfg, allNamespaces)
+	releases, err := helmutil.ListReleases(cfg, allNamespaces, c.Query("labelSelector"))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/resources/node_handler.go
+++ b/pkg/resources/node_handler.go
@@ -13,6 +13,7 @@ import (
 	"github.com/zxh326/kite/pkg/kube"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
 	"k8s.io/kubectl/pkg/drain"
@@ -277,8 +278,17 @@ func (h *NodeHandler) List(c *gin.Context) {
 	cs := c.MustGet("cluster").(*cluster.ClientSet)
 	var nodeMetrics metricsv1.NodeMetricsList
 
+	var listOpts []client.ListOption
+	if labelSelector := c.Query("labelSelector"); labelSelector != "" {
+		selector, err := labels.Parse(labelSelector)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid labelSelector parameter: " + err.Error()})
+			return
+		}
+		listOpts = append(listOpts, client.MatchingLabelsSelector{Selector: selector})
+	}
 	var nodes corev1.NodeList
-	if err := cs.K8sClient.List(c.Request.Context(), &nodes); err != nil {
+	if err := cs.K8sClient.List(c.Request.Context(), &nodes, listOpts...); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to list nodes: " + err.Error()})
 		return
 	}

--- a/ui/src/components/resource-table-toolbar.tsx
+++ b/ui/src/components/resource-table-toolbar.tsx
@@ -187,7 +187,7 @@ export function ResourceTableToolbar<T>({
             <div className="relative min-w-0 flex-1 sm:w-[280px]">
               <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
               <Input
-                placeholder={`Search ${resourceName}...`}
+                placeholder={`Search ${resourceName} or app=nginx...`}
                 value={searchQuery}
                 onChange={(e) => setSearchQuery(e.target.value)}
                 className="w-full pl-9 pr-4"

--- a/ui/src/components/resource-table.tsx
+++ b/ui/src/components/resource-table.tsx
@@ -79,6 +79,7 @@ function ResourceTableContent<T>({
     setDeleteDialogOpen,
     searchQuery,
     setSearchQuery,
+    debouncedSearchQuery,
     columnVisibility,
     setColumnVisibility,
     pagination,
@@ -96,6 +97,13 @@ function ResourceTableContent<T>({
     clusterScope,
     defaultHiddenColumns,
   })
+
+  // When the query looks like a label selector (contains '='), route it to the
+  // backend API instead of the client-side name filter.
+  const isLabelSelector = searchQuery.includes('=')
+  const effectiveLabelSelector = debouncedSearchQuery.includes('=')
+    ? debouncedSearchQuery
+    : undefined
   const selectedNamespaces = useMemo(() => {
     if (!selectedNamespace || selectedNamespace === '_all') return []
     return selectedNamespace.split(',').filter(Boolean)
@@ -124,6 +132,7 @@ function ResourceTableContent<T>({
     namespace: effectiveNamespace,
     useSSE,
     refreshInterval,
+    labelSelector: effectiveLabelSelector,
   })
   const displayResourceName = (() => {
     const resource = getResourceMetadata(resolvedResourceType)
@@ -267,7 +276,7 @@ function ResourceTableContent<T>({
     state: {
       sorting,
       columnFilters,
-      globalFilter: searchQuery,
+      globalFilter: isLabelSelector ? '' : searchQuery,
       pagination,
       rowSelection,
       columnVisibility,
@@ -417,7 +426,9 @@ function ResourceTableContent<T>({
           </h3>
           <p className="text-muted-foreground">
             {searchQuery
-              ? `No results match your search query: "${searchQuery}"`
+              ? isLabelSelector
+                ? `No ${displayResourceName} match labels: "${searchQuery}"`
+                : `No results match your search query: "${searchQuery}"`
               : clusterScope
                 ? `There are no ${displayResourceName} found`
                 : `There are no ${displayResourceName} in ${namespaceDescription}`}

--- a/ui/src/components/resource-table.tsx
+++ b/ui/src/components/resource-table.tsx
@@ -98,12 +98,13 @@ function ResourceTableContent<T>({
     defaultHiddenColumns,
   })
 
-  // When the query looks like a label selector (contains '='), route it to the
-  // backend API instead of the client-side name filter.
-  const isLabelSelector = searchQuery.includes('=')
-  const effectiveLabelSelector = debouncedSearchQuery.includes('=')
-    ? debouncedSearchQuery
-    : undefined
+  // When the query looks like a label selector, route it to the backend API
+  // instead of the client-side name filter.
+  const isLabelSelector = searchQuery.includes('=') || searchQuery.includes(':')
+  const effectiveLabelSelector =
+    debouncedSearchQuery.includes('=') || debouncedSearchQuery.includes(':')
+      ? debouncedSearchQuery.replace(/:\s*/g, '=')
+      : undefined
   const selectedNamespaces = useMemo(() => {
     if (!selectedNamespace || selectedNamespace === '_all') return []
     return selectedNamespace.split(',').filter(Boolean)
@@ -238,10 +239,10 @@ function ResourceTableContent<T>({
   )
 
   useEffect(() => {
-    if (!useSSE && error) {
+    if (!useSSE && error && !effectiveLabelSelector) {
       setRefreshInterval(0)
     }
-  }, [useSSE, error, setRefreshInterval])
+  }, [useSSE, error, effectiveLabelSelector, setRefreshInterval])
 
   // Create table instance using TanStack Table
   const table = useReactTable<T>({

--- a/ui/src/hooks/use-resource-table-data.ts
+++ b/ui/src/hooks/use-resource-table-data.ts
@@ -9,6 +9,7 @@ interface UseResourceTableDataOptions {
   namespace?: string
   useSSE: boolean
   refreshInterval: number
+  labelSelector?: string
 }
 
 export function useResourceTableData<T>({
@@ -17,6 +18,7 @@ export function useResourceTableData<T>({
   namespace,
   useSSE,
   refreshInterval,
+  labelSelector,
 }: UseResourceTableDataOptions) {
   const resolvedResourceType = (resourceType ??
     (resourceName.toLowerCase() as ResourceType)) as ResourceType
@@ -25,11 +27,13 @@ export function useResourceTableData<T>({
     refreshInterval: useSSE ? 0 : refreshInterval,
     reduce: true,
     disable: useSSE,
+    labelSelector,
   })
 
   const watch = useResourcesWatch(resolvedResourceType, namespace, {
     reduce: true,
     enabled: useSSE,
+    labelSelector,
   })
 
   const data = useMemo(

--- a/ui/src/hooks/use-resource-table-state.ts
+++ b/ui/src/hooks/use-resource-table-state.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import {
   ColumnFiltersState,
   PaginationState,
@@ -49,6 +49,8 @@ export function useResourceTableState({
       ) || ''
     )
   })
+  const [debouncedSearchQuery, setDebouncedSearchQuery] = useState(searchQuery)
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const [columnVisibility, setColumnVisibility] = useState<
     Record<string, boolean>
   >(() => {
@@ -115,6 +117,16 @@ export function useResourceTableState({
 
     sessionStorage.removeItem(storageKey)
   }, [resourceName, searchQuery])
+
+  useEffect(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current)
+    debounceRef.current = setTimeout(() => {
+      setDebouncedSearchQuery(searchQuery)
+    }, 500)
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current)
+    }
+  }, [searchQuery])
 
   useEffect(() => {
     localStorage.setItem(
@@ -184,6 +196,7 @@ export function useResourceTableState({
     setDeleteDialogOpen,
     searchQuery,
     setSearchQuery,
+    debouncedSearchQuery,
     columnVisibility,
     setColumnVisibility,
     pagination,


### PR DESCRIPTION
Implements #586.

## Summary

The resource table search box only supported client-side name filtering. This PR extends it to also accept Kubernetes label selector expressions (e.g. `app=nginx`, `env=prod,team=backend`), routing them to the backend list API instead of filtering in memory.

The backend already supported `?labelSelector=` on all list endpoints via `generic_resource_handler_list.go` and on the pod watch endpoint via `pod_handler.go`. No backend changes were needed.

## Changes

- `ui/src/hooks/use-resource-table-state.ts`: added `debouncedSearchQuery` — a 500ms debounced mirror of `searchQuery`, used to avoid firing an API call on every keystroke while the user is still typing the selector expression.

- `ui/src/hooks/use-resource-table-data.ts`: added `labelSelector?: string` option, passed through to both `useResources` (polling) and `useResourcesWatch` (SSE).

- `ui/src/components/resource-table.tsx`: derives `isLabelSelector` from whether `searchQuery` contains `=` (valid K8s resource names cannot contain `=`, so this is unambiguous). When true: passes `debouncedSearchQuery` as `labelSelector` to the data hook, and clears `globalFilter` to prevent TanStack Table from running a conflicting client-side filter on top of the server-filtered results. Also updates the empty-state message to reflect label filtering.

- `ui/src/components/resource-table-toolbar.tsx`: updated search box placeholder to `Search {resource} or app=nginx...` to hint at the dual behavior.

## Behavior

| Input | Route | Example |
|-------|-------|---------|
| Plain text | Client-side (existing behavior) | `nginx` |
| Contains `=` | Backend `?labelSelector=` | `app=nginx,env=prod` |