### PR TITLE
feat: change client contentType to protobuf

### DIFF
--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -152,7 +152,9 @@ func NewClient(config *rest.Config) (*K8sClient, error) {
 	if config.Burst == 0 {
 		config.Burst = kubeAPIBurst()
 	}
-
+	// Use Protobuf for better performance and less bandwidth on large clusters
+	config.AcceptContentTypes = "application/vnd.kubernetes.protobuf,application/json"
+	config.ContentType = "application/vnd.kubernetes.protobuf"
 	clientset, err := kubernetes.NewForConfig(config)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary

Switch the Kubernetes client to prefer Protobuf responses when creating the
client config.

## Why

Informer initial sync and other Kubernetes API reads can transfer a large amount
of data on big clusters. Preferring Protobuf reduces payload size and improves
transfer efficiency compared with JSON.

## Related issue

Closes #<issue-number>

## Validation

- Ran `go test ./pkg/kube`

## Checklist

- [ ] I reviewed this PR myself before requesting review.
- [ ] I understand the changes, including AI-generated parts (if any).
- [ ] For new features, a feature request issue is linked.
- [x] I cleaned up AI noise (unnecessary comments, dead code, and unrelated changes).
- [x] This PR is reasonably scoped (or split into smaller PRs).
