### PR TITLE
feat: enrich StorageClass views

### DIFF
--- a/pkg/common/resource.go
+++ b/pkg/common/resource.go
@@ -142,7 +142,7 @@ var Registry = []ResourceMeta{
 	{Kind: "ServiceCIDR", Singular: "servicecidr", Plural: ServiceCIDRs, Group: "networking.k8s.io", Version: "v1", ClusterScoped: true},
 
 	// storage.k8s.io/v1
-	{Kind: "StorageClass", Singular: "storageclass", Plural: StorageClasses, Short: []string{"sc"}, Group: "storage.k8s.io", Version: "v1", ClusterScoped: true},
+	{Kind: "StorageClass", Singular: "storageclass", Plural: StorageClasses, Short: []string{"sc"}, Group: "storage.k8s.io", Version: "v1", ClusterScoped: true, Related: true},
 	{Kind: "VolumeAttachment", Singular: "volumeattachment", Plural: VolumeAttachments, Group: "storage.k8s.io", Version: "v1", ClusterScoped: true},
 	{Kind: "CSIDriver", Singular: "csidriver", Plural: CSIDrivers, Group: "storage.k8s.io", Version: "v1", ClusterScoped: true},
 	{Kind: "CSINode", Singular: "csinode", Plural: CSINodes, Group: "storage.k8s.io", Version: "v1", ClusterScoped: true},

--- a/pkg/resources/handler.go
+++ b/pkg/resources/handler.go
@@ -208,14 +208,24 @@ func RegisterRoutes(group *gin.RouterGroup) {
 	}
 
 	for _, resourceType := range common.RelatedResourceTypes() {
-		if handler, exists := handlers[resourceType]; exists && !handler.IsClusterScoped() {
-			g := group.Group("/" + resourceType)
-			g.GET("/:namespace/:name/related", func(c *gin.Context) {
-				// Set the resource type in the context for GetRelatedResources
-				c.Set("resource", resourceType)
-				GetRelatedResources(c)
-			})
+		handler, exists := handlers[resourceType]
+		if !exists {
+			continue
 		}
+		path := "/:namespace/:name/related"
+		if handler.IsClusterScoped() {
+			path = "/_all/:name/related"
+		}
+		relatedHandler := GetRelatedResources
+		if resourceType == string(common.StorageClasses) {
+			relatedHandler = getStorageClassRelatedResources
+		}
+		g := group.Group("/" + resourceType)
+		g.GET(path, func(c *gin.Context) {
+			// Set the resource type in the context for related resource handlers
+			c.Set("resource", resourceType)
+			relatedHandler(c)
+		})
 	}
 
 	crHandler := NewCRHandler()

--- a/pkg/resources/related_resources.go
+++ b/pkg/resources/related_resources.go
@@ -402,6 +402,20 @@ func getStorageClassRelatedResources(c *gin.Context) {
 	c.JSON(http.StatusOK, result)
 }
 
+func getPersistentVolumeClaimRelatedResources(pvc *corev1.PersistentVolumeClaim) []common.RelatedResource {
+	result := make([]common.RelatedResource, 0, 2)
+	if pvc.Spec.StorageClassName != nil && *pvc.Spec.StorageClassName != "" {
+		result = append(result, common.RelatedResource{
+			Type: string(common.StorageClasses),
+			Name: *pvc.Spec.StorageClassName,
+		})
+	}
+	return append(result, common.RelatedResource{
+		Type: string(common.PersistentVolumes),
+		Name: pvc.Spec.VolumeName,
+	})
+}
+
 func GetRelatedResources(c *gin.Context) {
 	cs := c.MustGet("cluster").(*cluster.ClientSet)
 	namespace := c.Param("namespace")
@@ -450,10 +464,8 @@ func GetRelatedResources(c *gin.Context) {
 			return
 		} else {
 			if resourceType == string(common.PersistentVolumeClaims) {
-				result = append(result, common.RelatedResource{
-					Type: string(common.PersistentVolumes),
-					Name: res.(*corev1.PersistentVolumeClaim).Spec.VolumeName,
-				})
+				pvc := res.(*corev1.PersistentVolumeClaim)
+				result = append(result, getPersistentVolumeClaimRelatedResources(pvc)...)
 			}
 			result = append(result, workloads...)
 		}

--- a/pkg/resources/related_resources.go
+++ b/pkg/resources/related_resources.go
@@ -10,6 +10,8 @@ import (
 	"github.com/zxh326/kite/pkg/cluster"
 	"github.com/zxh326/kite/pkg/common"
 	"github.com/zxh326/kite/pkg/kube"
+	"github.com/zxh326/kite/pkg/model"
+	"github.com/zxh326/kite/pkg/rbac"
 	"golang.org/x/sync/errgroup"
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
@@ -366,6 +368,38 @@ func appendMatchingPodDisruptionBudget(relatedPDBs []common.RelatedResource, nam
 
 func isEmptyLabelSelector(selector *metav1.LabelSelector) bool {
 	return len(selector.MatchLabels) == 0 && len(selector.MatchExpressions) == 0
+}
+
+func getStorageClassRelatedResources(c *gin.Context) {
+	cs := c.MustGet("cluster").(*cluster.ClientSet)
+	name := c.Param("name")
+	if _, err := GetResource(c, string(common.StorageClasses), common.AllNamespaces, name); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to get resource: " + err.Error()})
+		return
+	}
+
+	var pvcList corev1.PersistentVolumeClaimList
+	if err := cs.K8sClient.List(c.Request.Context(), &pvcList); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to discover PVCs: " + err.Error()})
+		return
+	}
+
+	user := c.MustGet("user").(model.User)
+	result := make([]common.RelatedResource, 0)
+	for _, pvc := range pvcList.Items {
+		if pvc.Spec.StorageClassName == nil || *pvc.Spec.StorageClassName != name {
+			continue
+		}
+		if !rbac.CanAccess(user, string(common.PersistentVolumeClaims), string(common.VerbGet), cs.Name, pvc.Namespace) {
+			continue
+		}
+		result = append(result, common.RelatedResource{
+			Type:      string(common.PersistentVolumeClaims),
+			Name:      pvc.Name,
+			Namespace: pvc.Namespace,
+		})
+	}
+	c.JSON(http.StatusOK, result)
 }
 
 func GetRelatedResources(c *gin.Context) {

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -539,6 +539,22 @@
   "services": {
     "title": "Services"
   },
+  "storageClasses": {
+    "fields": {
+      "provisioner": "Provisioner",
+      "volumeBindingMode": "Volume Binding Mode",
+      "allowVolumeExpansion": "Allow Volume Expansion",
+      "default": "Default"
+    },
+    "actions": {
+      "setDefault": "Set as Default",
+      "settingDefault": "Setting..."
+    },
+    "messages": {
+      "clearDefaultsFailed": "Some previous default StorageClasses could not be cleared. Choose the desired default again to retry.",
+      "setDefaultSuccess": "{{name}} is now the default StorageClass"
+    }
+  },
   "nodes": {
     "title": "Nodes"
   },

--- a/ui/src/i18n/locales/zh.json
+++ b/ui/src/i18n/locales/zh.json
@@ -544,6 +544,22 @@
   "services": {
     "title": "Services"
   },
+  "storageClasses": {
+    "fields": {
+      "provisioner": "供应类型（Provisioner）",
+      "volumeBindingMode": "卷绑定模式",
+      "allowVolumeExpansion": "允许扩容",
+      "default": "默认"
+    },
+    "actions": {
+      "setDefault": "设为默认",
+      "settingDefault": "设置中..."
+    },
+    "messages": {
+      "clearDefaultsFailed": "部分旧的默认 StorageClass 未能取消，请再次选择目标默认项重试。",
+      "setDefaultSuccess": "已将 {{name}} 设为默认 StorageClass"
+    }
+  },
   "nodes": {
     "title": "Nodes"
   },

--- a/ui/src/pages/resource-definitions.tsx
+++ b/ui/src/pages/resource-definitions.tsx
@@ -41,6 +41,7 @@ import { ServiceDetail } from './service-detail'
 import { ServiceListPage } from './service-list-page'
 import { StatefulSetDetail } from './statefulset-detail'
 import { StatefulSetListPage } from './statefulset-list-page'
+import { StorageClassListPage } from './storageclass-list-page'
 
 export type ResourceScope = 'cluster' | 'namespace'
 
@@ -151,6 +152,10 @@ function getResourceViews(resourceType: ResourceType): ResourceViewDefinition {
     case 'persistentvolumeclaims':
       return {
         listPage: () => <PVCListPage />,
+      }
+    case 'storageclasses':
+      return {
+        listPage: () => <StorageClassListPage />,
       }
     case 'horizontalpodautoscalers':
       return {

--- a/ui/src/pages/storageclass-list-page.tsx
+++ b/ui/src/pages/storageclass-list-page.tsx
@@ -1,0 +1,183 @@
+import { useMemo } from 'react'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { createColumnHelper } from '@tanstack/react-table'
+import { StorageClass } from 'kubernetes-types/storage/v1'
+import { useTranslation } from 'react-i18next'
+import { Link } from 'react-router-dom'
+import { toast } from 'sonner'
+
+import { patchResource, useResources } from '@/lib/api'
+import { createSearchFilter } from '@/lib/k8s'
+import { formatDate, translateError } from '@/lib/utils'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { ResourceTable } from '@/components/resource-table'
+
+const defaultStorageClassAnnotation =
+  'storageclass.kubernetes.io/is-default-class'
+const betaDefaultStorageClassAnnotation =
+  'storageclass.beta.kubernetes.io/is-default-class'
+
+function isDefaultStorageClass(storageClass: StorageClass) {
+  const annotations = storageClass.metadata?.annotations
+  return (
+    annotations?.[defaultStorageClassAnnotation] === 'true' ||
+    annotations?.[betaDefaultStorageClassAnnotation] === 'true'
+  )
+}
+
+const storageClassSearchFilter = createSearchFilter<StorageClass>(
+  (storageClass) => storageClass.metadata?.name,
+  (storageClass) => storageClass.provisioner
+)
+
+const columnHelper = createColumnHelper<StorageClass>()
+
+export function StorageClassListPage() {
+  const { t } = useTranslation()
+  const queryClient = useQueryClient()
+  const { data: storageClasses = [] } = useResources(
+    'storageclasses',
+    undefined,
+    { reduce: true }
+  )
+  const defaultStorageClassCount = storageClasses.filter(
+    isDefaultStorageClass
+  ).length
+  const setDefaultMutation = useMutation({
+    mutationFn: async (storageClass: StorageClass) => {
+      const name = storageClass.metadata!.name!
+      const currentDefaults = storageClasses.filter(
+        (item) => item.metadata?.name !== name && isDefaultStorageClass(item)
+      )
+
+      await patchResource('storageclasses', name, undefined, {
+        metadata: {
+          annotations: {
+            [defaultStorageClassAnnotation]: 'true',
+          },
+        },
+      })
+      const results = await Promise.allSettled(
+        currentDefaults.map((item) =>
+          patchResource('storageclasses', item.metadata!.name!, undefined, {
+            metadata: {
+              annotations: {
+                [defaultStorageClassAnnotation]: 'false',
+                [betaDefaultStorageClassAnnotation]: 'false',
+              },
+            },
+          })
+        )
+      )
+      if (results.some((result) => result.status === 'rejected')) {
+        throw new Error(t('storageClasses.messages.clearDefaultsFailed'))
+      }
+    },
+    onSuccess: (_, storageClass) => {
+      toast.success(
+        t('storageClasses.messages.setDefaultSuccess', {
+          name: storageClass.metadata!.name,
+        })
+      )
+    },
+    onError: (error) => {
+      toast.error(translateError(error, t))
+    },
+    onSettled: () =>
+      queryClient.invalidateQueries({ queryKey: ['storageclasses'] }),
+  })
+
+  const columns = useMemo(
+    () => [
+      columnHelper.accessor('metadata.name', {
+        header: t('common.fields.name'),
+        cell: ({ row }) => (
+          <div className="font-medium app-link">
+            <Link to={`/storageclasses/${row.original.metadata!.name}`}>
+              {row.original.metadata!.name}
+            </Link>
+          </div>
+        ),
+      }),
+      columnHelper.accessor('provisioner', {
+        header: t('storageClasses.fields.provisioner'),
+        enableColumnFilter: true,
+      }),
+      columnHelper.accessor('reclaimPolicy', {
+        header: t('common.fields.reclaimPolicy'),
+        cell: ({ getValue }) => getValue() || 'Delete',
+      }),
+      columnHelper.accessor('volumeBindingMode', {
+        header: t('storageClasses.fields.volumeBindingMode'),
+        cell: ({ getValue }) => getValue() || 'Immediate',
+      }),
+      columnHelper.accessor('allowVolumeExpansion', {
+        header: t('storageClasses.fields.allowVolumeExpansion'),
+        cell: ({ getValue }) =>
+          getValue() === true ? t('common.values.yes') : t('common.values.no'),
+      }),
+      columnHelper.accessor(isDefaultStorageClass, {
+        id: 'default',
+        header: t('storageClasses.fields.default'),
+        cell: ({ getValue }) =>
+          getValue() ? (
+            <Badge variant="secondary">
+              {t('storageClasses.fields.default')}
+            </Badge>
+          ) : (
+            '-'
+          ),
+      }),
+      columnHelper.accessor('metadata.creationTimestamp', {
+        header: t('common.fields.created'),
+        cell: ({ getValue }) => (
+          <span className="text-muted-foreground text-sm tabular-nums">
+            {formatDate(getValue() || '')}
+          </span>
+        ),
+      }),
+      columnHelper.display({
+        id: 'actions',
+        header: t('common.fields.actions'),
+        cell: ({ row }) => {
+          if (
+            isDefaultStorageClass(row.original) &&
+            defaultStorageClassCount === 1
+          ) {
+            return '-'
+          }
+
+          const isCurrent =
+            setDefaultMutation.variables?.metadata?.name ===
+            row.original.metadata?.name
+
+          return (
+            <Button
+              variant="link"
+              size="sm"
+              className="h-auto p-0"
+              disabled={setDefaultMutation.isPending}
+              onClick={() => setDefaultMutation.mutate(row.original)}
+            >
+              {isCurrent && setDefaultMutation.isPending
+                ? t('storageClasses.actions.settingDefault')
+                : t('storageClasses.actions.setDefault')}
+            </Button>
+          )
+        },
+      }),
+    ],
+    [defaultStorageClassCount, setDefaultMutation, t]
+  )
+
+  return (
+    <ResourceTable
+      resourceName="StorageClasses"
+      resourceType="storageclasses"
+      columns={columns}
+      clusterScope={true}
+      searchQueryFilter={storageClassSearchFilter}
+    />
+  )
+}


### PR DESCRIPTION
## What changed

- add a dedicated StorageClass list with provisioner, reclaim policy, volume binding mode, expansion support, default state, creation time, and actions
- add name search and provisioner filtering
- allow operators to set a StorageClass as default while clearing stable and legacy default annotations from previous defaults
- keep retry actions available if multiple defaults remain, and add English and Chinese translations
- show PVCs that reference a StorageClass in its existing Overview and Related views
- show each PVC's StorageClass in the PVC Related view
- filter cross-namespace PVC results by the viewer's PVC read permissions

## Why

StorageClasses previously used the generic resource list, which only exposed the name and creation time and provided no workflow for changing the cluster default. Their detail page also had no related-resource backend for discovering PVCs that use the StorageClass, and PVC details did not link back to their StorageClass.

## Impact

Operators can compare important StorageClass settings, switch the default without editing YAML, and navigate the StorageClass/PVC relationship in either direction from resource details.

## Validation

- `make pre-commit`
- `go test ./pkg/resources ./pkg/common`
- `pnpm --dir ui run type-check`
- `pnpm --dir ui run build`

Fixes #620