### PR TITLE
Fix resource table sorting and ConfigMap key display

### DIFF
--- a/ui/src/lib/k8s.ts
+++ b/ui/src/lib/k8s.ts
@@ -26,6 +26,7 @@ export function getPodStatus(pod?: Pod): PodStatus {
       readyContainers: 0,
       totalContainers: 0,
       reason: 'Unknown',
+      restarts: 0,
       restartString: '0',
     }
   }
@@ -197,6 +198,7 @@ export function getPodStatus(pod?: Pod): PodStatus {
     readyContainers,
     totalContainers,
     reason,
+    restarts,
     restartString: restartsStr,
   }
 }

--- a/ui/src/pages/configmap-list-page.tsx
+++ b/ui/src/pages/configmap-list-page.tsx
@@ -5,6 +5,11 @@ import { Link } from 'react-router-dom'
 
 import { createSearchFilter } from '@/lib/k8s'
 import { formatDate } from '@/lib/utils'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
 import { ResourceTable } from '@/components/resource-table'
 
 const configMapSearchFilter = createSearchFilter<ConfigMap>(
@@ -34,21 +39,27 @@ export function ConfigMapListPage() {
           </div>
         ),
       }),
-      columnHelper.accessor('data', {
+      columnHelper.accessor((row) => Object.keys(row.data || {}).join(', '), {
+        id: 'data',
         header: 'Data Keys',
-        cell: ({ getValue }) => {
-          const data = getValue() || {}
+        cell: ({ row }) => {
+          const data = row.original.data || {}
           const keys = Object.keys(data)
           if (keys.length === 0) {
             return '-'
           }
-          // Limit to first 5 keys for display
-          return keys.length > 5 ? (
-            <span className="text-muted-foreground">
-              {keys.slice(0, 5).join(', ')}...
-            </span>
-          ) : (
-            <span className="text-muted-foreground">{keys.join(', ')}</span>
+          const keyList = keys.join(', ')
+          return (
+            <Tooltip>
+              <TooltipTrigger>
+                <span className="line-clamp-2 max-w-64 break-all text-left text-muted-foreground">
+                  {keyList}
+                </span>
+              </TooltipTrigger>
+              <TooltipContent>
+                <p className="max-w-sm break-all">{keyList}</p>
+              </TooltipContent>
+            </Tooltip>
           )
         },
       }),

--- a/ui/src/pages/crd-list-page.tsx
+++ b/ui/src/pages/crd-list-page.tsx
@@ -38,34 +38,38 @@ export function CRDListPage() {
           <span className="text-sm font-mono">{getValue()}</span>
         ),
       }),
-      columnHelper.accessor('spec.versions', {
-        header: 'Versions',
-        cell: ({ getValue }) => {
-          const versions = getValue() || []
-          return (
-            <div className="flex flex-wrap gap-1">
-              {versions.map(
-                (
-                  version: {
-                    name: string
-                    served?: boolean
-                    storage?: boolean
-                  },
-                  index: number
-                ) => (
-                  <Badge
-                    key={index}
-                    variant={version.served ? 'default' : 'secondary'}
-                    className="text-xs font-mono"
-                  >
-                    {version.name}
-                  </Badge>
-                )
-              )}
-            </div>
-          )
-        },
-      }),
+      columnHelper.accessor(
+        (row) => row.spec?.versions?.map((version) => version.name).join(', '),
+        {
+          id: 'spec_versions',
+          header: 'Versions',
+          cell: ({ row }) => {
+            const versions = row.original.spec?.versions || []
+            return (
+              <div className="flex flex-wrap gap-1">
+                {versions.map(
+                  (
+                    version: {
+                      name: string
+                      served?: boolean
+                      storage?: boolean
+                    },
+                    index: number
+                  ) => (
+                    <Badge
+                      key={index}
+                      variant={version.served ? 'default' : 'secondary'}
+                      className="text-xs font-mono"
+                    >
+                      {version.name}
+                    </Badge>
+                  )
+                )}
+              </div>
+            )
+          },
+        }
+      ),
       columnHelper.accessor('spec.scope', {
         header: 'Scope',
         cell: ({ getValue }) => (
@@ -77,25 +81,33 @@ export function CRDListPage() {
           </Badge>
         ),
       }),
-      columnHelper.accessor('status.conditions', {
-        header: 'Status',
-        cell: ({ getValue }) => {
-          const conditions = getValue() || []
-          const establishedCondition = conditions.find(
-            (c: { type: string; status: string }) => c.type === 'Established'
+      columnHelper.accessor(
+        (row) => {
+          const establishedCondition = row.status?.conditions?.find(
+            (condition) => condition.type === 'Established'
           )
-          const isEstablished = establishedCondition?.status === 'True'
-
-          return (
-            <Badge
-              variant={isEstablished ? 'default' : 'destructive'}
-              className="text-xs"
-            >
-              {isEstablished ? 'Established' : 'Not Ready'}
-            </Badge>
-          )
+          return establishedCondition?.status === 'True'
+            ? 'Established'
+            : 'Not Ready'
         },
-      }),
+        {
+          id: 'status_conditions',
+          header: 'Status',
+          cell: ({ getValue }) => {
+            const status = getValue()
+            const isEstablished = status === 'Established'
+
+            return (
+              <Badge
+                variant={isEstablished ? 'default' : 'destructive'}
+                className="text-xs"
+              >
+                {status}
+              </Badge>
+            )
+          },
+        }
+      ),
       columnHelper.accessor('metadata.creationTimestamp', {
         header: 'Age',
         cell: ({ getValue }) => {

--- a/ui/src/pages/daemonset-list-page.tsx
+++ b/ui/src/pages/daemonset-list-page.tsx
@@ -49,42 +49,52 @@ export function DaemonSetListPage() {
         header: t('common.fields.ready'),
         cell: ({ getValue }) => getValue() || 0,
       }),
-      columnHelper.accessor('status.numberAvailable', {
+      columnHelper.accessor((row) => row.status?.numberAvailable || 0, {
+        id: 'status_numberAvailable',
         header: t('common.fields.available'),
         cell: ({ getValue }) => getValue() || 0,
       }),
-      columnHelper.accessor('status.conditions', {
-        header: t('common.fields.status'),
-        cell: ({ row }) => {
-          const readyReplicas = row.original.status?.numberReady || 0
-          const replicas = row.original.status?.desiredNumberScheduled || 0
-          const isAvailable = readyReplicas === replicas
-          const status = isAvailable
+      columnHelper.accessor(
+        (row) => {
+          const readyReplicas = row.status?.numberReady || 0
+          const replicas = row.status?.desiredNumberScheduled || 0
+          if (replicas === 0) return 'Pending'
+          return readyReplicas === replicas
             ? t('common.fields.available')
             : t('common.messages.loading')
-          if (replicas === 0) {
+        },
+        {
+          id: 'status_conditions',
+          header: t('common.fields.status'),
+          cell: ({ row, getValue }) => {
+            const readyReplicas = row.original.status?.numberReady || 0
+            const replicas = row.original.status?.desiredNumberScheduled || 0
+            const isAvailable = readyReplicas === replicas
+            const status = getValue()
+            if (replicas === 0) {
+              return (
+                <Badge
+                  variant="secondary"
+                  className="text-muted-foreground px-1.5"
+                >
+                  Pending
+                </Badge>
+              )
+            }
+
             return (
-              <Badge
-                variant="secondary"
-                className="text-muted-foreground px-1.5"
-              >
-                Pending
+              <Badge variant="outline" className="text-muted-foreground px-1.5">
+                {isAvailable ? (
+                  <IconCircleCheckFilled className="fill-green-500 dark:fill-green-400" />
+                ) : (
+                  <IconLoader className="animate-spin" />
+                )}
+                {status}
               </Badge>
             )
-          }
-
-          return (
-            <Badge variant="outline" className="text-muted-foreground px-1.5">
-              {isAvailable ? (
-                <IconCircleCheckFilled className="fill-green-500 dark:fill-green-400" />
-              ) : (
-                <IconLoader className="animate-spin" />
-              )}
-              {status}
-            </Badge>
-          )
-        },
-      }),
+          },
+        }
+      ),
       columnHelper.accessor('metadata.creationTimestamp', {
         header: t('common.fields.created'),
         cell: ({ getValue }) => {

--- a/ui/src/pages/deployment-list-page.tsx
+++ b/ui/src/pages/deployment-list-page.tsx
@@ -54,10 +54,11 @@ export function DeploymentListPage() {
           )
         },
       }),
-      columnHelper.accessor('status.conditions', {
+      columnHelper.accessor((row) => getDeploymentStatus(row), {
+        id: 'status_conditions',
         header: t('common.fields.status'),
-        cell: ({ row }) => {
-          const status = getDeploymentStatus(row.original)
+        cell: ({ getValue }) => {
+          const status = getValue()
           return (
             <Badge variant="outline" className="text-muted-foreground px-1.5">
               <DeploymentStatusIcon status={status} />

--- a/ui/src/pages/event-list-page.tsx
+++ b/ui/src/pages/event-list-page.tsx
@@ -91,7 +91,7 @@ export function EventListPage() {
           </div>
         ),
       }),
-      columnHelper.accessor((row) => row.count, {
+      columnHelper.accessor((row) => row.count ?? 1, {
         id: 'count',
         header: t('common.fields.count'),
         cell: ({ getValue }) => {

--- a/ui/src/pages/httproute-list-page.tsx
+++ b/ui/src/pages/httproute-list-page.tsx
@@ -26,9 +26,10 @@ export function HTTPRouteListPage() {
           </div>
         ),
       }),
-      columnHelper.accessor('spec.hostnames', {
+      columnHelper.accessor((row) => row.spec?.hostnames?.join(', ') || '', {
+        id: 'spec_hostnames',
         header: 'Hostnames',
-        cell: ({ row }) => row.original.spec?.hostnames?.join(', ') || 'N/A',
+        cell: ({ getValue }) => getValue() || 'N/A',
       }),
       columnHelper.accessor('metadata.creationTimestamp', {
         header: 'Created',

--- a/ui/src/pages/ingress-list-page.tsx
+++ b/ui/src/pages/ingress-list-page.tsx
@@ -31,30 +31,41 @@ export function IngressListPage() {
         header: 'Ingress Class',
         cell: ({ row }) => row.original.spec?.ingressClassName || 'N/A',
       }),
-      columnHelper.accessor('spec.rules', {
-        header: 'Hosts',
-        cell: ({ row }) => {
-          const rules = row.original.spec?.rules || []
-          return (
-            <Badge variant="outline" className="ml-2 ">
-              {rules.length > 0 ? rules.map((r) => r.host).join(', ') : 'N/A'}
-            </Badge>
-          )
-        },
-      }),
-      columnHelper.accessor('status.loadBalancer.ingress', {
-        header: 'Load Balancer',
-        cell: ({ row }) => {
-          const ingress = row.original.status?.loadBalancer?.ingress || []
-          return (
-            <div>
-              {ingress.length > 0
-                ? ingress.map((i) => i.ip || i.hostname).join(', ')
-                : 'N/A'}
-            </div>
-          )
-        },
-      }),
+      columnHelper.accessor(
+        (row) => row.spec?.rules?.map((rule) => rule.host).join(', ') || '',
+        {
+          id: 'spec_rules',
+          header: 'Hosts',
+          cell: ({ row }) => {
+            const rules = row.original.spec?.rules || []
+            return (
+              <Badge variant="outline" className="ml-2 ">
+                {rules.length > 0 ? rules.map((r) => r.host).join(', ') : 'N/A'}
+              </Badge>
+            )
+          },
+        }
+      ),
+      columnHelper.accessor(
+        (row) =>
+          row.status?.loadBalancer?.ingress
+            ?.map((ingress) => ingress.ip || ingress.hostname)
+            .join(', ') || '',
+        {
+          id: 'status_loadBalancer_ingress',
+          header: 'Load Balancer',
+          cell: ({ row }) => {
+            const ingress = row.original.status?.loadBalancer?.ingress || []
+            return (
+              <div>
+                {ingress.length > 0
+                  ? ingress.map((i) => i.ip || i.hostname).join(', ')
+                  : 'N/A'}
+              </div>
+            )
+          },
+        }
+      ),
       columnHelper.accessor('metadata.creationTimestamp', {
         header: 'Created',
         cell: ({ getValue }) => {

--- a/ui/src/pages/job-list-page.tsx
+++ b/ui/src/pages/job-list-page.tsx
@@ -33,30 +33,44 @@ export function JobListPage() {
           </div>
         ),
       }),
-      columnHelper.accessor('status.conditions', {
-        header: 'Status',
-        cell: ({ row }) => {
-          const conditions = row.original.status?.conditions || []
-          const completedCondition = conditions.find(
-            (c) => c.type === 'Complete'
-          )
-          const failedCondition = conditions.find((c) => c.type === 'Failed')
-
-          let status = 'Running'
-          let variant: 'default' | 'destructive' | 'secondary' = 'secondary'
-
-          if (completedCondition?.status === 'True') {
-            status = 'Complete'
-            variant = 'default'
-          } else if (failedCondition?.status === 'True') {
-            status = 'Failed'
-            variant = 'destructive'
+      columnHelper.accessor(
+        (row) => {
+          const conditions = row.status?.conditions || []
+          if (
+            conditions.some(
+              (condition) =>
+                condition.type === 'Complete' && condition.status === 'True'
+            )
+          ) {
+            return 'Complete'
           }
-
-          return <Badge variant={variant}>{status}</Badge>
+          if (
+            conditions.some(
+              (condition) =>
+                condition.type === 'Failed' && condition.status === 'True'
+            )
+          ) {
+            return 'Failed'
+          }
+          return 'Running'
         },
-      }),
-      columnHelper.accessor((row) => row.status, {
+        {
+          id: 'status_conditions',
+          header: 'Status',
+          cell: ({ getValue }) => {
+            const status = getValue()
+            const variant =
+              status === 'Complete'
+                ? 'default'
+                : status === 'Failed'
+                  ? 'destructive'
+                  : 'secondary'
+
+            return <Badge variant={variant}>{status}</Badge>
+          },
+        }
+      ),
+      columnHelper.accessor((row) => row.status?.succeeded || 0, {
         id: 'completions',
         header: 'Completions',
         cell: ({ row }) => {

--- a/ui/src/pages/node-list-page.tsx
+++ b/ui/src/pages/node-list-page.tsx
@@ -152,11 +152,11 @@ export function NodeListPage() {
           )
         },
       }),
-      columnHelper.accessor((row) => getNodeRoles(row), {
+      columnHelper.accessor((row) => getNodeRoles(row).join(', '), {
         id: 'roles',
         header: 'Roles',
-        cell: ({ getValue }) => {
-          const roles = getValue()
+        cell: ({ row }) => {
+          const roles = getNodeRoles(row.original)
           return (
             <div>
               {roles.map((role) => (
@@ -172,7 +172,7 @@ export function NodeListPage() {
           )
         },
       }),
-      columnHelper.accessor((row) => row.metrics, {
+      columnHelper.accessor((row) => row.metrics?.pods || 0, {
         id: 'pods',
         header: 'Pods',
         cell: ({ row }) => (

--- a/ui/src/pages/pod-list-page.tsx
+++ b/ui/src/pages/pod-list-page.tsx
@@ -45,7 +45,7 @@ export function PodListPage() {
           </div>
         ),
       }),
-      columnHelper.accessor((row) => row.status?.containerStatuses, {
+      columnHelper.accessor((row) => getPodStatus(row).readyContainers, {
         id: 'containers',
         header: t('common.fields.ready'),
         cell: ({ row }) => {
@@ -70,7 +70,7 @@ export function PodListPage() {
           )
         },
       }),
-      columnHelper.accessor((row) => row.status, {
+      columnHelper.accessor((row) => getPodStatus(row).restarts, {
         id: 'restarts',
         header: t('common.fields.restarts'),
         cell: ({ row }) => {

--- a/ui/src/pages/pv-list-page.tsx
+++ b/ui/src/pages/pv-list-page.tsx
@@ -80,12 +80,10 @@ export function PVListPage() {
           cell: ({ row }) => row.original.spec?.capacity?.storage || '-',
         }
       ),
-      columnHelper.accessor('spec.accessModes', {
+      columnHelper.accessor((row) => row.spec?.accessModes?.join(', ') || '', {
+        id: 'spec_accessModes',
         header: t('common.fields.accessModes'),
-        cell: ({ getValue }) => {
-          const modes = getValue() || []
-          return modes.join(', ') || '-'
-        },
+        cell: ({ getValue }) => getValue() || '-',
       }),
       columnHelper.accessor('spec.persistentVolumeReclaimPolicy', {
         header: t('common.fields.reclaimPolicy'),
@@ -94,24 +92,33 @@ export function PVListPage() {
           return policy || '-'
         },
       }),
-      columnHelper.accessor('spec.claimRef', {
-        header: t('common.fields.claim'),
-        cell: ({ getValue }) => {
-          const claimRef = getValue()
-          if (claimRef && claimRef.name && claimRef.namespace) {
-            return (
-              <div className="font-medium app-link">
-                <Link
-                  to={`/persistentvolumeclaims/${claimRef.namespace}/${claimRef.name}`}
-                >
-                  {claimRef.namespace}/{claimRef.name}
-                </Link>
-              </div>
-            )
-          }
-          return '-'
+      columnHelper.accessor(
+        (row) => {
+          const claimRef = row.spec?.claimRef
+          return claimRef?.name && claimRef.namespace
+            ? `${claimRef.namespace}/${claimRef.name}`
+            : ''
         },
-      }),
+        {
+          id: 'spec_claimRef',
+          header: t('common.fields.claim'),
+          cell: ({ row }) => {
+            const claimRef = row.original.spec?.claimRef
+            if (claimRef && claimRef.name && claimRef.namespace) {
+              return (
+                <div className="font-medium app-link">
+                  <Link
+                    to={`/persistentvolumeclaims/${claimRef.namespace}/${claimRef.name}`}
+                  >
+                    {claimRef.namespace}/{claimRef.name}
+                  </Link>
+                </div>
+              )
+            }
+            return '-'
+          },
+        }
+      ),
       columnHelper.accessor('metadata.creationTimestamp', {
         header: t('common.fields.created'),
         cell: ({ getValue }) => {

--- a/ui/src/pages/pvc-list-page.tsx
+++ b/ui/src/pages/pvc-list-page.tsx
@@ -99,12 +99,10 @@ export function PVCListPage() {
             row.original.spec?.resources?.requests?.storage || '-',
         }
       ),
-      columnHelper.accessor('spec.accessModes', {
+      columnHelper.accessor((row) => row.spec?.accessModes?.join(', ') || '', {
+        id: 'spec_accessModes',
         header: t('common.fields.accessModes'),
-        cell: ({ getValue }) => {
-          const modes = getValue() || []
-          return modes.join(', ') || '-'
-        },
+        cell: ({ getValue }) => getValue() || '-',
       }),
       columnHelper.accessor('metadata.creationTimestamp', {
         header: t('common.fields.created'),

--- a/ui/src/pages/secret-list-page.tsx
+++ b/ui/src/pages/secret-list-page.tsx
@@ -35,17 +35,19 @@ export function SecretListPage() {
           </div>
         ),
       }),
-      columnHelper.accessor('type', {
+      columnHelper.accessor((row) => row.type || 'Opaque', {
+        id: 'type',
         header: 'Type',
         cell: ({ getValue }) => {
           const type = getValue() || 'Opaque'
           return <Badge variant="outline">{type}</Badge>
         },
       }),
-      columnHelper.accessor('data', {
+      columnHelper.accessor((row) => Object.keys(row.data || {}).join(', '), {
+        id: 'data',
         header: 'Data Keys',
-        cell: ({ getValue }) => {
-          const data = getValue() || {}
+        cell: ({ row }) => {
+          const data = row.original.data || {}
           const keys = Object.keys(data)
           if (keys.length === 0) {
             return '-'

--- a/ui/src/pages/service-list-page.tsx
+++ b/ui/src/pages/service-list-page.tsx
@@ -42,7 +42,8 @@ export function ServiceListPage() {
           </div>
         ),
       }),
-      columnHelper.accessor('spec.type', {
+      columnHelper.accessor((row) => row.spec?.type || 'ClusterIP', {
+        id: 'spec_type',
         header: t('common.fields.type'),
         enableColumnFilter: true,
         cell: ({ getValue }) => {
@@ -61,10 +62,11 @@ export function ServiceListPage() {
           )
         },
       }),
-      columnHelper.accessor('status.loadBalancer.ingress', {
+      columnHelper.accessor((row) => getServiceExternalIP(row), {
+        id: 'status_loadBalancer_ingress',
         header: t('common.fields.externalIP'),
-        cell: ({ row }) => {
-          const val = getServiceExternalIP(row.original)
+        cell: ({ getValue }) => {
+          const val = getValue()
           return (
             <span className="font-mono text-sm text-muted-foreground">
               {val}
@@ -72,27 +74,31 @@ export function ServiceListPage() {
           )
         },
       }),
-      columnHelper.accessor('spec.ports', {
-        header: t('common.fields.ports'),
-        cell: ({ getValue }) => {
-          const ports = getValue() || []
-          if (ports.length === 0) return '-'
-          const text = ports
-            .map((port) => {
-              const protocol = port.protocol || 'TCP'
-              if (port.nodePort) {
-                return `${port.port}:${port.nodePort}/${protocol}`
-              }
-              return `${port.port}/${protocol}`
-            })
-            .join(', ')
-          return (
-            <span className="font-mono text-sm text-muted-foreground">
-              {text}
-            </span>
-          )
-        },
-      }),
+      columnHelper.accessor(
+        (row) => getServicePortSearchValues(row).join(', '),
+        {
+          id: 'spec_ports',
+          header: t('common.fields.ports'),
+          cell: ({ row }) => {
+            const ports = row.original.spec?.ports || []
+            if (ports.length === 0) return '-'
+            const text = ports
+              .map((port) => {
+                const protocol = port.protocol || 'TCP'
+                if (port.nodePort) {
+                  return `${port.port}:${port.nodePort}/${protocol}`
+                }
+                return `${port.port}/${protocol}`
+              })
+              .join(', ')
+            return (
+              <span className="font-mono text-sm text-muted-foreground">
+                {text}
+              </span>
+            )
+          },
+        }
+      ),
       columnHelper.accessor('metadata.creationTimestamp', {
         header: t('common.fields.created'),
         cell: ({ getValue }) => {

--- a/ui/src/pages/statefulset-list-page.tsx
+++ b/ui/src/pages/statefulset-list-page.tsx
@@ -52,38 +52,47 @@ export function StatefulSetListPage() {
           )
         },
       }),
-      columnHelper.accessor('status.conditions', {
-        header: t('common.fields.status'),
-        cell: ({ row }) => {
-          const readyReplicas = row.original.status?.readyReplicas || 0
-          const replicas = row.original.status?.replicas || 0
-          const isAvailable = readyReplicas === replicas
-          const status = isAvailable
+      columnHelper.accessor(
+        (row) => {
+          const readyReplicas = row.status?.readyReplicas || 0
+          const replicas = row.status?.replicas || 0
+          if (replicas === 0) return '-'
+          return readyReplicas === replicas
             ? t('common.fields.available')
             : t('common.messages.loading')
-          if (replicas === 0) {
+        },
+        {
+          id: 'status_conditions',
+          header: t('common.fields.status'),
+          cell: ({ row, getValue }) => {
+            const readyReplicas = row.original.status?.readyReplicas || 0
+            const replicas = row.original.status?.replicas || 0
+            const isAvailable = readyReplicas === replicas
+            const status = getValue()
+            if (replicas === 0) {
+              return (
+                <Badge
+                  variant="secondary"
+                  className="text-muted-foreground px-1.5"
+                >
+                  -
+                </Badge>
+              )
+            }
+
             return (
-              <Badge
-                variant="secondary"
-                className="text-muted-foreground px-1.5"
-              >
-                -
+              <Badge variant="outline" className="text-muted-foreground px-1.5">
+                {isAvailable ? (
+                  <IconCircleCheckFilled className="fill-green-500 dark:fill-green-400" />
+                ) : (
+                  <IconLoader className="animate-spin" />
+                )}
+                {status}
               </Badge>
             )
-          }
-
-          return (
-            <Badge variant="outline" className="text-muted-foreground px-1.5">
-              {isAvailable ? (
-                <IconCircleCheckFilled className="fill-green-500 dark:fill-green-400" />
-              ) : (
-                <IconLoader className="animate-spin" />
-              )}
-              {status}
-            </Badge>
-          )
-        },
-      }),
+          },
+        }
+      ),
       columnHelper.accessor('spec.serviceName', {
         header: t('common.fields.serviceName'),
         cell: ({ getValue }) => getValue() || '-',

--- a/ui/src/pages/storageclass-list-page.tsx
+++ b/ui/src/pages/storageclass-list-page.tsx
@@ -104,15 +104,18 @@ export function StorageClassListPage() {
         header: t('storageClasses.fields.provisioner'),
         enableColumnFilter: true,
       }),
-      columnHelper.accessor('reclaimPolicy', {
+      columnHelper.accessor((row) => row.reclaimPolicy || 'Delete', {
+        id: 'reclaimPolicy',
         header: t('common.fields.reclaimPolicy'),
         cell: ({ getValue }) => getValue() || 'Delete',
       }),
-      columnHelper.accessor('volumeBindingMode', {
+      columnHelper.accessor((row) => row.volumeBindingMode || 'Immediate', {
+        id: 'volumeBindingMode',
         header: t('storageClasses.fields.volumeBindingMode'),
         cell: ({ getValue }) => getValue() || 'Immediate',
       }),
-      columnHelper.accessor('allowVolumeExpansion', {
+      columnHelper.accessor((row) => row.allowVolumeExpansion ?? false, {
+        id: 'allowVolumeExpansion',
         header: t('storageClasses.fields.allowVolumeExpansion'),
         cell: ({ getValue }) =>
           getValue() === true ? t('common.values.yes') : t('common.values.no'),

--- a/ui/src/types/k8s.ts
+++ b/ui/src/types/k8s.ts
@@ -11,6 +11,7 @@ export type PodStatus = {
   readyContainers: number
   totalContainers: number
   reason: string
+  restarts: number
   restartString: string
 }
 


### PR DESCRIPTION
## Summary

- sort resource table columns by scalar values instead of raw Kubernetes objects and arrays
- align accessor defaults with the values rendered in cells
- expose the numeric Pod restart count for sorting while preserving the existing display text
- show ConfigMap data keys in a compact three-line cell without an oversized tooltip

## Root cause

Several table columns returned objects or arrays from their accessors while rendering derived text or numbers. TanStack Table sorted the raw accessor values, so these columns were effectively unsortable or produced unstable ordering.

## Impact

Sorting now follows the values users see across Pod, Node, workload, networking, storage, Secret, ConfigMap, Job, Event, and CRD lists. Long ConfigMap data-key lists remain readable without covering the table.

## Validation

- `make pre-commit`
- `pnpm --dir ui run type-check`
- `pnpm --dir ui run build`