### PR TITLE
feat: GPU 佔用顯示插件(卡級 DCGM 即時視圖 + 節點 GPU 重置)

### DIFF
--- a/GPU-PLUGIN.md
+++ b/GPU-PLUGIN.md
@@ -1,0 +1,98 @@
+# GPU 佔用顯示插件(fork 功能)
+
+當叢集有 GPU 時,側邊欄自動出現「GPU」頁面,顯示:
+
+- 全叢集 GPU 總卡數 / 已佔用 / 空閒
+- 依節點分組,每張卡一格:佔用中的卡顯示 pod / container(可點擊跳轉),空卡顯示 Idle
+- 偵測到 dcgm-exporter 時自動升級為卡級即時資料:每卡使用率、顯存、實體卡 UUID 與 pod 歸屬
+- 每個節點提供「重置 GPU」按鈕:刪除該節點的 nvidia-device-plugin pod(DaemonSet 自動重建)以重新註冊 GPU
+
+無 GPU 的叢集不顯示選單;多叢集各自獨立偵測,切換叢集即時生效。
+
+## 部署需求
+
+### 1.(必要)dcgm-exporter 設定 —— 卡級 pod 歸屬
+
+要正確抓取每張卡上的佔用資訊,dcgm-exporter **必須**同時設定:
+
+```yaml
+# gpu-operator ClusterPolicy → spec.dcgmExporter.env
+- name: DCGM_EXPORTER_KUBERNETES
+  value: "true"
+- name: DCGM_EXPORTER_KUBERNETES_GPU_ID_TYPE
+  value: "uid"        # ← 關鍵,絕不能是 device-name
+```
+
+**為什麼 `uid` 是關鍵**:exporter 透過 kubelet podresources API 對應「哪個 pod 分到哪張卡」。nvidia device plugin 向 kubelet 回報的裝置 ID 是 GPU UUID;若設成 `device-name`(以 `nvidia0` 這類名稱比對)會永遠對不上,metrics 完全不帶 pod label,頁面上所有卡都會顯示 Idle、無法正確抓取佔用狀態。
+
+既有叢集修正方式(gpu-operator 會自動 rolling restart exporter,一次一台,不影響工作負載):
+
+```bash
+kubectl patch clusterpolicy cluster-policy --type json -p '[
+  {"op":"test","path":"/spec/dcgmExporter/env/2/name","value":"DCGM_EXPORTER_KUBERNETES_GPU_ID_TYPE"},
+  {"op":"replace","path":"/spec/dcgmExporter/env/2/value","value":"uid"}
+]'
+```
+
+> **注意**:若 gpu-operator 由 Helm 管理,請同步把上述 env 寫入 values,否則下次 `helm upgrade` 會沖掉。
+> `env/2` 的 index 依實際 env 陣列順序調整,`test` op 會保護改錯位置。
+
+### 2. Prometheus URL(dcgm 卡級模式的前提)
+
+kite 會自動發現叢集內的 Prometheus,但**只認 9090 / 8429 port**。VictoriaMetrics 的 `vmsingle` 預設 **8428** 不會被發現,需在 kite 管理介面(設定 → 叢集)手動填入,例如:
+
+```
+http://vmsingle-vmks.monitoring.svc.cluster.local:8428
+```
+
+`.svc` 開頭的 URL kite 會自動經該叢集的 API server proxy 存取,kite 本體部署在哪個叢集都可以。
+
+### 3. 降級行為(自動,無需設定)
+
+| 條件 | 顯示層級 |
+|---|---|
+| 只有 K8s API | **排程視圖**:依 Pod resource requests 推算佔用數量,合成卡格 |
+| + Prometheus + dcgm-exporter | **卡級即時**:每卡使用率 / 顯存 / UUID |
+| + `GPU_ID_TYPE=uid` | 卡級 + **每卡 pod 歸屬**(完整功能) |
+
+dcgm 查詢失敗時自動退回排程視圖,不會讓頁面出錯。偵測結果每叢集快取 60 秒。
+
+### 4. RBAC
+
+- GPU 頁面:需具備該叢集存取權(同 overview / prometheus endpoints 水位)
+- 重置 GPU(刪 device-plugin pod):額外檢查該 namespace 的 `pods` `delete` 權限,並記錄操作者於 log
+
+### 5. 支援的 GPU 資源類型
+
+預設 `nvidia.com/gpu`。可用環境變數擴充(未知的 key 以數量級追蹤):
+
+```
+GPU_RESOURCE_KEYS=nvidia.com/gpu,amd.com/gpu
+```
+
+## API
+
+| Method | Path | 說明 |
+|---|---|---|
+| GET | `/api/v1/plugins` | 各插件對當前叢集的啟用狀態(前端據此顯示/隱藏選單) |
+| GET | `/api/v1/plugins/gpu/overview` | 整頁資料:summary、各節點卡格、pod 歸屬 |
+| POST | `/api/v1/plugins/gpu/nodes/:node/reset-device-plugin` | 刪除該節點 device-plugin pod;`?dryRun=true` 僅預覽目標 |
+
+## 架構與上游 merge
+
+本功能以輕量插件層實作,程式碼自成一體:
+
+```
+pkg/plugins/registry.go     插件 interface 與註冊表
+pkg/plugins/gpu/            GPU 插件後端
+ui/src/plugins/index.tsx    前端插件註冊層
+ui/src/plugins/gpu/         GPU 插件前端(含自帶 i18n)
+```
+
+核心檔案僅各插入 1–2 行 hook,全部以 `kite-fork` 註解標記:
+
+- `routes.go` — `pluginsall.RegisterRoutes(api)`(於 RBACMiddleware 之前)
+- `ui/src/routes.tsx` — spread `...pluginRoutes`
+- `ui/src/components/app-sidebar.tsx` — `<PluginSidebarItems />`
+
+merge 上游後若 hook 遺失,`grep -rn "kite-fork"` 找回插入點即可。新增插件:實作 `plugins.Plugin` interface + 在 `pkg/plugins/all` blank import;前端加一個 descriptor 到 `ui/src/plugins/index.tsx`。

--- a/pkg/plugins/all/all.go
+++ b/pkg/plugins/all/all.go
@@ -1,0 +1,14 @@
+// Package all collects every plugin's blank import so that routes.go only
+// needs to import this single package.
+package all
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/zxh326/kite/pkg/plugins"
+
+	_ "github.com/zxh326/kite/pkg/plugins/gpu"
+)
+
+func RegisterRoutes(api *gin.RouterGroup) {
+	plugins.RegisterRoutes(api)
+}

--- a/pkg/plugins/gpu/allocation.go
+++ b/pkg/plugins/gpu/allocation.go
@@ -1,0 +1,170 @@
+package gpu
+
+import (
+	"context"
+	"sort"
+
+	"github.com/zxh326/kite/pkg/kube"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// buildOverview assembles the basic (scheduler view) overview from the
+// Kubernetes API: node allocatable vs. GPU requests of active pods.
+func buildOverview(ctx context.Context, k8sClient *kube.K8sClient, keys []GPUResourceKey) (*Overview, error) {
+	gpuNodes, err := listGPUNodes(ctx, k8sClient, keys)
+	if err != nil {
+		return nil, err
+	}
+
+	overview := &Overview{
+		Level: levelBasic,
+		Nodes: make([]NodeGPU, 0, len(gpuNodes)),
+	}
+	for _, k := range keys {
+		overview.ResourceKeys = append(overview.ResourceKeys, string(k.Key))
+	}
+
+	podsByNode := listPodsByNode(ctx, k8sClient, gpuNodes)
+	for i := range gpuNodes {
+		node := &gpuNodes[i]
+		nodeGPU := NodeGPU{
+			Name:      node.Name,
+			Ready:     isNodeReady(node),
+			Resources: []NodeResource{},
+		}
+		for _, k := range keys {
+			allocatable, ok := node.Status.Allocatable[k.Key]
+			if !ok || allocatable.IsZero() {
+				continue
+			}
+			if nodeGPU.GPUModel == "" && k.ProductLabel != "" {
+				nodeGPU.GPUModel = node.Labels[k.ProductLabel]
+			}
+			allocated, pods := podAllocations(podsByNode[node.Name], k.Key)
+			nodeGPU.Resources = append(nodeGPU.Resources, NodeResource{
+				Key:         string(k.Key),
+				Allocatable: allocatable.Value(),
+				Allocated:   allocated,
+				Pods:        pods,
+			})
+			overview.Summary.TotalGPUs += allocatable.Value()
+			overview.Summary.AllocatedGPUs += allocated
+		}
+		overview.Nodes = append(overview.Nodes, nodeGPU)
+	}
+	sort.Slice(overview.Nodes, func(i, j int) bool {
+		return overview.Nodes[i].Name < overview.Nodes[j].Name
+	})
+	overview.Summary.FreeGPUs = overview.Summary.TotalGPUs - overview.Summary.AllocatedGPUs
+	if overview.Summary.FreeGPUs < 0 {
+		overview.Summary.FreeGPUs = 0
+	}
+	return overview, nil
+}
+
+func listGPUNodes(ctx context.Context, k8sClient *kube.K8sClient, keys []GPUResourceKey) ([]corev1.Node, error) {
+	var nodes corev1.NodeList
+	if err := k8sClient.List(ctx, &nodes); err != nil {
+		return nil, err
+	}
+	var gpuNodes []corev1.Node
+	for i := range nodes.Items {
+		if nodeGPUCount(&nodes.Items[i], keys) > 0 {
+			gpuNodes = append(gpuNodes, nodes.Items[i])
+		}
+	}
+	return gpuNodes, nil
+}
+
+func nodeGPUCount(node *corev1.Node, keys []GPUResourceKey) int64 {
+	var total int64
+	for _, k := range keys {
+		if q, ok := node.Status.Allocatable[k.Key]; ok {
+			total += q.Value()
+		}
+	}
+	return total
+}
+
+// listPodsByNode mirrors listNodeResourceRequests in pkg/resources: with the
+// informer cache it lists per node via the spec.nodeName field index,
+// otherwise it lists all pods once and groups them.
+func listPodsByNode(ctx context.Context, k8sClient *kube.K8sClient, nodes []corev1.Node) map[string][]corev1.Pod {
+	podsByNode := make(map[string][]corev1.Pod, len(nodes))
+	if !k8sClient.CacheEnabled {
+		var allPods corev1.PodList
+		if err := k8sClient.List(ctx, &allPods); err != nil {
+			klog.Warningf("gpu plugin: failed to list pods: %v", err)
+			return podsByNode
+		}
+		for _, pod := range allPods.Items {
+			if pod.Spec.NodeName != "" {
+				podsByNode[pod.Spec.NodeName] = append(podsByNode[pod.Spec.NodeName], pod)
+			}
+		}
+		return podsByNode
+	}
+
+	for i := range nodes {
+		var nodePods corev1.PodList
+		if err := k8sClient.List(ctx, &nodePods, client.MatchingFields{"spec.nodeName": nodes[i].Name}); err != nil {
+			klog.Warningf("gpu plugin: failed to list pods for node %s: %v", nodes[i].Name, err)
+			continue
+		}
+		podsByNode[nodes[i].Name] = nodePods.Items
+	}
+	return podsByNode
+}
+
+// podAllocations sums the GPU requests of active pods for one resource key.
+// Only Running and Pending pods count: Succeeded/Failed pods no longer hold
+// devices. GPUs are extended resources where requests must equal limits, so
+// Limits is authoritative.
+func podAllocations(pods []corev1.Pod, key corev1.ResourceName) (int64, []PodAllocation) {
+	var total int64
+	allocations := []PodAllocation{}
+	for i := range pods {
+		pod := &pods[i]
+		if pod.Status.Phase != corev1.PodRunning && pod.Status.Phase != corev1.PodPending {
+			continue
+		}
+		var containers []ContainerAllocation
+		var podCount int64
+		for _, container := range pod.Spec.Containers {
+			q, ok := container.Resources.Limits[key]
+			if !ok || q.IsZero() {
+				continue
+			}
+			containers = append(containers, ContainerAllocation{Name: container.Name, Count: q.Value()})
+			podCount += q.Value()
+		}
+		if podCount == 0 {
+			continue
+		}
+		total += podCount
+		allocations = append(allocations, PodAllocation{
+			Namespace:  pod.Namespace,
+			Name:       pod.Name,
+			Count:      podCount,
+			Containers: containers,
+		})
+	}
+	sort.Slice(allocations, func(i, j int) bool {
+		if allocations[i].Namespace != allocations[j].Namespace {
+			return allocations[i].Namespace < allocations[j].Namespace
+		}
+		return allocations[i].Name < allocations[j].Name
+	})
+	return total, allocations
+}
+
+func isNodeReady(node *corev1.Node) bool {
+	for _, cond := range node.Status.Conditions {
+		if cond.Type == corev1.NodeReady {
+			return cond.Status == corev1.ConditionTrue
+		}
+	}
+	return false
+}

--- a/pkg/plugins/gpu/dcgm.go
+++ b/pkg/plugins/gpu/dcgm.go
@@ -1,0 +1,210 @@
+package gpu
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	prommodel "github.com/prometheus/common/model"
+	"github.com/zxh326/kite/pkg/cluster"
+)
+
+const mib = 1024 * 1024
+
+// enrichWithCards upgrades a basic overview with per-card data from the
+// vendor exporters (dcgm-exporter for NVIDIA). It mutates overview only on
+// success; on error the caller keeps serving the basic view.
+func enrichWithCards(ctx context.Context, cs *cluster.ClientSet, keys []GPUResourceKey, overview *Overview) error {
+	if cs.PromClient == nil {
+		return fmt.Errorf("prometheus client not available")
+	}
+
+	cards := map[string]*Card{}
+	cardNode := map[string]string{}
+	for _, k := range keys {
+		if k.Exporter == nil {
+			continue
+		}
+		utilVec, err := queryVector(ctx, cs, k.Exporter.UtilMetric)
+		if err != nil {
+			return err
+		}
+		if len(utilVec) == 0 {
+			continue
+		}
+		// With honor_labels=false Prometheus renames the exporter's own
+		// workload labels to exported_*, while plain pod/namespace describe
+		// the dcgm-exporter pod itself. If any sample carries exported_pod,
+		// only trust the exported_* variant for the whole family.
+		exportedOnly := false
+		for _, s := range utilVec {
+			if labelOf(s.Metric, "exported_pod") != "" {
+				exportedOnly = true
+				break
+			}
+		}
+		for _, s := range utilVec {
+			id := cardID(s.Metric)
+			if id == "" {
+				continue
+			}
+			card := &Card{
+				Index:       labelOf(s.Metric, "gpu", "device"),
+				UUID:        labelOf(s.Metric, "UUID", "uuid"),
+				ModelName:   labelOf(s.Metric, "modelName", "DCGM_FI_DEV_NAME"),
+				Utilization: float64(s.Value),
+				Occupant:    occupantOf(s.Metric, exportedOnly),
+			}
+			cards[id] = card
+			cardNode[id] = labelOf(s.Metric, "Hostname", "kubernetes_node", "node")
+		}
+
+		usedVec, err := queryVector(ctx, cs, k.Exporter.MemUsedMetric)
+		if err == nil {
+			for _, s := range usedVec {
+				if card, ok := cards[cardID(s.Metric)]; ok {
+					card.MemoryUsedBytes = int64(s.Value) * mib
+				}
+			}
+		}
+		totalVec, err := queryVector(ctx, cs, k.Exporter.MemTotalMetric)
+		if err == nil && len(totalVec) > 0 {
+			for _, s := range totalVec {
+				if card, ok := cards[cardID(s.Metric)]; ok {
+					card.MemoryTotalBytes = int64(s.Value) * mib
+				}
+			}
+		} else if k.Exporter.MemFreeMetric != "" {
+			freeVec, err := queryVector(ctx, cs, k.Exporter.MemFreeMetric)
+			if err == nil {
+				for _, s := range freeVec {
+					if card, ok := cards[cardID(s.Metric)]; ok {
+						card.MemoryTotalBytes = card.MemoryUsedBytes + int64(s.Value)*mib
+					}
+				}
+			}
+		}
+	}
+
+	if len(cards) == 0 {
+		return fmt.Errorf("no card series found")
+	}
+
+	nodeIndex := make(map[string]*NodeGPU, len(overview.Nodes))
+	for i := range overview.Nodes {
+		nodeIndex[overview.Nodes[i].Name] = &overview.Nodes[i]
+	}
+	var unassigned []Card
+	for id, card := range cards {
+		if node, ok := nodeIndex[cardNode[id]]; ok {
+			node.Cards = append(node.Cards, *card)
+		} else {
+			unassigned = append(unassigned, *card)
+		}
+	}
+	for i := range overview.Nodes {
+		sortCards(overview.Nodes[i].Cards)
+	}
+	sortCards(unassigned)
+
+	overview.Level = levelDCGM
+	overview.UnassignedCards = unassigned
+	return nil
+}
+
+func queryVector(ctx context.Context, cs *cluster.ClientSet, metric string) (prommodel.Vector, error) {
+	if metric == "" {
+		return nil, nil
+	}
+	val, _, err := cs.PromClient.Query(ctx, metric, time.Now())
+	if err != nil {
+		return nil, err
+	}
+	vec, ok := val.(prommodel.Vector)
+	if !ok {
+		return nil, fmt.Errorf("unexpected result type %T for %s", val, metric)
+	}
+	return vec, nil
+}
+
+// labelOf returns the first non-empty label among names. dcgm-exporter
+// versions and scrape configs disagree on label names, so every lookup goes
+// through a candidate list.
+func labelOf(m prommodel.Metric, names ...string) string {
+	for _, n := range names {
+		if v, ok := m[prommodel.LabelName(n)]; ok && v != "" {
+			return string(v)
+		}
+	}
+	return ""
+}
+
+// cardID identifies a card across metric families. MIG instances share the
+// parent UUID, so GPU_I_ID is part of the key.
+func cardID(m prommodel.Metric) string {
+	id := labelOf(m, "UUID", "uuid")
+	if id == "" {
+		id = labelOf(m, "Hostname", "kubernetes_node", "node", "instance") + "/gpu-" + labelOf(m, "gpu", "device")
+	}
+	if gi := labelOf(m, "GPU_I_ID"); gi != "" {
+		id += "/mig-" + gi
+	}
+	return id
+}
+
+func occupantOf(m prommodel.Metric, exportedOnly bool) *Occupant {
+	if pod := labelOf(m, "exported_pod"); pod != "" {
+		return &Occupant{
+			Namespace: labelOf(m, "exported_namespace"),
+			Pod:       pod,
+			Container: labelOf(m, "exported_container"),
+		}
+	}
+	if exportedOnly {
+		return nil
+	}
+	pod := labelOf(m, "pod")
+	if pod == "" || isSelfReference(m) {
+		return nil
+	}
+	return &Occupant{
+		Namespace: labelOf(m, "namespace"),
+		Pod:       pod,
+		Container: labelOf(m, "container"),
+	}
+}
+
+// isSelfReference detects series whose pod/namespace labels describe the
+// scrape target (the exporter's own pod) rather than a workload — the case
+// when dcgm-exporter runs without Kubernetes pod mapping. Target-metadata
+// pods are named after their job/service (e.g. job="nvidia-dcgm-exporter",
+// pod="nvidia-dcgm-exporter-l6wjn").
+func isSelfReference(m prommodel.Metric) bool {
+	pod := labelOf(m, "pod")
+	if pod == "" {
+		return false
+	}
+	for _, l := range []string{"job", "service"} {
+		if v := labelOf(m, l); v != "" && strings.HasPrefix(pod, v+"-") {
+			return true
+		}
+	}
+	return false
+}
+
+func sortCards(cards []Card) {
+	sort.Slice(cards, func(i, j int) bool {
+		a, errA := strconv.Atoi(cards[i].Index)
+		b, errB := strconv.Atoi(cards[j].Index)
+		if errA == nil && errB == nil && a != b {
+			return a < b
+		}
+		if cards[i].Index != cards[j].Index {
+			return cards[i].Index < cards[j].Index
+		}
+		return cards[i].UUID < cards[j].UUID
+	})
+}

--- a/pkg/plugins/gpu/detect.go
+++ b/pkg/plugins/gpu/detect.go
@@ -1,0 +1,74 @@
+package gpu
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	prommodel "github.com/prometheus/common/model"
+	"github.com/zxh326/kite/pkg/cluster"
+	"k8s.io/klog/v2"
+)
+
+const detectTTL = 60 * time.Second
+
+type detectResult struct {
+	enabled bool
+	level   string
+	expires time.Time
+}
+
+var (
+	detectMu    sync.Mutex
+	detectCache = map[string]detectResult{}
+)
+
+// detect reports whether the cluster has GPU nodes and which display level
+// is available. Results are cached per cluster for detectTTL.
+func detect(ctx context.Context, cs *cluster.ClientSet) detectResult {
+	detectMu.Lock()
+	if r, ok := detectCache[cs.Name]; ok && time.Now().Before(r.expires) {
+		detectMu.Unlock()
+		return r
+	}
+	detectMu.Unlock()
+
+	r := detectResult{level: levelBasic, expires: time.Now().Add(detectTTL)}
+	keys := ResourceKeys()
+	nodes, err := listGPUNodes(ctx, cs.K8sClient, keys)
+	if err != nil {
+		klog.Warningf("gpu plugin: failed to list nodes for cluster %s: %v", cs.Name, err)
+	}
+	r.enabled = len(nodes) > 0
+	if r.enabled && detectExporter(ctx, cs, keys) {
+		r.level = levelDCGM
+	}
+
+	detectMu.Lock()
+	detectCache[cs.Name] = r
+	detectMu.Unlock()
+	return r
+}
+
+// detectExporter checks whether any vendor's card-level exporter has series
+// in the cluster's Prometheus.
+func detectExporter(ctx context.Context, cs *cluster.ClientSet, keys []GPUResourceKey) bool {
+	if cs.PromClient == nil {
+		return false
+	}
+	for _, k := range keys {
+		if k.Exporter == nil {
+			continue
+		}
+		val, _, err := cs.PromClient.Query(ctx, fmt.Sprintf("count(%s)", k.Exporter.DetectMetric), time.Now())
+		if err != nil {
+			klog.V(4).Infof("gpu plugin: exporter detection query failed for cluster %s: %v", cs.Name, err)
+			continue
+		}
+		if vec, ok := val.(prommodel.Vector); ok && len(vec) > 0 && vec[0].Value > 0 {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/plugins/gpu/gpu_test.go
+++ b/pkg/plugins/gpu/gpu_test.go
@@ -1,0 +1,246 @@
+package gpu
+
+import (
+	"context"
+	"testing"
+
+	prommodel "github.com/prometheus/common/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zxh326/kite/pkg/kube"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+const nvidiaGPU = corev1.ResourceName("nvidia.com/gpu")
+
+func podNodeIndexer(obj client.Object) []string {
+	pod := obj.(*corev1.Pod)
+	if pod.Spec.NodeName == "" {
+		return nil
+	}
+	return []string{pod.Spec.NodeName}
+}
+
+func newFakeK8sClient(t *testing.T, cached bool, objs ...client.Object) *kube.K8sClient {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	cb := fake.NewClientBuilder().WithScheme(scheme)
+	if cached {
+		cb = cb.WithIndex(&corev1.Pod{}, "spec.nodeName", podNodeIndexer)
+	}
+	for _, o := range objs {
+		cb = cb.WithObjects(o)
+	}
+	return &kube.K8sClient{Client: cb.Build(), CacheEnabled: cached}
+}
+
+func gpuNode(name string, gpus int64) *corev1.Node {
+	return &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   name,
+			Labels: map[string]string{"nvidia.com/gpu.product": "NVIDIA-A100-SXM4-80GB"},
+		},
+		Status: corev1.NodeStatus{
+			Allocatable: corev1.ResourceList{
+				nvidiaGPU: *resource.NewQuantity(gpus, resource.DecimalSI),
+			},
+			Conditions: []corev1.NodeCondition{
+				{Type: corev1.NodeReady, Status: corev1.ConditionTrue},
+			},
+		},
+	}
+}
+
+func gpuPod(ns, name, node string, phase corev1.PodPhase, gpus int64) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: name},
+		Spec: corev1.PodSpec{
+			NodeName: node,
+			Containers: []corev1.Container{
+				{
+					Name: "main",
+					Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							nvidiaGPU: *resource.NewQuantity(gpus, resource.DecimalSI),
+						},
+					},
+				},
+			},
+		},
+		Status: corev1.PodStatus{Phase: phase},
+	}
+}
+
+func TestBuildOverviewBasic(t *testing.T) {
+	for _, cached := range []bool{true, false} {
+		k8sClient := newFakeK8sClient(t, cached,
+			gpuNode("gpu-node-1", 4),
+			&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "cpu-node"}},
+			gpuPod("ml", "train", "gpu-node-1", corev1.PodRunning, 2),
+			gpuPod("ml", "pending", "gpu-node-1", corev1.PodPending, 1),
+			gpuPod("ml", "done", "gpu-node-1", corev1.PodSucceeded, 1),
+			gpuPod("ml", "failed", "gpu-node-1", corev1.PodFailed, 1),
+		)
+
+		overview, err := buildOverview(context.Background(), k8sClient, defaultKeys)
+		require.NoError(t, err, "cached=%v", cached)
+
+		assert.Equal(t, levelBasic, overview.Level)
+		assert.Equal(t, int64(4), overview.Summary.TotalGPUs)
+		// Succeeded/Failed pods must not count as occupied.
+		assert.Equal(t, int64(3), overview.Summary.AllocatedGPUs)
+		assert.Equal(t, int64(1), overview.Summary.FreeGPUs)
+
+		require.Len(t, overview.Nodes, 1, "non-GPU nodes must be excluded")
+		node := overview.Nodes[0]
+		assert.Equal(t, "gpu-node-1", node.Name)
+		assert.True(t, node.Ready)
+		assert.Equal(t, "NVIDIA-A100-SXM4-80GB", node.GPUModel)
+		require.Len(t, node.Resources, 1)
+		assert.Equal(t, int64(4), node.Resources[0].Allocatable)
+		assert.Equal(t, int64(3), node.Resources[0].Allocated)
+		require.Len(t, node.Resources[0].Pods, 2)
+		assert.Equal(t, "pending", node.Resources[0].Pods[0].Name)
+		assert.Equal(t, "train", node.Resources[0].Pods[1].Name)
+		assert.Equal(t, int64(2), node.Resources[0].Pods[1].Count)
+	}
+}
+
+func TestBuildOverviewFreeClamp(t *testing.T) {
+	// Over-committed (e.g. device plugin restarted and allocatable dropped):
+	// free must clamp to 0, not go negative.
+	k8sClient := newFakeK8sClient(t, true,
+		gpuNode("gpu-node-1", 1),
+		gpuPod("ml", "a", "gpu-node-1", corev1.PodRunning, 2),
+	)
+	overview, err := buildOverview(context.Background(), k8sClient, defaultKeys)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), overview.Summary.FreeGPUs)
+}
+
+func TestResourceKeysEnvOverride(t *testing.T) {
+	t.Setenv("GPU_RESOURCE_KEYS", "nvidia.com/gpu, amd.com/gpu, example.com/npu")
+	keys := ResourceKeys()
+	require.Len(t, keys, 3)
+	assert.Equal(t, "nvidia", keys[0].Vendor)
+	assert.NotNil(t, keys[0].Exporter)
+	assert.Equal(t, "amd", keys[1].Vendor)
+	assert.Nil(t, keys[1].Exporter)
+	assert.Equal(t, "example", keys[2].Vendor)
+
+	t.Setenv("GPU_RESOURCE_KEYS", "")
+	assert.Equal(t, defaultKeys, ResourceKeys())
+}
+
+func TestOccupantOf(t *testing.T) {
+	// honor_labels=false: exported_* carries the workload, pod is the exporter itself.
+	m := prommodel.Metric{
+		"exported_namespace": "ml",
+		"exported_pod":       "train-abc",
+		"exported_container": "trainer",
+		"namespace":          "gpu-operator",
+		"pod":                "dcgm-exporter-xyz",
+	}
+	occ := occupantOf(m, true)
+	require.NotNil(t, occ)
+	assert.Equal(t, "ml", occ.Namespace)
+	assert.Equal(t, "train-abc", occ.Pod)
+	assert.Equal(t, "trainer", occ.Container)
+
+	// Idle card in honor_labels=false mode: exported_pod absent, the plain pod
+	// label (exporter's own pod) must NOT be mistaken for an occupant.
+	idle := prommodel.Metric{
+		"namespace": "gpu-operator",
+		"pod":       "dcgm-exporter-xyz",
+	}
+	assert.Nil(t, occupantOf(idle, true))
+
+	// honor_labels=true: plain labels carry the workload.
+	direct := prommodel.Metric{
+		"namespace": "ml",
+		"pod":       "train-abc",
+		"container": "trainer",
+	}
+	occ = occupantOf(direct, false)
+	require.NotNil(t, occ)
+	assert.Equal(t, "train-abc", occ.Pod)
+
+	// dcgm-exporter without Kubernetes pod mapping: pod/namespace are the
+	// scrape target's own metadata and must not become an occupant.
+	self := prommodel.Metric{
+		"namespace": "gpu-operator",
+		"pod":       "nvidia-dcgm-exporter-l6wjn",
+		"container": "nvidia-dcgm-exporter",
+		"job":       "nvidia-dcgm-exporter",
+		"service":   "nvidia-dcgm-exporter",
+	}
+	assert.Nil(t, occupantOf(self, false))
+
+	assert.Nil(t, occupantOf(prommodel.Metric{}, false))
+}
+
+func TestCardID(t *testing.T) {
+	assert.Equal(t, "GPU-abc", cardID(prommodel.Metric{"UUID": "GPU-abc"}))
+	assert.Equal(t, "GPU-abc/mig-3", cardID(prommodel.Metric{"UUID": "GPU-abc", "GPU_I_ID": "3"}))
+	// No UUID: fall back to node + index.
+	assert.Equal(t, "node-1/gpu-0", cardID(prommodel.Metric{"Hostname": "node-1", "gpu": "0"}))
+}
+
+func devicePluginPod(name, node string, labels map[string]string, ownedByDS bool) *corev1.Pod {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "gpu-operator", Name: name, Labels: labels},
+		Spec:       corev1.PodSpec{NodeName: node},
+	}
+	if ownedByDS {
+		pod.OwnerReferences = []metav1.OwnerReference{{Kind: "DaemonSet", Name: "nvidia-device-plugin-daemonset", APIVersion: "apps/v1"}}
+	}
+	return pod
+}
+
+func TestFindDevicePluginPods(t *testing.T) {
+	for _, cached := range []bool{true, false} {
+		k8sClient := newFakeK8sClient(t, cached,
+			// gpu-operator style on the target node
+			devicePluginPod("nvidia-device-plugin-daemonset-5k4fg", "gpu-node-1",
+				map[string]string{"app": "nvidia-device-plugin-daemonset"}, true),
+			// same daemonset but on another node — must not match
+			devicePluginPod("nvidia-device-plugin-daemonset-other", "gpu-node-2",
+				map[string]string{"app": "nvidia-device-plugin-daemonset"}, true),
+			// dcgm-exporter on the target node — must not match
+			devicePluginPod("nvidia-dcgm-exporter-7zrqx", "gpu-node-1",
+				map[string]string{"app": "nvidia-dcgm-exporter"}, true),
+			// name matches but not DaemonSet-owned — must not match
+			devicePluginPod("nvidia-device-plugin-standalone", "gpu-node-1",
+				map[string]string{}, false),
+		)
+
+		pods, err := findDevicePluginPods(context.Background(), k8sClient, "gpu-node-1")
+		require.NoError(t, err, "cached=%v", cached)
+		require.Len(t, pods, 1, "cached=%v", cached)
+		assert.Equal(t, "nvidia-device-plugin-daemonset-5k4fg", pods[0].Name)
+	}
+}
+
+func TestIsDevicePluginPod(t *testing.T) {
+	// static manifests style
+	assert.True(t, isDevicePluginPod(devicePluginPod("nvidia-device-plugin-ds-abc", "n1",
+		map[string]string{"name": "nvidia-device-plugin-ds"}, true)))
+	// nvdp helm chart style
+	assert.True(t, isDevicePluginPod(devicePluginPod("nvdp-xyz", "n1",
+		map[string]string{"app.kubernetes.io/name": "nvidia-device-plugin"}, true)))
+	// name-prefix fallback
+	assert.True(t, isDevicePluginPod(devicePluginPod("nvidia-device-plugin-abc", "n1", nil, true)))
+	assert.False(t, isDevicePluginPod(devicePluginPod("some-workload", "n1", nil, true)))
+}
+
+func TestSortCards(t *testing.T) {
+	cards := []Card{{Index: "10"}, {Index: "2"}, {Index: "0"}}
+	sortCards(cards)
+	assert.Equal(t, []string{"0", "2", "10"}, []string{cards[0].Index, cards[1].Index, cards[2].Index})
+}

--- a/pkg/plugins/gpu/plugin.go
+++ b/pkg/plugins/gpu/plugin.go
@@ -1,0 +1,60 @@
+// Package gpu is a kite-fork plugin showing per-node GPU occupancy: total
+// cards, cards held by containers, and idle cards. It serves a basic
+// scheduler view from the Kubernetes API and upgrades to real per-card data
+// when a card-level exporter (dcgm-exporter) is reachable via Prometheus.
+package gpu
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/zxh326/kite/pkg/cluster"
+	"github.com/zxh326/kite/pkg/model"
+	"github.com/zxh326/kite/pkg/plugins"
+	"github.com/zxh326/kite/pkg/rbac"
+	"k8s.io/klog/v2"
+)
+
+type Plugin struct{}
+
+func init() {
+	plugins.Register(&Plugin{})
+}
+
+func (p *Plugin) Name() string { return "gpu" }
+
+func (p *Plugin) Enabled(ctx context.Context, cs *cluster.ClientSet) (bool, map[string]any) {
+	r := detect(ctx, cs)
+	return r.enabled, map[string]any{"level": r.level}
+}
+
+func (p *Plugin) RegisterRoutes(group *gin.RouterGroup) {
+	group.GET("/overview", p.GetOverview)
+	group.POST("/nodes/:node/reset-device-plugin", p.ResetDevicePlugin)
+}
+
+func (p *Plugin) GetOverview(c *gin.Context) {
+	ctx := c.Request.Context()
+	cs := c.MustGet("cluster").(*cluster.ClientSet)
+	user := c.MustGet("user").(model.User)
+	if !rbac.CanAccessCluster(user, cs.Name) {
+		c.JSON(http.StatusForbidden, gin.H{"error": "Access denied"})
+		return
+	}
+
+	keys := ResourceKeys()
+	overview, err := buildOverview(ctx, cs.K8sClient, keys)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to build GPU overview: " + err.Error()})
+		return
+	}
+
+	if detect(ctx, cs).level == levelDCGM {
+		if err := enrichWithCards(ctx, cs, keys, overview); err != nil {
+			klog.Warningf("gpu plugin: card-level query failed for cluster %s, serving basic view: %v", cs.Name, err)
+		}
+	}
+
+	c.JSON(http.StatusOK, overview)
+}

--- a/pkg/plugins/gpu/reset.go
+++ b/pkg/plugins/gpu/reset.go
@@ -1,0 +1,121 @@
+package gpu
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/zxh326/kite/pkg/cluster"
+	"github.com/zxh326/kite/pkg/kube"
+	"github.com/zxh326/kite/pkg/model"
+	"github.com/zxh326/kite/pkg/rbac"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type ResetPodRef struct {
+	Namespace string `json:"namespace"`
+	Name      string `json:"name"`
+}
+
+// ResetDevicePlugin deletes the NVIDIA device-plugin pod(s) on a node so the
+// owning DaemonSet recreates them and re-registers the node's GPUs.
+// ?dryRun=true only reports which pods would be deleted — the UI uses it to
+// preview the target before the user confirms.
+func (p *Plugin) ResetDevicePlugin(c *gin.Context) {
+	ctx := c.Request.Context()
+	cs := c.MustGet("cluster").(*cluster.ClientSet)
+	user := c.MustGet("user").(model.User)
+	if !rbac.CanAccessCluster(user, cs.Name) {
+		c.JSON(http.StatusForbidden, gin.H{"error": "Access denied"})
+		return
+	}
+
+	nodeName := c.Param("node")
+	dryRun := c.Query("dryRun") == "true"
+
+	pods, err := findDevicePluginPods(ctx, cs.K8sClient, nodeName)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to list pods: " + err.Error()})
+		return
+	}
+	if len(pods) == 0 {
+		c.JSON(http.StatusNotFound, gin.H{"error": "no device plugin pod found on node " + nodeName})
+		return
+	}
+
+	refs := make([]ResetPodRef, 0, len(pods))
+	for i := range pods {
+		if !rbac.CanAccess(user, "pods", "delete", cs.Name, pods[i].Namespace) {
+			c.JSON(http.StatusForbidden, gin.H{
+				"error": rbac.NoAccess(user.Key(), "delete", "pods", pods[i].Namespace, cs.Name),
+			})
+			return
+		}
+		refs = append(refs, ResetPodRef{Namespace: pods[i].Namespace, Name: pods[i].Name})
+	}
+
+	if !dryRun {
+		for i := range pods {
+			if err := cs.K8sClient.Delete(ctx, &pods[i]); err != nil {
+				c.JSON(http.StatusInternalServerError, gin.H{
+					"error": "Failed to delete pod " + pods[i].Namespace + "/" + pods[i].Name + ": " + err.Error(),
+				})
+				return
+			}
+			klog.Infof("gpu plugin: user %s deleted device plugin pod %s/%s on node %s (cluster %s)",
+				user.Key(), pods[i].Namespace, pods[i].Name, nodeName, cs.Name)
+		}
+	}
+
+	c.JSON(http.StatusOK, gin.H{"dryRun": dryRun, "pods": refs})
+}
+
+// findDevicePluginPods returns DaemonSet-owned NVIDIA device-plugin pods on
+// the node, covering the common deployment styles: gpu-operator
+// (app=nvidia-device-plugin-daemonset), static manifests
+// (name=nvidia-device-plugin-ds) and the nvdp helm chart
+// (app.kubernetes.io/name=nvidia-device-plugin).
+func findDevicePluginPods(ctx context.Context, k8sClient *kube.K8sClient, nodeName string) ([]corev1.Pod, error) {
+	var pods corev1.PodList
+	if k8sClient.CacheEnabled {
+		if err := k8sClient.List(ctx, &pods, client.MatchingFields{"spec.nodeName": nodeName}); err != nil {
+			return nil, err
+		}
+	} else {
+		if err := k8sClient.List(ctx, &pods); err != nil {
+			return nil, err
+		}
+	}
+
+	var matched []corev1.Pod
+	for i := range pods.Items {
+		pod := &pods.Items[i]
+		if pod.Spec.NodeName != nodeName {
+			continue
+		}
+		if isDevicePluginPod(pod) {
+			matched = append(matched, *pod)
+		}
+	}
+	return matched, nil
+}
+
+func isDevicePluginPod(pod *corev1.Pod) bool {
+	ownedByDaemonSet := false
+	for _, o := range pod.OwnerReferences {
+		if o.Kind == "DaemonSet" {
+			ownedByDaemonSet = true
+			break
+		}
+	}
+	if !ownedByDaemonSet {
+		return false
+	}
+	return pod.Labels["app"] == "nvidia-device-plugin-daemonset" ||
+		pod.Labels["name"] == "nvidia-device-plugin-ds" ||
+		pod.Labels["app.kubernetes.io/name"] == "nvidia-device-plugin" ||
+		strings.HasPrefix(pod.Name, "nvidia-device-plugin")
+}

--- a/pkg/plugins/gpu/resource_keys.go
+++ b/pkg/plugins/gpu/resource_keys.go
@@ -1,0 +1,76 @@
+package gpu
+
+import (
+	"os"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// ExporterSpec describes the Prometheus metrics exposed by a vendor's
+// card-level exporter (e.g. dcgm-exporter for NVIDIA). Memory metrics are
+// reported in MiB by dcgm-exporter.
+type ExporterSpec struct {
+	DetectMetric   string
+	UtilMetric     string
+	MemUsedMetric  string
+	MemTotalMetric string
+	// MemFreeMetric is combined with MemUsedMetric to derive the total when
+	// MemTotalMetric has no series (older dcgm-exporter versions).
+	MemFreeMetric string
+}
+
+type GPUResourceKey struct {
+	Key    corev1.ResourceName
+	Vendor string
+	// ProductLabel is the node label carrying the GPU product name when the
+	// vendor's feature discovery publishes one (e.g. GPU Feature Discovery).
+	ProductLabel string
+	// Exporter is nil when the vendor has no supported card-level exporter.
+	Exporter *ExporterSpec
+}
+
+var dcgmSpec = ExporterSpec{
+	DetectMetric:   "DCGM_FI_DEV_GPU_UTIL",
+	UtilMetric:     "DCGM_FI_DEV_GPU_UTIL",
+	MemUsedMetric:  "DCGM_FI_DEV_FB_USED",
+	MemTotalMetric: "DCGM_FI_DEV_FB_TOTAL",
+	MemFreeMetric:  "DCGM_FI_DEV_FB_FREE",
+}
+
+var knownKeys = map[string]GPUResourceKey{
+	"nvidia.com/gpu": {Key: "nvidia.com/gpu", Vendor: "nvidia", ProductLabel: "nvidia.com/gpu.product", Exporter: &dcgmSpec},
+	"amd.com/gpu":    {Key: "amd.com/gpu", Vendor: "amd"},
+}
+
+var defaultKeys = []GPUResourceKey{knownKeys["nvidia.com/gpu"]}
+
+// ResourceKeys returns the GPU extended-resource names the plugin watches.
+// GPU_RESOURCE_KEYS (comma-separated) overrides the default list; unknown
+// keys are tracked count-only, with the vendor derived from the key's domain.
+func ResourceKeys() []GPUResourceKey {
+	env := strings.TrimSpace(os.Getenv("GPU_RESOURCE_KEYS"))
+	if env == "" {
+		return defaultKeys
+	}
+	var keys []GPUResourceKey
+	for _, raw := range strings.Split(env, ",") {
+		name := strings.TrimSpace(raw)
+		if name == "" {
+			continue
+		}
+		if k, ok := knownKeys[name]; ok {
+			keys = append(keys, k)
+			continue
+		}
+		vendor := name
+		if i := strings.IndexAny(name, "./"); i > 0 {
+			vendor = name[:i]
+		}
+		keys = append(keys, GPUResourceKey{Key: corev1.ResourceName(name), Vendor: vendor})
+	}
+	if len(keys) == 0 {
+		return defaultKeys
+	}
+	return keys
+}

--- a/pkg/plugins/gpu/types.go
+++ b/pkg/plugins/gpu/types.go
@@ -1,0 +1,68 @@
+package gpu
+
+const (
+	levelBasic = "basic"
+	levelDCGM  = "dcgm"
+)
+
+type Summary struct {
+	TotalGPUs     int64 `json:"totalGPUs"`
+	AllocatedGPUs int64 `json:"allocatedGPUs"`
+	FreeGPUs      int64 `json:"freeGPUs"`
+}
+
+type ContainerAllocation struct {
+	Name  string `json:"name"`
+	Count int64  `json:"count"`
+}
+
+type PodAllocation struct {
+	Namespace  string                `json:"namespace"`
+	Name       string                `json:"name"`
+	Count      int64                 `json:"count"`
+	Containers []ContainerAllocation `json:"containers"`
+}
+
+type NodeResource struct {
+	Key         string          `json:"key"`
+	Allocatable int64           `json:"allocatable"`
+	Allocated   int64           `json:"allocated"`
+	Pods        []PodAllocation `json:"pods"`
+}
+
+type Occupant struct {
+	Namespace string `json:"namespace"`
+	Pod       string `json:"pod"`
+	Container string `json:"container,omitempty"`
+}
+
+// Card is a physical GPU (or MIG instance) reported by a card-level
+// exporter. Occupant is nil for idle cards.
+type Card struct {
+	Index            string    `json:"index"`
+	UUID             string    `json:"uuid"`
+	ModelName        string    `json:"modelName,omitempty"`
+	Utilization      float64   `json:"utilization"`
+	MemoryUsedBytes  int64     `json:"memoryUsedBytes,omitempty"`
+	MemoryTotalBytes int64     `json:"memoryTotalBytes,omitempty"`
+	Occupant         *Occupant `json:"occupant"`
+}
+
+type NodeGPU struct {
+	Name      string         `json:"name"`
+	Ready     bool           `json:"ready"`
+	GPUModel  string         `json:"gpuModel,omitempty"`
+	Resources []NodeResource `json:"resources"`
+	// Cards is only populated when Level is "dcgm".
+	Cards []Card `json:"cards,omitempty"`
+}
+
+type Overview struct {
+	Level        string    `json:"level"`
+	ResourceKeys []string  `json:"resourceKeys"`
+	Summary      Summary   `json:"summary"`
+	Nodes        []NodeGPU `json:"nodes"`
+	// UnassignedCards are exporter series whose node label could not be
+	// matched to a known GPU node.
+	UnassignedCards []Card `json:"unassignedCards,omitempty"`
+}

--- a/pkg/plugins/registry.go
+++ b/pkg/plugins/registry.go
@@ -1,0 +1,62 @@
+// Package plugins provides a lightweight runtime extension point for kite
+// forks. Plugins live under pkg/plugins/<name>, register themselves via
+// Register from an init function, and are collected by pkg/plugins/all so
+// that routes.go only needs a single hook line.
+package plugins
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/zxh326/kite/pkg/cluster"
+	"github.com/zxh326/kite/pkg/model"
+	"github.com/zxh326/kite/pkg/rbac"
+)
+
+type Plugin interface {
+	Name() string
+	// Enabled reports whether the plugin is usable for the given cluster.
+	// extra is returned verbatim in the /plugins response.
+	Enabled(ctx context.Context, cs *cluster.ClientSet) (bool, map[string]any)
+	// RegisterRoutes mounts the plugin's routes under /api/v1/plugins/<name>.
+	// Plugin routes are registered before the resource RBAC middleware, so
+	// handlers must enforce access control themselves (e.g.
+	// rbac.CanAccessCluster), same as the overview/metrics endpoints.
+	RegisterRoutes(group *gin.RouterGroup)
+}
+
+// registry is only mutated from init functions, before RegisterRoutes runs.
+var registry []Plugin
+
+func Register(p Plugin) {
+	registry = append(registry, p)
+}
+
+type PluginStatus struct {
+	Name    string         `json:"name"`
+	Enabled bool           `json:"enabled"`
+	Extra   map[string]any `json:"extra,omitempty"`
+}
+
+func RegisterRoutes(api *gin.RouterGroup) {
+	api.GET("/plugins", listPlugins)
+	for _, p := range registry {
+		p.RegisterRoutes(api.Group("/plugins/" + p.Name()))
+	}
+}
+
+func listPlugins(c *gin.Context) {
+	cs := c.MustGet("cluster").(*cluster.ClientSet)
+	user := c.MustGet("user").(model.User)
+	if !rbac.CanAccessCluster(user, cs.Name) {
+		c.JSON(http.StatusForbidden, gin.H{"error": "Access denied"})
+		return
+	}
+	statuses := make([]PluginStatus, 0, len(registry))
+	for _, p := range registry {
+		enabled, extra := p.Enabled(c.Request.Context(), cs)
+		statuses = append(statuses, PluginStatus{Name: p.Name(), Enabled: enabled, Extra: extra})
+	}
+	c.JSON(http.StatusOK, gin.H{"plugins": statuses})
+}

--- a/routes.go
+++ b/routes.go
@@ -15,6 +15,7 @@ import (
 	"github.com/zxh326/kite/pkg/images"
 	"github.com/zxh326/kite/pkg/metrics"
 	"github.com/zxh326/kite/pkg/middleware"
+	pluginsall "github.com/zxh326/kite/pkg/plugins/all" // kite-fork: plugin registry
 	"github.com/zxh326/kite/pkg/proxy"
 	"github.com/zxh326/kite/pkg/rbac"
 	"github.com/zxh326/kite/pkg/resources"
@@ -187,6 +188,8 @@ func registerClusterProtectedRoutes(api *gin.RouterGroup, helmChartsHandler *hel
 	api.POST("/ai/chat", ai.HandleChat)
 	api.POST("/ai/execute/continue", ai.HandleExecuteContinue)
 	api.POST("/ai/input/continue", ai.HandleInputContinue)
+
+	pluginsall.RegisterRoutes(api) // kite-fork: plugin registry (handlers enforce rbac themselves)
 
 	api.Use(middleware.RBACMiddleware())
 	resources.RegisterRoutes(api)

--- a/ui/src/components/app-sidebar.tsx
+++ b/ui/src/components/app-sidebar.tsx
@@ -23,6 +23,8 @@ import {
   useSidebar,
 } from '@/components/ui/sidebar'
 
+import { PluginSidebarItems } from '@/plugins' // kite-fork: plugin registry
+
 import { ClusterSelector } from './cluster-selector'
 import { Collapsible, CollapsibleTrigger } from './ui/collapsible'
 import { VersionInfo } from './version-info'
@@ -159,6 +161,8 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
             </SidebarMenuItem>
           </SidebarMenu>
         </SidebarGroup>
+
+        <PluginSidebarItems onItemClick={handleMenuItemClick} />
 
         {pinnedItems.length > 0 && (
           <SidebarGroup>

--- a/ui/src/plugins/gpu/api.ts
+++ b/ui/src/plugins/gpu/api.ts
@@ -1,0 +1,20 @@
+import { useQuery } from '@tanstack/react-query'
+
+import { apiClient } from '@/lib/api-client'
+
+import type { GpuOverview, ResetDevicePluginResponse } from './types'
+
+export function useGpuOverview() {
+  return useQuery<GpuOverview>({
+    queryKey: ['plugin-gpu', 'overview'],
+    queryFn: () => apiClient.get<GpuOverview>('/plugins/gpu/overview'),
+    refetchInterval: 30_000,
+    placeholderData: (prev) => prev,
+  })
+}
+
+export function resetDevicePlugin(node: string, dryRun: boolean) {
+  return apiClient.post<ResetDevicePluginResponse>(
+    `/plugins/gpu/nodes/${encodeURIComponent(node)}/reset-device-plugin${dryRun ? '?dryRun=true' : ''}`
+  )
+}

--- a/ui/src/plugins/gpu/components/gpu-slot.tsx
+++ b/ui/src/plugins/gpu/components/gpu-slot.tsx
@@ -1,0 +1,151 @@
+import { IconCpu2 } from '@tabler/icons-react'
+import { useTranslation } from 'react-i18next'
+import { Link } from 'react-router-dom'
+
+import { formatMemory } from '@/lib/utils'
+import { Badge } from '@/components/ui/badge'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+
+import type { GpuCard, GpuOccupant } from '../types'
+
+function OccupantLink({ occupant }: { occupant: GpuOccupant }) {
+  return (
+    <div className="min-w-0 text-xs">
+      <Link
+        to={`/pods/${occupant.namespace}/${occupant.pod}`}
+        className="block truncate font-medium text-primary hover:underline"
+        title={`${occupant.namespace}/${occupant.pod}`}
+      >
+        {occupant.namespace}/{occupant.pod}
+      </Link>
+      {occupant.container && (
+        <span className="block truncate text-muted-foreground">
+          {occupant.container}
+        </span>
+      )}
+    </div>
+  )
+}
+
+function SlotFrame({
+  occupied,
+  children,
+}: {
+  occupied: boolean
+  children: React.ReactNode
+}) {
+  return (
+    <div
+      className={`flex flex-col gap-1.5 rounded-md border p-2.5 ${
+        occupied ? 'border-primary/40 bg-primary/5' : 'border-dashed bg-muted/30'
+      }`}
+    >
+      {children}
+    </div>
+  )
+}
+
+function utilizationColor(pct: number) {
+  if (pct > 90) return 'bg-red-500'
+  if (pct > 60) return 'bg-yellow-500'
+  return 'bg-blue-500'
+}
+
+// Real card reported by dcgm-exporter. A card counts as active when a
+// workload is attributed to it or it shows utilization (exporters without
+// Kubernetes pod mapping report no occupant).
+export function GpuCardSlot({ card }: { card: GpuCard }) {
+  const { t } = useTranslation()
+  const pct = Math.min(Math.max(card.utilization, 0), 100)
+  const active = card.occupant !== null || pct > 0
+
+  return (
+    <SlotFrame occupied={active}>
+      <div className="flex items-center justify-between gap-1">
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span className="flex items-center gap-1 text-xs font-semibold">
+              <IconCpu2 className="h-3.5 w-3.5 text-sidebar-primary" />
+              GPU {card.index}
+            </span>
+          </TooltipTrigger>
+          <TooltipContent>
+            <div className="text-xs">
+              {card.modelName && <div>{card.modelName}</div>}
+              <div className="text-muted-foreground">{card.uuid}</div>
+            </div>
+          </TooltipContent>
+        </Tooltip>
+        <Badge variant={active ? 'default' : 'outline'} className="text-[10px]">
+          {active ? `${pct.toFixed(0)}%` : t('plugin.gpu.idle')}
+        </Badge>
+      </div>
+
+      <div className="h-1.5 w-full overflow-hidden rounded-full bg-muted">
+        <div
+          className={`h-1.5 rounded-full transition-all duration-300 ${utilizationColor(pct)}`}
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+
+      {card.memoryTotalBytes ? (
+        <span className="text-[11px] tabular-nums text-muted-foreground">
+          {t('plugin.gpu.memory')}: {formatMemory(card.memoryUsedBytes ?? 0)} /{' '}
+          {formatMemory(card.memoryTotalBytes)}
+        </span>
+      ) : null}
+
+      {card.occupant ? (
+        <OccupantLink occupant={card.occupant} />
+      ) : (
+        !active && (
+          <span className="text-xs text-muted-foreground">
+            {t('plugin.gpu.idle')}
+          </span>
+        )
+      )}
+    </SlotFrame>
+  )
+}
+
+// Synthetic slot for the basic (scheduler view) mode: derived from pod
+// resource requests, not an actual card binding.
+export function SyntheticSlot({
+  index,
+  occupant,
+}: {
+  index: number
+  occupant: GpuOccupant | null
+}) {
+  const { t } = useTranslation()
+  return (
+    <SlotFrame occupied={occupant !== null}>
+      <div className="flex items-center justify-between gap-1">
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span className="flex items-center gap-1 text-xs font-semibold">
+              <IconCpu2 className="h-3.5 w-3.5 text-sidebar-primary" />
+              GPU {index}
+            </span>
+          </TooltipTrigger>
+          <TooltipContent className="max-w-56 text-xs">
+            {t('plugin.gpu.syntheticSlotHint')}
+          </TooltipContent>
+        </Tooltip>
+        <Badge
+          variant={occupant ? 'default' : 'outline'}
+          className="text-[10px]"
+        >
+          {occupant ? t('plugin.gpu.allocated') : t('plugin.gpu.idle')}
+        </Badge>
+      </div>
+      {occupant ? (
+        <OccupantLink occupant={occupant} />
+      ) : (
+        <span className="text-xs text-muted-foreground">
+          {t('plugin.gpu.idle')}
+        </span>
+      )}
+    </SlotFrame>
+  )
+}

--- a/ui/src/plugins/gpu/components/node-gpu-card.tsx
+++ b/ui/src/plugins/gpu/components/node-gpu-card.tsx
@@ -1,0 +1,141 @@
+import { useState } from 'react'
+import { IconRefreshAlert, IconServer2 } from '@tabler/icons-react'
+import { useTranslation } from 'react-i18next'
+import { Link } from 'react-router-dom'
+
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
+
+import type { GpuNode, GpuOccupant } from '../types'
+import { GpuCardSlot, SyntheticSlot } from './gpu-slot'
+import { ResetDevicePluginDialog } from './reset-device-plugin-dialog'
+
+// Expand basic-mode pod allocations into one synthetic slot per requested
+// GPU, followed by idle slots up to the node's allocatable count.
+function syntheticSlots(node: GpuNode): (GpuOccupant | null)[] {
+  const slots: (GpuOccupant | null)[] = []
+  for (const res of node.resources) {
+    for (const pod of res.pods) {
+      for (const container of pod.containers) {
+        for (let i = 0; i < container.count; i++) {
+          slots.push({
+            namespace: pod.namespace,
+            pod: pod.name,
+            container: container.name,
+          })
+        }
+      }
+    }
+    const allocatable = res.allocatable
+    while (slots.length < allocatable) {
+      slots.push(null)
+    }
+  }
+  return slots
+}
+
+export function NodeGpuCard({
+  node,
+  level,
+}: {
+  node: GpuNode
+  level: 'basic' | 'dcgm'
+}) {
+  const { t } = useTranslation()
+  const [resetOpen, setResetOpen] = useState(false)
+  const allocatable = node.resources.reduce((sum, r) => sum + r.allocatable, 0)
+  const allocated = node.resources.reduce((sum, r) => sum + r.allocated, 0)
+  const useCards = level === 'dcgm' && (node.cards?.length ?? 0) > 0
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <div className="flex flex-wrap items-center gap-2">
+          <CardTitle className="flex items-center gap-2 text-base">
+            <IconServer2 className="h-4 w-4 text-sidebar-primary" />
+            <Link
+              to={`/nodes/${node.name}`}
+              className="hover:underline"
+            >
+              {node.name}
+            </Link>
+          </CardTitle>
+          {!node.ready && (
+            <Badge variant="destructive" className="text-[10px]">
+              {t('plugin.gpu.nodeNotReady')}
+            </Badge>
+          )}
+          {node.gpuModel && (
+            <Badge variant="secondary" className="text-[10px]">
+              {node.gpuModel}
+            </Badge>
+          )}
+          <span className="ml-auto text-sm tabular-nums text-muted-foreground">
+            {t('plugin.gpu.allocated')} {allocated}/{allocatable}
+          </span>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="outline"
+                size="sm"
+                className="h-7 gap-1 px-2 text-xs"
+                onClick={() => setResetOpen(true)}
+              >
+                <IconRefreshAlert className="h-3.5 w-3.5" />
+                {t('plugin.gpu.resetGpu')}
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent className="max-w-64 text-xs">
+              {t('plugin.gpu.resetDescription')}
+            </TooltipContent>
+          </Tooltip>
+        </div>
+      </CardHeader>
+      <ResetDevicePluginDialog
+        node={node.name}
+        open={resetOpen}
+        onOpenChange={setResetOpen}
+      />
+      <CardContent className="flex flex-col gap-3">
+        <div className="grid grid-cols-2 gap-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-6">
+          {useCards
+            ? node.cards!.map((card) => (
+                <GpuCardSlot key={`${card.uuid}-${card.index}`} card={card} />
+              ))
+            : syntheticSlots(node).map((occupant, i) => (
+                <SyntheticSlot key={i} index={i} occupant={occupant} />
+              ))}
+        </div>
+        {useCards &&
+          allocated > 0 &&
+          !node.cards!.some((c) => c.occupant) && (
+            <div className="flex flex-col gap-1 border-t pt-2">
+              <span className="text-xs font-semibold text-muted-foreground">
+                {t('plugin.gpu.occupiedBy')}
+              </span>
+              <div className="flex flex-wrap gap-x-4 gap-y-1">
+                {node.resources.flatMap((res) =>
+                  res.pods.map((pod) => (
+                    <Link
+                      key={`${pod.namespace}/${pod.name}`}
+                      to={`/pods/${pod.namespace}/${pod.name}`}
+                      className="text-xs text-primary hover:underline"
+                    >
+                      {pod.namespace}/{pod.name}
+                      <span className="text-muted-foreground"> ×{pod.count}</span>
+                    </Link>
+                  ))
+                )}
+              </div>
+            </div>
+          )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/ui/src/plugins/gpu/components/reset-device-plugin-dialog.tsx
+++ b/ui/src/plugins/gpu/components/reset-device-plugin-dialog.tsx
@@ -1,0 +1,136 @@
+import { useEffect, useState } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
+import { AlertTriangle } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import { toast } from 'sonner'
+
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Skeleton } from '@/components/ui/skeleton'
+
+import { resetDevicePlugin } from '../api'
+import type { ResetPodRef } from '../types'
+
+// Confirmation dialog for resetting a node's GPU registration. On open it
+// dry-runs the reset to show exactly which device-plugin pod(s) will be
+// deleted; the DaemonSet recreates them, which re-registers the GPUs.
+export function ResetDevicePluginDialog({
+  node,
+  open,
+  onOpenChange,
+}: {
+  node: string
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}) {
+  const { t } = useTranslation()
+  const queryClient = useQueryClient()
+  const [targets, setTargets] = useState<ResetPodRef[] | null>(null)
+  const [previewError, setPreviewError] = useState<string | null>(null)
+  const [isResetting, setIsResetting] = useState(false)
+
+  useEffect(() => {
+    if (!open) {
+      setTargets(null)
+      setPreviewError(null)
+      return
+    }
+    let cancelled = false
+    resetDevicePlugin(node, true)
+      .then((res) => {
+        if (!cancelled) setTargets(res.pods)
+      })
+      .catch((err) => {
+        if (!cancelled)
+          setPreviewError(err instanceof Error ? err.message : String(err))
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [open, node])
+
+  const handleConfirm = async () => {
+    setIsResetting(true)
+    try {
+      const res = await resetDevicePlugin(node, false)
+      toast.success(
+        t('plugin.gpu.resetSuccess', {
+          pods: res.pods.map((p) => `${p.namespace}/${p.name}`).join(', '),
+        })
+      )
+      queryClient.invalidateQueries({ queryKey: ['plugin-gpu'] })
+      onOpenChange(false)
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : String(err))
+    } finally {
+      setIsResetting(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <div className="flex items-center gap-3">
+            <div className="flex h-10 w-10 items-center justify-center rounded-full bg-destructive/10">
+              <AlertTriangle className="h-5 w-5 text-destructive" />
+            </div>
+            <div className="flex-1">
+              <DialogTitle className="text-left">
+                {t('plugin.gpu.resetTitle', { node })}
+              </DialogTitle>
+              <DialogDescription className="text-left">
+                {t('plugin.gpu.resetDescription')}
+              </DialogDescription>
+            </div>
+          </div>
+        </DialogHeader>
+
+        <div className="rounded-lg border border-destructive/20 bg-destructive/5 p-4 text-sm">
+          <p className="mb-2 font-medium text-destructive">
+            {t('plugin.gpu.resetWillDelete')}
+          </p>
+          {previewError ? (
+            <p className="text-muted-foreground">{previewError}</p>
+          ) : targets === null ? (
+            <Skeleton className="h-5 w-3/4" />
+          ) : (
+            <ul className="space-y-1 font-mono text-xs text-muted-foreground">
+              {targets.map((p) => (
+                <li key={`${p.namespace}/${p.name}`}>
+                  {p.namespace}/{p.name}
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={isResetting}
+          >
+            {t('common.actions.cancel', 'Cancel')}
+          </Button>
+          <Button
+            variant="destructive"
+            onClick={handleConfirm}
+            disabled={isResetting || !targets || targets.length === 0}
+          >
+            {isResetting
+              ? t('plugin.gpu.resetting')
+              : t('plugin.gpu.resetConfirm')}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/ui/src/plugins/gpu/gpu-page.tsx
+++ b/ui/src/plugins/gpu/gpu-page.tsx
@@ -1,0 +1,119 @@
+import { IconCpu2, IconInfoCircle } from '@tabler/icons-react'
+import { useTranslation } from 'react-i18next'
+
+import { Badge } from '@/components/ui/badge'
+import { Card, CardContent } from '@/components/ui/card'
+import { Skeleton } from '@/components/ui/skeleton'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+
+import './i18n'
+
+import { useGpuOverview } from './api'
+import { GpuCardSlot } from './components/gpu-slot'
+import { NodeGpuCard } from './components/node-gpu-card'
+
+function SummaryCard({ label, value }: { label: string; value: number }) {
+  return (
+    <Card>
+      <CardContent className="pt-4">
+        <div className="text-sm text-muted-foreground">{label}</div>
+        <div className="text-2xl font-bold tabular-nums">{value}</div>
+      </CardContent>
+    </Card>
+  )
+}
+
+export function GpuPage() {
+  const { t } = useTranslation()
+  const { data, isLoading, error } = useGpuOverview()
+
+  if (error) {
+    return (
+      <div className="flex h-64 flex-col items-center justify-center gap-2">
+        <h2 className="text-lg font-semibold">{t('plugin.gpu.failedToLoad')}</h2>
+        <p className="text-sm text-muted-foreground">
+          {error instanceof Error ? error.message : String(error)}
+        </p>
+      </div>
+    )
+  }
+
+  if (isLoading || !data) {
+    return (
+      <div className="flex flex-col gap-6">
+        <h1 className="text-2xl font-bold">{t('plugin.gpu.title')}</h1>
+        <div className="grid grid-cols-3 gap-4">
+          <Skeleton className="h-20" />
+          <Skeleton className="h-20" />
+          <Skeleton className="h-20" />
+        </div>
+        <Skeleton className="h-48" />
+      </div>
+    )
+  }
+
+  if (data.nodes.length === 0) {
+    return (
+      <div className="flex h-64 flex-col items-center justify-center gap-2">
+        <IconCpu2 className="h-8 w-8 text-muted-foreground" />
+        <p className="text-sm text-muted-foreground">
+          {t('plugin.gpu.noGpuInCluster')}
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex flex-wrap items-center gap-3">
+        <h1 className="text-2xl font-bold">{t('plugin.gpu.title')}</h1>
+        {data.level === 'dcgm' ? (
+          <Badge>{t('plugin.gpu.modeDcgm')}</Badge>
+        ) : (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Badge variant="secondary" className="cursor-help gap-1">
+                {t('plugin.gpu.modeBasic')}
+                <IconInfoCircle className="h-3 w-3" />
+              </Badge>
+            </TooltipTrigger>
+            <TooltipContent className="max-w-64 text-xs">
+              {t('plugin.gpu.basicModeHint')}
+            </TooltipContent>
+          </Tooltip>
+        )}
+      </div>
+
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+        <SummaryCard
+          label={t('plugin.gpu.totalGpus')}
+          value={data.summary.totalGPUs}
+        />
+        <SummaryCard
+          label={t('plugin.gpu.allocated')}
+          value={data.summary.allocatedGPUs}
+        />
+        <SummaryCard label={t('plugin.gpu.free')} value={data.summary.freeGPUs} />
+      </div>
+
+      <div className="flex flex-col gap-4">
+        {data.nodes.map((node) => (
+          <NodeGpuCard key={node.name} node={node} level={data.level} />
+        ))}
+      </div>
+
+      {data.unassignedCards && data.unassignedCards.length > 0 && (
+        <div className="flex flex-col gap-2">
+          <h2 className="text-sm font-semibold text-muted-foreground">
+            {t('plugin.gpu.unassignedCards')}
+          </h2>
+          <div className="grid grid-cols-2 gap-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-6">
+            {data.unassignedCards.map((card) => (
+              <GpuCardSlot key={`${card.uuid}-${card.index}`} card={card} />
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/ui/src/plugins/gpu/i18n.ts
+++ b/ui/src/plugins/gpu/i18n.ts
@@ -1,0 +1,73 @@
+// Plugin-owned translations, registered at module load so the core i18n
+// files stay untouched.
+import i18n from '@/i18n'
+
+const en = {
+  nav: { gpu: 'GPU' },
+  plugin: {
+    gpu: {
+      title: 'GPU Overview',
+      totalGpus: 'Total GPUs',
+      allocated: 'Allocated',
+      free: 'Free',
+      idle: 'Idle',
+      utilization: 'Utilization',
+      memory: 'Memory',
+      occupiedBy: 'Occupied by',
+      modeBasic: 'Scheduler view',
+      modeDcgm: 'Live (DCGM)',
+      basicModeHint:
+        'Estimated from resource requests, not actual card binding. Install dcgm-exporter for per-card live data.',
+      syntheticSlotHint:
+        'Synthetic slot estimated from resource requests, not an actual card binding.',
+      noGpuInCluster: 'No GPU detected in this cluster.',
+      unassignedCards: 'Unassigned cards',
+      failedToLoad: 'Failed to load GPU overview',
+      nodeNotReady: 'NotReady',
+      resetGpu: 'Reset GPU',
+      resetTitle: 'Reset GPU on {{node}}',
+      resetDescription:
+        'Deletes the NVIDIA device-plugin pod on this node; its DaemonSet recreates it and re-registers the GPUs. Running workloads keep their GPUs.',
+      resetWillDelete: 'The following pod(s) will be deleted:',
+      resetConfirm: 'Delete & Reset',
+      resetting: 'Resetting...',
+      resetSuccess: 'Device plugin pod deleted: {{pods}}. GPUs will re-register shortly.',
+    },
+  },
+}
+
+const zh = {
+  nav: { gpu: 'GPU' },
+  plugin: {
+    gpu: {
+      title: 'GPU 總覽',
+      totalGpus: '總卡數',
+      allocated: '已佔用',
+      free: '空閒',
+      idle: '空閒',
+      utilization: '使用率',
+      memory: '顯存',
+      occupiedBy: '佔用者',
+      modeBasic: '排程視圖',
+      modeDcgm: '即時(DCGM)',
+      basicModeHint:
+        '依 resource requests 推算,非實際綁定。安裝 dcgm-exporter 可顯示每張卡的即時資料。',
+      syntheticSlotHint: '依 resource requests 推算的合成卡格,非實際卡綁定。',
+      noGpuInCluster: '此叢集未偵測到 GPU。',
+      unassignedCards: '未歸屬節點的卡',
+      failedToLoad: '載入 GPU 總覽失敗',
+      nodeNotReady: 'NotReady',
+      resetGpu: '重置 GPU',
+      resetTitle: '重置 {{node}} 的 GPU',
+      resetDescription:
+        '刪除此節點上的 NVIDIA device-plugin pod,DaemonSet 會自動重建並重新註冊 GPU。執行中的工作負載不受影響。',
+      resetWillDelete: '將刪除以下 pod:',
+      resetConfirm: '刪除並重置',
+      resetting: '重置中...',
+      resetSuccess: '已刪除 device plugin pod:{{pods}},GPU 將在稍後重新註冊。',
+    },
+  },
+}
+
+i18n.addResourceBundle('en', 'translation', en, true, false)
+i18n.addResourceBundle('zh', 'translation', zh, true, false)

--- a/ui/src/plugins/gpu/index.tsx
+++ b/ui/src/plugins/gpu/index.tsx
@@ -1,0 +1,16 @@
+import { IconCpu2 } from '@tabler/icons-react'
+
+import './i18n'
+
+import type { KitePluginDescriptor } from '../types'
+import { GpuPage } from './gpu-page'
+
+export const gpuPlugin: KitePluginDescriptor = {
+  name: 'gpu',
+  route: { path: 'gpu', element: <GpuPage /> },
+  sidebar: {
+    titleKey: 'nav.gpu',
+    icon: IconCpu2,
+    url: '/gpu',
+  },
+}

--- a/ui/src/plugins/gpu/types.ts
+++ b/ui/src/plugins/gpu/types.ts
@@ -1,0 +1,69 @@
+// Mirrors pkg/plugins/gpu/types.go
+export interface GpuSummary {
+  totalGPUs: number
+  allocatedGPUs: number
+  freeGPUs: number
+}
+
+export interface GpuContainerAllocation {
+  name: string
+  count: number
+}
+
+export interface GpuPodAllocation {
+  namespace: string
+  name: string
+  count: number
+  containers: GpuContainerAllocation[]
+}
+
+export interface GpuNodeResource {
+  key: string
+  allocatable: number
+  allocated: number
+  pods: GpuPodAllocation[]
+}
+
+export interface GpuOccupant {
+  namespace: string
+  pod: string
+  container?: string
+}
+
+export interface GpuCard {
+  index: string
+  uuid: string
+  modelName?: string
+  utilization: number
+  memoryUsedBytes?: number
+  memoryTotalBytes?: number
+  occupant: GpuOccupant | null
+}
+
+export interface GpuNode {
+  name: string
+  ready: boolean
+  gpuModel?: string
+  resources: GpuNodeResource[]
+  cards?: GpuCard[]
+}
+
+export type GpuLevel = 'basic' | 'dcgm'
+
+export interface GpuOverview {
+  level: GpuLevel
+  resourceKeys: string[]
+  summary: GpuSummary
+  nodes: GpuNode[]
+  unassignedCards?: GpuCard[]
+}
+
+export interface ResetPodRef {
+  namespace: string
+  name: string
+}
+
+export interface ResetDevicePluginResponse {
+  dryRun: boolean
+  pods: ResetPodRef[]
+}

--- a/ui/src/plugins/index.tsx
+++ b/ui/src/plugins/index.tsx
@@ -1,0 +1,83 @@
+// kite-fork plugin registry: collects plugin descriptors and exposes the
+// route/sidebar mount points consumed by routes.tsx and app-sidebar.tsx.
+import { useQuery } from '@tanstack/react-query'
+import { useTranslation } from 'react-i18next'
+import { Link, useLocation, type RouteObject } from 'react-router-dom'
+
+import { apiClient } from '@/lib/api-client'
+import {
+  SidebarGroup,
+  SidebarGroupContent,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+} from '@/components/ui/sidebar'
+
+import { gpuPlugin } from './gpu'
+import type { KitePluginDescriptor, PluginsResponse } from './types'
+
+export const plugins: KitePluginDescriptor[] = [gpuPlugin]
+
+export const pluginRoutes: RouteObject[] = plugins.map((p) => p.route)
+
+export function usePluginsStatus() {
+  // The 'plugins' queryKey is not in cluster-context's invalidation exclude
+  // list, so switching clusters refetches and the sidebar follows.
+  return useQuery<PluginsResponse>({
+    queryKey: ['plugins'],
+    queryFn: () => apiClient.get<PluginsResponse>('/plugins'),
+    staleTime: 60_000,
+    refetchInterval: 60_000,
+    retry: 1,
+  })
+}
+
+export function usePluginEnabled(name: string): boolean {
+  const { data } = usePluginsStatus()
+  return data?.plugins?.find((p) => p.name === name)?.enabled ?? false
+}
+
+export function PluginSidebarItems({
+  onItemClick,
+}: {
+  onItemClick?: () => void
+}) {
+  const { t } = useTranslation()
+  const location = useLocation()
+  const { data } = usePluginsStatus()
+
+  const enabledPlugins = plugins.filter(
+    (p) => data?.plugins?.find((s) => s.name === p.name)?.enabled
+  )
+  if (enabledPlugins.length === 0) {
+    return null
+  }
+
+  return (
+    <SidebarGroup>
+      <SidebarGroupContent>
+        <SidebarMenu>
+          {enabledPlugins.map((p) => {
+            const title = t(p.sidebar.titleKey, {
+              defaultValue: p.sidebar.titleKey,
+            })
+            return (
+              <SidebarMenuItem key={p.name}>
+                <SidebarMenuButton
+                  tooltip={title}
+                  asChild
+                  isActive={location.pathname.startsWith(p.sidebar.url)}
+                >
+                  <Link to={p.sidebar.url} onClick={onItemClick}>
+                    <p.sidebar.icon className="text-sidebar-primary" />
+                    <span>{title}</span>
+                  </Link>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+            )
+          })}
+        </SidebarMenu>
+      </SidebarGroupContent>
+    </SidebarGroup>
+  )
+}

--- a/ui/src/plugins/types.ts
+++ b/ui/src/plugins/types.ts
@@ -1,0 +1,25 @@
+import type { ComponentType, ReactElement } from 'react'
+
+// KitePluginDescriptor is the frontend half of a kite-fork plugin. The
+// `name` must match the backend plugin name reported by GET /api/v1/plugins;
+// the sidebar entry is only rendered when the backend reports enabled=true
+// for the current cluster.
+export interface KitePluginDescriptor {
+  name: string
+  route: { path: string; element: ReactElement }
+  sidebar: {
+    titleKey: string
+    icon: ComponentType<{ className?: string }>
+    url: string
+  }
+}
+
+export interface PluginStatus {
+  name: string
+  enabled: boolean
+  extra?: Record<string, unknown>
+}
+
+export interface PluginsResponse {
+  plugins: PluginStatus[]
+}

--- a/ui/src/routes.tsx
+++ b/ui/src/routes.tsx
@@ -4,6 +4,7 @@ import App, { StandaloneAIChatApp } from './App'
 import { InitCheckRoute } from './components/init-check-route'
 import { ProtectedRoute } from './components/protected-route'
 import { getSubPath } from './lib/subpath'
+import { pluginRoutes } from './plugins' // kite-fork: plugin registry
 import { CRListPage } from './pages/cr-list-page'
 import { HelmChartDetailPage } from './pages/helm-chart-detail-page'
 import { HelmChartListPage } from './pages/helm-chart-list-page'
@@ -58,6 +59,7 @@ export const router = createBrowserRouter(
           path: 'dashboard',
           element: <Overview />,
         },
+        ...pluginRoutes, // kite-fork: plugin registry (must precede :resource)
         {
           path: 'settings',
           element: <SettingsPage />,


### PR DESCRIPTION
## 功能

當叢集有 GPU 時,側邊欄自動出現「GPU」頁面(無 GPU 的叢集不顯示,多叢集各自偵測):

- **總覽**:全叢集 GPU 總卡數 / 已佔用 / 空閒
- **依節點分組的卡格**:佔用中的卡顯示 pod / container(可點擊跳轉 pod 詳情),空卡顯示 Idle
- **卡級即時模式**:偵測到 dcgm-exporter 時自動升級,顯示每卡使用率、顯存、UUID 與 pod 歸屬;dcgm 不可用時自動降級回排程視圖(依 resource requests 推算)
- **重置 GPU**:每節點提供按鈕,刪除該節點的 nvidia-device-plugin pod(DaemonSet 自動重建)以重新註冊 GPU;先 dryRun 預覽目標 pod 再確認執行

## 架構:輕量插件層

kite 上游沒有 runtime 擴充機制。本 PR 引入插件層,讓 fork 功能自成一體、後續 merge 上游時衝突面最小:

```
pkg/plugins/registry.go     插件 interface + 註冊表 + GET /api/v1/plugins
pkg/plugins/gpu/            GPU 插件後端(第一個插件)
ui/src/plugins/index.tsx    前端插件註冊層(路由 + 條件式側邊欄)
ui/src/plugins/gpu/         GPU 插件前端(含自帶 i18n,en/zh)
```

核心檔案只插入 hook 行,全部以 `kite-fork` 註解標記,rebase 時 `grep -rn "kite-fork"` 即可找回:

| 檔案 | 改動 |
|---|---|
| `routes.go` | +3 行(import + `pluginsall.RegisterRoutes(api)`,位於 RBACMiddleware 之前) |
| `ui/src/routes.tsx` | +2 行(spread `...pluginRoutes`) |
| `ui/src/components/app-sidebar.tsx` | +4 行(`<PluginSidebarItems />`) |

## ⚠️ 部署必要條件(詳見 GPU-PLUGIN.md)

1. **dcgm-exporter 必須設 `DCGM_EXPORTER_KUBERNETES_GPU_ID_TYPE=uid`**(搭配 `DCGM_EXPORTER_KUBERNETES=true`)才能正確抓取每張卡的佔用。`device-name` 會與 device plugin 回報給 kubelet 的 GPU UUID 對不上,metrics 完全不帶 pod label,所有卡都會顯示 Idle。既有叢集的 patch 指令與「gpu-operator 由 Helm 管理時需同步寫入 values,否則 upgrade 會沖掉」的提醒都在 GPU-PLUGIN.md。
2. **Prometheus URL**:kite 自動發現只認 9090/8429,VictoriaMetrics vmsingle 的 8428 需在叢集設定手動填入(如 `http://vmsingle-vmks.monitoring.svc.cluster.local:8428`)。

## 安全性

- 插件路由掛在 RBACMiddleware 之前(其 URL 解析不認得 `/plugins/*`),每個 handler 內自行做 `rbac.CanAccessCluster`,與 overview / metrics endpoints 同水位
- 重置 GPU 額外逐 pod 檢查該 namespace 的 `pods delete` 權限,並在 log 記錄操作者

## 測試與驗證

- 單元測試 10 個:allocation 計算(Succeeded/Failed pod 排除、free clamp、cache/非 cache 兩種路徑)、resource key env 覆寫、dcgm label 正規化(exported_*/plain/self-reference)、device-plugin pod 匹配(gpu-operator/靜態/helm 三種部署風格、跨節點不誤中)
- 已在實際 GPU 叢集端到端驗證:數量與 `kubectl describe node` 交叉一致、無 GPU 叢集正確隱藏選單、dcgm 卡級歸屬正確、reset dryRun 找到正確目標 pod、rolling restart 期間無告警誤發
- `go test ./...`、前端 tsc/vite build、eslint 全數通過

## 相容性

- GPU 資源 key 可用 `GPU_RESOURCE_KEYS` 環境變數擴充(預設 `nvidia.com/gpu`)
- 相容 main 最新的 `/_clusters/:cluster` 路由結構(插件在兩種路徑下都註冊)
- `DISABLE_CACHE` 模式有 list-all fallback
