### PR TITLE
fix: secure user account lifecycle

### DIFF
--- a/pkg/model/user.go
+++ b/pkg/model/user.go
@@ -206,13 +206,24 @@ func ListUsers(limit int, offset int, search string, sortBy string, sortOrder st
 func LoginUser(u *User) error {
 	now := time.Now()
 	u.LastLoginAt = &now
-	return DB.Save(u).Error
+	err := DB.Model(&User{}).Where("id = ? AND enabled = ?", u.ID, true).Update("last_login_at", now).Error
+	InvalidateUserCache(uint64(u.ID))
+	return err
 }
 
 // DeleteUserByID removes a user by ID
 func DeleteUserByID(id uint) error {
 	_ = DB.Where("operator_id = ?", id).Delete(&ResourceHistory{}).Error
-	err := DB.Delete(&User{}, id).Error
+	err := DB.Transaction(func(tx *gorm.DB) error {
+		var user User
+		if err := tx.Select("username").First(&user, id).Error; err != nil {
+			return err
+		}
+		if err := tx.Where("subject_type = ? AND subject = ?", SubjectTypeUser, user.Username).Delete(&RoleAssignment{}).Error; err != nil {
+			return err
+		}
+		return tx.Delete(&User{}, id).Error
+	})
 	InvalidateUserCache(uint64(id))
 	return err
 }


### PR DESCRIPTION
## What changed

- Delete user role assignments by username in the same transaction as user deletion.
- Replace the full-row `Save` during login with a conditional `last_login_at` update.
- Invalidate the user cache after recording a login.

## Why

Role assignments are keyed by username rather than user ID, so deleting and recreating the same username could restore the deleted account's roles. The login path also saved a potentially stale full user object, which could overwrite concurrent password or enabled-state changes and recreate a concurrently deleted row.

## Impact

Deleted usernames no longer retain Kite RBAC grants, and login activity updates cannot overwrite security-sensitive user fields or resurrect deleted accounts.

## Validation

- `make pre-commit`