### PR TITLE
fix: isolate cluster-switched UI state

### DIFF
--- a/ui/src/components/terminal-content.tsx
+++ b/ui/src/components/terminal-content.tsx
@@ -22,6 +22,7 @@ import { appendCurrentClusterParam } from '@/lib/current-cluster'
 import { toSimpleContainer } from '@/lib/k8s'
 import { getWebSocketUrl } from '@/lib/subpath'
 import { translateError } from '@/lib/utils'
+import { useCluster } from '@/hooks/use-cluster'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Label } from '@/components/ui/label'
@@ -103,6 +104,7 @@ export function Terminal({
   })
   const speedUpdateTimerRef = useRef<NodeJS.Timeout | null>(null)
   const { t } = useTranslation()
+  const { currentCluster } = useCluster()
 
   // Keep user selection unless the current pod is no longer available.
   useEffect(() => {
@@ -326,7 +328,7 @@ export function Terminal({
     // WebSocket connection
     setIsConnected(false)
     const clusterParams = new URLSearchParams()
-    appendCurrentClusterParam(clusterParams)
+    appendCurrentClusterParam(clusterParams, currentCluster)
     const podParams = new URLSearchParams(clusterParams)
     podParams.set('container', selectedContainer)
     const wsPath =
@@ -493,7 +495,9 @@ export function Terminal({
     selectedPod,
     selectedContainer,
     namespace,
+    nodeName,
     type,
+    currentCluster,
     updateNetworkStats,
     reconnectFlag,
   ])

--- a/ui/src/contexts/cluster-context.tsx
+++ b/ui/src/contexts/cluster-context.tsx
@@ -4,7 +4,7 @@ import { useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { Cluster } from '@/types/api'
-import { useCurrentClusterList } from '@/lib/api'
+import { useCurrentClusterList } from '@/lib/api/cluster'
 import {
   clearCurrentCluster,
   getCurrentCluster,

--- a/ui/src/lib/api/core.ts
+++ b/ui/src/lib/api/core.ts
@@ -24,6 +24,7 @@ import {
   ResourceTypeMap,
 } from '@/types/api'
 import { getResourceQueryKey } from '@/lib/resource-metadata'
+import { useCluster } from '@/hooks/use-cluster'
 
 import { API_BASE_URL, apiClient } from '../api-client'
 import {
@@ -818,12 +819,13 @@ export function useResourcesWatch<T extends ResourceType>(
 export const fetchResource = <T>(
   resource: string,
   name: string,
-  namespace?: string
+  namespace?: string,
+  cluster?: string | null
 ): Promise<T> => {
-  const endpoint = namespace
+  const resourcePath = namespace
     ? `/${resource}/${namespace}/${name}`
     : `/${resource}/${name}`
-  return fetchAPI<T>(endpoint)
+  return fetchAPI<T>(withCurrentClusterPath(resourcePath, cluster))
 }
 export const useResource = <T extends keyof ResourceTypeMap>(
   resource: T,
@@ -831,15 +833,20 @@ export const useResource = <T extends keyof ResourceTypeMap>(
   namespace?: string,
   options?: { staleTime?: number; refreshInterval?: number }
 ) => {
+  const { currentCluster } = useCluster()
   const ns = namespace || '_all'
   return useQuery({
-    queryKey: getResourceQueryKey(resource, ns, name),
+    queryKey: getResourceQueryKey(resource, ns, name, currentCluster),
     queryFn: () => {
-      return fetchResource<ResourceTypeMap[T]>(resource, name, ns)
+      return fetchResource<ResourceTypeMap[T]>(
+        resource,
+        name,
+        ns,
+        currentCluster
+      )
     },
     refetchOnWindowFocus: 'always',
     refetchInterval: options?.refreshInterval || 0, // Default to no auto-refresh
-    placeholderData: (prevData) => prevData,
     staleTime: options?.staleTime || 1000,
   })
 }

--- a/ui/src/lib/api/observability.ts
+++ b/ui/src/lib/api/observability.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
 
 import { OverviewData, PodMetrics, ResourceUsageHistory } from '@/types/api'
+import { useCluster } from '@/hooks/use-cluster'
 
 import { API_BASE_URL } from '../api-client'
 import { appendCurrentClusterParam } from '../current-cluster'
@@ -457,6 +458,9 @@ export const useLogsWebSocket = (
     onClear?: () => void
   }
 ) => {
+  const { currentCluster } = useCluster()
+  const onClear = options?.onClear
+
   // Build WebSocket URL
   const buildWebSocketUrl = useCallback(() => {
     if (!options?.enabled || !namespace || !podName) return ''
@@ -482,7 +486,7 @@ export const useLogsWebSocket = (
       params.append('labelSelector', options.labelSelector)
     }
 
-    appendCurrentClusterParam(params)
+    appendCurrentClusterParam(params, currentCluster)
 
     const wsPath = `/api/v1/logs/${namespace}/${podName}/ws?${params.toString()}`
     return getWebSocketUrl(wsPath)
@@ -496,6 +500,7 @@ export const useLogsWebSocket = (
     options?.sinceSeconds,
     options?.enabled,
     options?.labelSelector,
+    currentCluster,
   ])
 
   // WebSocket event handlers
@@ -552,6 +557,10 @@ export const useLogsWebSocket = (
       reconnectInterval: 5000,
     }
   )
+
+  useEffect(() => {
+    onClear?.()
+  }, [currentCluster, onClear])
 
   const refetch = useCallback(() => {
     wsActions.reconnect()

--- a/ui/src/lib/current-cluster.ts
+++ b/ui/src/lib/current-cluster.ts
@@ -18,8 +18,10 @@ export function clearCurrentCluster() {
   localStorage.removeItem(CURRENT_CLUSTER_STORAGE_KEY)
 }
 
-export function appendCurrentClusterParam(params: URLSearchParams) {
-  const currentCluster = getCurrentCluster()
+export function appendCurrentClusterParam(
+  params: URLSearchParams,
+  currentCluster = getCurrentCluster()
+) {
   if (currentCluster) {
     params.append(CURRENT_CLUSTER_HEADER_KEY, currentCluster)
   }
@@ -32,8 +34,10 @@ export function appendCurrentClusterHeader(headers: Record<string, string>) {
   }
 }
 
-export function withCurrentClusterPath(path: string) {
-  const currentCluster = getCurrentCluster()
+export function withCurrentClusterPath(
+  path: string,
+  currentCluster: string | null = getCurrentCluster()
+) {
   const normalizedPath = path.startsWith('/') ? path : `/${path}`
   if (!currentCluster) {
     return normalizedPath

--- a/ui/src/lib/resource-catalog.ts
+++ b/ui/src/lib/resource-catalog.ts
@@ -1087,9 +1087,10 @@ export function getResourceDetailPath(
 export function getResourceQueryKey(
   resource: string,
   namespace?: string,
-  name?: string
+  name?: string,
+  cluster?: string | null
 ) {
-  return [resource, namespace || '_all', name || '_all']
+  return [resource, namespace || '_all', name || '_all', cluster || '']
 }
 
 export const clusterScopedResourceTypes = resourceMetadataList


### PR DESCRIPTION
## What changed

- Bind terminal and log WebSocket URLs to the reactive current cluster.
- Close and recreate WebSocket connections when the cluster changes, and clear logs from the previous cluster.
- Add the cluster to single-resource query keys and stop retaining placeholder data across cluster changes.
- Bind resource fetches to the cluster represented by their query key.

## Why

WebSocket lifecycle dependencies did not include the selected cluster, so terminal commands and logs could remain connected to the previous cluster after a UI switch. Single-resource queries also reused cache keys and placeholder data across clusters, allowing resources from one cluster to remain visible while mutations targeted another.

## Impact

Cluster switches now isolate terminal sessions, log streams, displayed resource data, and resource operations to the same selected cluster.

## Validation

- `make pre-commit`