### PR TITLE
feat: add bulk resource actions and localize node views

### DIFF
--- a/pkg/resources/node_handler.go
+++ b/pkg/resources/node_handler.go
@@ -41,7 +41,7 @@ func (h *NodeHandler) DrainNode(c *gin.Context) {
 	user := c.MustGet("user").(model.User)
 	// Parse the request body for drain options
 	var drainRequest struct {
-		Force            bool `json:"force" binding:"required"`
+		Force            bool `json:"force"`
 		GracePeriod      int  `json:"gracePeriod" binding:"min=0"`
 		DeleteLocal      bool `json:"deleteLocalData"`
 		IgnoreDaemonsets bool `json:"ignoreDaemonsets"`

--- a/ui/src/components/chart/chart-utils.tsx
+++ b/ui/src/components/chart/chart-utils.tsx
@@ -82,6 +82,7 @@ interface ChartStateWrapperProps {
   isEmpty?: boolean
   cardClassName?: string
   contentClassName?: string
+  emptyMessage?: string
   children: React.ReactNode
 }
 
@@ -92,6 +93,7 @@ export function ChartStateWrapper({
   isEmpty,
   cardClassName = '@container/card',
   contentClassName,
+  emptyMessage,
   children,
 }: ChartStateWrapperProps) {
   if (isLoading) {
@@ -136,7 +138,7 @@ export function ChartStateWrapper({
         </CardHeader>
         <CardContent className={contentClassName}>
           <div className="flex h-[250px] w-full items-center justify-center text-muted-foreground">
-            <p>No {title.toLowerCase()} data available</p>
+            <p>{emptyMessage || `No ${title.toLowerCase()} data available`}</p>
           </div>
         </CardContent>
       </Card>

--- a/ui/src/components/chart/network-usage-chart.tsx
+++ b/ui/src/components/chart/network-usage-chart.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import React from 'react'
+import { useTranslation } from 'react-i18next'
 import {
   Area,
   AreaChart,
@@ -36,19 +37,19 @@ interface NetworkUsageChartProps {
   syncId?: string
 }
 
-const chartConfig = {
-  networkIn: {
-    label: 'Incoming',
-    color: 'oklch(0.55 0.20 145)',
-  },
-  networkOut: {
-    label: 'Outgoing',
-    color: 'oklch(0.55 0.22 235)',
-  },
-} satisfies ChartConfig
-
 const NetworkUsageChart = React.memo((prop: NetworkUsageChartProps) => {
+  const { t } = useTranslation()
   const { networkIn, networkOut, isLoading, error, syncId } = prop
+  const chartConfig = {
+    networkIn: {
+      label: t('monitoring.incoming'),
+      color: 'oklch(0.55 0.20 145)',
+    },
+    networkOut: {
+      label: t('monitoring.outgoing'),
+      color: 'oklch(0.55 0.22 235)',
+    },
+  } satisfies ChartConfig
 
   const chartData = React.useMemo(() => {
     const outbound = networkOut.map((point) => ({
@@ -61,7 +62,7 @@ const NetworkUsageChart = React.memo((prop: NetworkUsageChartProps) => {
 
   return (
     <ChartStateWrapper
-      title="Network Usage"
+      title={t('monitoring.networkUsage')}
       isLoading={isLoading}
       error={error}
       isEmpty={
@@ -70,6 +71,7 @@ const NetworkUsageChart = React.memo((prop: NetworkUsageChartProps) => {
         (networkIn.length === 0 && networkOut.length === 0)
       }
       contentClassName="px-2 sm:px-6"
+      emptyMessage={t('monitoring.noNetworkUsageData')}
     >
       <ChartContainer
         config={chartConfig}

--- a/ui/src/components/chart/resource-utilization.tsx
+++ b/ui/src/components/chart/resource-utilization.tsx
@@ -2,6 +2,7 @@
 
 import React from 'react'
 import { AlertTriangle, Loader2 } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
 import { Area, AreaChart, CartesianGrid, XAxis, YAxis } from 'recharts'
 
 import { UsageDataPoint } from '@/types/api'
@@ -26,23 +27,23 @@ interface ResourceUtilizationChartProps {
   error?: Error | null
 }
 
-const chartConfig = {
-  usage: {
-    label: 'Usage',
-  },
-  cpu: {
-    label: 'CPU',
-    color: 'hsl(220, 70%, 50%)',
-  },
-  memory: {
-    label: 'Memory',
-    color: 'hsl(142, 70%, 50%)',
-  },
-} satisfies ChartConfig
-
 const ResourceUtilizationChart = React.memo(
   (prop: ResourceUtilizationChartProps) => {
+    const { t } = useTranslation()
     const { cpu, memory, isLoading, error } = prop
+    const chartConfig = {
+      usage: {
+        label: t('monitoring.usage'),
+      },
+      cpu: {
+        label: t('common.fields.cpu'),
+        color: 'hsl(220, 70%, 50%)',
+      },
+      memory: {
+        label: t('common.fields.memory'),
+        color: 'hsl(142, 70%, 50%)',
+      },
+    } satisfies ChartConfig
     const chartData = React.useMemo(() => {
       if (!cpu || !memory) return []
 
@@ -81,7 +82,7 @@ const ResourceUtilizationChart = React.memo(
           <CardHeader>
             <CardTitle className="flex items-center gap-2">
               <Loader2 className="h-4 w-4 animate-spin" />
-              Resource Utilization
+              {t('monitoring.resourceUtilization')}
             </CardTitle>
           </CardHeader>
           <CardContent className="px-2 sm:px-6">
@@ -98,7 +99,7 @@ const ResourceUtilizationChart = React.memo(
       return (
         <Card className="@container/card">
           <CardHeader>
-            <CardTitle>Resource Utilization</CardTitle>
+            <CardTitle>{t('monitoring.resourceUtilization')}</CardTitle>
           </CardHeader>
           <CardContent className="px-2 sm:px-6">
             <Alert variant="destructive">
@@ -115,11 +116,11 @@ const ResourceUtilizationChart = React.memo(
       return (
         <Card className="@container/card">
           <CardHeader>
-            <CardTitle>Resource Utilization</CardTitle>
+            <CardTitle>{t('monitoring.resourceUtilization')}</CardTitle>
           </CardHeader>
           <CardContent className="px-2 sm:px-6">
             <div className="flex h-[250px] w-full items-center justify-center text-muted-foreground">
-              <p>No resource utilization data available</p>
+              <p>{t('monitoring.noResourceUtilizationData')}</p>
             </div>
           </CardContent>
         </Card>
@@ -129,7 +130,7 @@ const ResourceUtilizationChart = React.memo(
     return (
       <Card className="@container/card">
         <CardHeader>
-          <CardTitle>Resource Utilization</CardTitle>
+          <CardTitle>{t('monitoring.resourceUtilization')}</CardTitle>
         </CardHeader>
         <CardContent className="px-2 sm:px-6">
           <ChartContainer

--- a/ui/src/components/node-monitoring.tsx
+++ b/ui/src/components/node-monitoring.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
 
 import { useResourceUsageHistory } from '@/lib/api'
 import {
@@ -17,6 +18,7 @@ interface NodeMonitoringProps {
 }
 
 export function NodeMonitoring({ name }: NodeMonitoringProps) {
+  const { t } = useTranslation()
   const [timeRange, setTimeRange] = useState('1h')
 
   const {
@@ -28,9 +30,9 @@ export function NodeMonitoring({ name }: NodeMonitoringProps) {
   })
 
   const timeRangeOptions = [
-    { value: '30m', label: 'Last 30 min' },
-    { value: '1h', label: 'Last 1 hour' },
-    { value: '24h', label: 'Last 24 hours' },
+    { value: '30m', label: t('monitoring.last30Minutes') },
+    { value: '1h', label: t('monitoring.lastHour') },
+    { value: '24h', label: t('monitoring.last24Hours') },
   ]
 
   return (
@@ -40,7 +42,7 @@ export function NodeMonitoring({ name }: NodeMonitoringProps) {
         <div className="w-full space-y-2 md:w-auto">
           <Select value={timeRange} onValueChange={setTimeRange}>
             <SelectTrigger className="w-full md:w-[200px]">
-              <SelectValue placeholder="Select time range" />
+              <SelectValue placeholder={t('monitoring.selectTimeRange')} />
             </SelectTrigger>
             <SelectContent>
               {timeRangeOptions.map((option) => (

--- a/ui/src/components/resource-batch-action-dialog.tsx
+++ b/ui/src/components/resource-batch-action-dialog.tsx
@@ -1,0 +1,204 @@
+import React, { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { toast } from 'sonner'
+
+import { translateError } from '@/lib/utils'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+
+interface BatchResource {
+  metadata?: {
+    name?: string
+    namespace?: string
+  }
+}
+
+interface ResourceBatchActionDialogProps<T extends BatchResource> {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  resources: T[]
+  title: string
+  description: string
+  actionLabel: string
+  onExecute: (resource: T) => Promise<unknown>
+  onComplete?: () => void | Promise<void>
+  sequential?: boolean
+  destructive?: boolean
+  options?: (disabled: boolean) => React.ReactNode
+}
+
+interface BatchFailure {
+  resource: string
+  error: string
+}
+
+export function ResourceBatchActionDialog<T extends BatchResource>({
+  open,
+  onOpenChange,
+  resources,
+  title,
+  description,
+  actionLabel,
+  onExecute,
+  onComplete,
+  sequential = false,
+  destructive = false,
+  options,
+}: ResourceBatchActionDialogProps<T>) {
+  const { t } = useTranslation()
+  const [isRunning, setIsRunning] = useState(false)
+  const [progress, setProgress] = useState({ done: 0, total: 0 })
+  const [failures, setFailures] = useState<BatchFailure[]>([])
+
+  const reset = () => {
+    setProgress({ done: 0, total: 0 })
+    setFailures([])
+  }
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (isRunning) return
+    if (!nextOpen) reset()
+    onOpenChange(nextOpen)
+  }
+
+  const handleExecute = async () => {
+    setIsRunning(true)
+    setFailures([])
+    setProgress({ done: 0, total: resources.length })
+
+    const nextFailures: BatchFailure[] = []
+    let succeeded = 0
+
+    const executeResource = async (resource: T) => {
+      const name = resource.metadata!.name!
+      const displayName = resource.metadata?.namespace
+        ? `${resource.metadata.namespace}/${name}`
+        : name
+
+      try {
+        await onExecute(resource)
+        succeeded += 1
+      } catch (error) {
+        nextFailures.push({
+          resource: displayName,
+          error: translateError(error, t),
+        })
+      } finally {
+        setProgress((current) => ({
+          ...current,
+          done: current.done + 1,
+        }))
+      }
+    }
+
+    if (sequential) {
+      for (const resource of resources) {
+        await executeResource(resource)
+      }
+    } else {
+      await Promise.all(resources.map(executeResource))
+    }
+
+    await onComplete?.()
+    setIsRunning(false)
+
+    if (nextFailures.length === 0) {
+      toast.success(
+        t('resourceTable.batchActionSuccess', {
+          action: actionLabel,
+          count: succeeded,
+        })
+      )
+      reset()
+      onOpenChange(false)
+      return
+    }
+
+    setFailures(nextFailures)
+    toast.error(
+      t('resourceTable.batchActionFailed', {
+        count: nextFailures.length,
+      })
+    )
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent
+        role={destructive ? 'alertdialog' : 'dialog'}
+        showCloseButton={!isRunning}
+      >
+        <DialogHeader>
+          <DialogTitle className="text-balance">{title}</DialogTitle>
+          <DialogDescription className="text-pretty">
+            {description}
+          </DialogDescription>
+        </DialogHeader>
+
+        {options?.(isRunning)}
+
+        {failures.length > 0 && (
+          <div
+            role="alert"
+            className="rounded-md border border-destructive/40 bg-destructive/5 p-3"
+          >
+            <p className="text-pretty text-sm">
+              {t('resourceTable.batchActionPartialResult', {
+                succeeded: resources.length - failures.length,
+                total: resources.length,
+              })}
+            </p>
+            <p className="mt-2 text-sm font-medium text-destructive">
+              {t('resourceTable.failedResources', {
+                count: failures.length,
+              })}
+            </p>
+            <ul className="mt-2 max-h-40 space-y-1 overflow-y-auto text-sm">
+              {failures.map((failure) => (
+                <li key={failure.resource} className="text-pretty">
+                  <span className="font-medium">{failure.resource}:</span>{' '}
+                  {failure.error}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        <DialogFooter>
+          {failures.length > 0 ? (
+            <Button variant="outline" onClick={() => handleOpenChange(false)}>
+              {t('common.actions.close')}
+            </Button>
+          ) : (
+            <>
+              <Button
+                variant="outline"
+                onClick={() => handleOpenChange(false)}
+                disabled={isRunning}
+              >
+                {t('common.actions.cancel')}
+              </Button>
+              <Button
+                variant={destructive ? 'destructive' : 'default'}
+                onClick={handleExecute}
+                disabled={isRunning}
+                className="tabular-nums"
+              >
+                {isRunning
+                  ? t('resourceTable.processingProgress', progress)
+                  : actionLabel}
+              </Button>
+            </>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/ui/src/components/resource-table-toolbar.tsx
+++ b/ui/src/components/resource-table-toolbar.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { ColumnDef, Table } from '@tanstack/react-table'
 import {
+  ChevronDown,
   Plus,
   RefreshCw,
   Search,
@@ -17,6 +18,7 @@ import {
   DropdownMenu,
   DropdownMenuCheckboxItem,
   DropdownMenuContent,
+  DropdownMenuItem,
   DropdownMenuLabel,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
@@ -32,6 +34,13 @@ import {
 import { Toggle } from '@/components/ui/toggle'
 
 import { NamespaceSelector } from './selector/namespace-selector'
+
+export interface ResourceTableBatchAction<T> {
+  id: string
+  label: string
+  icon?: React.ReactNode
+  onSelect: (rows: T[]) => void
+}
 
 interface ResourceTableToolbarProps<T> {
   table: Table<T>
@@ -52,6 +61,7 @@ interface ResourceTableToolbarProps<T> {
   onRefreshIntervalChange: (value: number) => void
   selectedRowCount: number
   onOpenDeleteDialog: () => void
+  batchActions: ResourceTableBatchAction<T>[]
 }
 
 export function ResourceTableToolbar<T>({
@@ -73,6 +83,7 @@ export function ResourceTableToolbar<T>({
   onRefreshIntervalChange,
   selectedRowCount,
   onOpenDeleteDialog,
+  batchActions,
 }: ResourceTableToolbarProps<T>) {
   const { t } = useTranslation()
 
@@ -82,6 +93,10 @@ export function ResourceTableToolbar<T>({
     }
     return columnDef.enableColumnFilter && column.getCanFilter()
   })
+
+  const getSelectedRows = () =>
+    table.getSelectedRowModel().rows.map((row) => row.original)
+  const showBatchActionsInline = batchActions.length + 1 <= 2
 
   return (
     <div className="flex flex-col gap-3">
@@ -207,17 +222,65 @@ export function ResourceTableToolbar<T>({
           </div>
 
           <div className="flex flex-wrap items-center gap-2 sm:justify-end">
-            {selectedRowCount > 0 && (
-              <Button
-                variant="destructive"
-                onClick={onOpenDeleteDialog}
-                className="gap-2"
-              >
-                <Trash2 className="h-4 w-4" />
-                {t('resourceTable.deleteSelected', {
-                  count: selectedRowCount,
-                })}
-              </Button>
+            {selectedRowCount > 0 && showBatchActionsInline && (
+              <>
+                {batchActions.map((action) => (
+                  <Button
+                    key={action.id}
+                    variant="outline"
+                    onClick={() => action.onSelect(getSelectedRows())}
+                    className="gap-2 tabular-nums"
+                  >
+                    {action.icon}
+                    {action.label} ({selectedRowCount})
+                  </Button>
+                ))}
+                <Button
+                  variant="destructive"
+                  onClick={onOpenDeleteDialog}
+                  className="gap-2 tabular-nums"
+                >
+                  <Trash2 className="size-4" />
+                  {t('resourceTable.deleteSelected', {
+                    count: selectedRowCount,
+                  })}
+                </Button>
+              </>
+            )}
+            {selectedRowCount > 0 && !showBatchActionsInline && (
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button variant="outline" className="gap-2">
+                    {t('resourceTable.bulkActions')}
+                    <ChevronDown className="size-4" />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end">
+                  <DropdownMenuLabel>
+                    {t('resourceTable.selectedCount', {
+                      count: selectedRowCount,
+                    })}
+                  </DropdownMenuLabel>
+                  <DropdownMenuSeparator />
+                  {batchActions.map((action) => (
+                    <DropdownMenuItem
+                      key={action.id}
+                      onSelect={() => action.onSelect(getSelectedRows())}
+                    >
+                      {action.icon}
+                      {action.label}
+                    </DropdownMenuItem>
+                  ))}
+                  {batchActions.length > 0 && <DropdownMenuSeparator />}
+                  <DropdownMenuItem
+                    variant="destructive"
+                    onSelect={onOpenDeleteDialog}
+                  >
+                    <Trash2 className="size-4" />
+                    {t('common.actions.delete')}
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
             )}
             {showCreateButton && onCreateClick && (
               <Button onClick={onCreateClick} className="gap-1">

--- a/ui/src/components/resource-table.tsx
+++ b/ui/src/components/resource-table.tsx
@@ -32,8 +32,13 @@ import {
 } from '@/components/ui/dialog'
 
 import { ErrorMessage } from './error-message'
-import { ResourceTableToolbar } from './resource-table-toolbar'
+import {
+  ResourceTableToolbar,
+  type ResourceTableBatchAction,
+} from './resource-table-toolbar'
 import { ResourceTableView } from './resource-table-view'
+
+export type { ResourceTableBatchAction } from './resource-table-toolbar'
 
 export interface ResourceTableProps<T> {
   resourceName: string
@@ -45,6 +50,7 @@ export interface ResourceTableProps<T> {
   showCreateButton?: boolean // If true, show create button
   onCreateClick?: () => void // Callback for create button click
   extraToolbars?: React.ReactNode[] // Additional toolbar components
+  batchActions?: ResourceTableBatchAction<T>[]
   defaultHiddenColumns?: string[] // Columns to hide by default
 }
 
@@ -65,6 +71,7 @@ function ResourceTableContent<T>({
   showCreateButton = false,
   onCreateClick,
   extraToolbars = [],
+  batchActions = [],
   defaultHiddenColumns = [],
 }: ResourceTableProps<T>) {
   const { t } = useTranslation()
@@ -473,6 +480,7 @@ function ResourceTableContent<T>({
         onRefreshIntervalChange={handleRefreshIntervalChange}
         selectedRowCount={table.getSelectedRowModel().rows.length}
         onOpenDeleteDialog={() => setDeleteDialogOpen(true)}
+        batchActions={batchActions}
       />
 
       <ResourceTableView

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -271,6 +271,7 @@
       "passwordLoginWarningDescription": "Verify that your LDAP、OAuth Provider、Passkey provider is working before saving. Without a working alternative login method, you will be locked out and can only recover by resetting the database.",
       "passwordLoginWarningTitle": "Warning: You may lose access!",
       "passwordReset": "Password reset",
+      "resourceNotFound": "{{resource}} not found",
       "somethingWentWrong": "Something went wrong",
       "startedAgo": "started {{time}} ago",
       "startedShort": "started",
@@ -611,6 +612,15 @@
     "networkUsage": "Network Usage",
     "diskUsage": "Disk Usage",
     "resourceUtilization": "Resource Utilization",
+    "usage": "Usage",
+    "incoming": "Incoming",
+    "outgoing": "Outgoing",
+    "selectTimeRange": "Select time range",
+    "last30Minutes": "Last 30 minutes",
+    "lastHour": "Last hour",
+    "last24Hours": "Last 24 hours",
+    "noResourceUtilizationData": "No resource utilization data available",
+    "noNetworkUsageData": "No network usage data available",
     "requests": "Requests",
     "limits": "Limits",
     "total": "Total"
@@ -685,6 +695,23 @@
     "deletingProgress": "Deleting... ({{done}}/{{total}})",
     "deleteSuccess": "Deleted {{name}} successfully",
     "deleteFailed": "Failed to delete {{name}}: {{error}}",
+    "bulkActions": "Bulk actions",
+    "selectedCount": "{{count}} selected",
+    "processingProgress": "Processing... ({{done}}/{{total}})",
+    "batchActionSuccess": "{{action}} completed for {{count}} resources",
+    "batchActionFailed": "{{count}} resources failed",
+    "batchActionPartialResult": "Completed {{succeeded}} of {{total}} resources.",
+    "failedResources": "{{count}} failed resources",
+    "batchActions": {
+      "cordonNodesTitle": "Cordon {{count}} selected nodes?",
+      "cordonNodesDescription": "Selected nodes will stop accepting new Pods. Existing Pods will keep running.",
+      "uncordonNodesTitle": "Uncordon {{count}} selected nodes?",
+      "uncordonNodesDescription": "Selected nodes will be marked as schedulable and can accept new Pods.",
+      "drainNodesTitle": "Drain {{count}} selected nodes?",
+      "drainNodesDescription": "Selected nodes will be cordoned and drained one at a time. Pod eviction can be disruptive and cannot be automatically rolled back.",
+      "restartResourcesTitle": "Restart {{count}} selected {{resource}}?",
+      "restartResourcesDescription": "This updates each {{resource}} Pod template and triggers a rollout. Paused or OnDelete strategies may not restart immediately, and rollout health is not monitored."
+    },
     "watch": "Watch",
     "namespace": "Namespace"
   },
@@ -984,10 +1011,11 @@
       "deleted": "{{resource}} deleted successfully",
       "taintKeyRequired": "Taint key is required",
       "taintRemoved": "Taint removed from {{resource}} successfully",
-      "nodeDrained": "Node {{name}} drained successfully",
+      "nodeDrained": "Node {{name}} drained successfully ({{pods}} pods)",
       "nodeCordoned": "Node {{name}} cordoned successfully",
       "nodeUncordoned": "Node {{name}} uncordoned successfully",
-      "nodeTainted": "Node {{name}} tainted successfully"
+      "nodeTainted": "Node {{name}} tainted successfully",
+      "nodeTaintRemoved": "Taint removed from node {{name}} successfully"
     },
     "dialogs": {
       "drainNode": {
@@ -1036,7 +1064,9 @@
       "conditions": "Conditions"
     },
     "fields": {
-      "schedulingDisabled": "(SchedulingDisabled)"
+      "schedulingDisabled": "Scheduling disabled",
+      "podCapacity": "Pod Capacity",
+      "noMessage": "No message"
     }
   },
   "aiChat": {

--- a/ui/src/i18n/locales/zh.json
+++ b/ui/src/i18n/locales/zh.json
@@ -11,7 +11,7 @@
       "confirm": "确认",
       "copy": "复制",
       "collapse": "收起",
-      "cordon": "Cordon",
+      "cordon": "停止调度",
       "createGroup": "创建新分组",
       "create": "创建",
       "customizeSidebar": "自定义侧边栏",
@@ -271,6 +271,7 @@
       "passwordLoginWarningDescription": "保存前请确认 LDAP、OAuth Provider、Passkey 可用。没有可用的替代登录方式时，你将无法登录，只能通过重置数据库恢复。",
       "passwordLoginWarningTitle": "警告：你可能会失去访问权限！",
       "passwordReset": "密码已重置",
+      "resourceNotFound": "未找到{{resource}}",
       "somethingWentWrong": "出现错误",
       "startedAgo": "{{time}} 前启动",
       "startedShort": "已启动",
@@ -616,6 +617,15 @@
     "networkUsage": "网络使用量",
     "diskUsage": "磁盘使用率",
     "resourceUtilization": "资源利用率",
+    "usage": "使用率",
+    "incoming": "流入",
+    "outgoing": "流出",
+    "selectTimeRange": "选择时间范围",
+    "last30Minutes": "最近 30 分钟",
+    "lastHour": "最近 1 小时",
+    "last24Hours": "最近 24 小时",
+    "noResourceUtilizationData": "暂无资源利用率数据",
+    "noNetworkUsageData": "暂无网络使用量数据",
     "requests": "Requests",
     "limits": "Limits",
     "total": "总计"
@@ -690,6 +700,23 @@
     "deletingProgress": "删除中... ({{done}}/{{total}})",
     "deleteSuccess": "已删除 {{name}}",
     "deleteFailed": "删除 {{name}} 失败：{{error}}",
+    "bulkActions": "批量操作",
+    "selectedCount": "已选择 {{count}} 项",
+    "processingProgress": "处理中... ({{done}}/{{total}})",
+    "batchActionSuccess": "已对 {{count}} 个资源完成{{action}}",
+    "batchActionFailed": "{{count}} 个资源操作失败",
+    "batchActionPartialResult": "已完成 {{succeeded}}/{{total}} 个资源。",
+    "failedResources": "{{count}} 个失败资源",
+    "batchActions": {
+      "cordonNodesTitle": "停止所选 {{count}} 个节点的调度？",
+      "cordonNodesDescription": "所选节点将停止接受新的 Pod，现有 Pod 会继续运行。",
+      "uncordonNodesTitle": "恢复已选择的 {{count}} 个节点的调度？",
+      "uncordonNodesDescription": "所选节点将恢复为可调度状态，并可以接受新的 Pod。",
+      "drainNodesTitle": "驱逐已选择的 {{count}} 个节点？",
+      "drainNodesDescription": "所选节点将逐个停止调度并执行驱逐。Pod 驱逐可能影响业务，且无法自动回滚。",
+      "restartResourcesTitle": "重启已选择的 {{count}} 个 {{resource}}？",
+      "restartResourcesDescription": "此操作会更新每个 {{resource}} 的 Pod 模板并触发滚动更新。Paused 或 OnDelete 策略可能不会立即重启，且不会等待滚动更新健康完成。"
+    },
     "watch": "监听",
     "namespace": "Namespace"
   },
@@ -1130,10 +1157,11 @@
       "deleted": "{{resource}} 已删除",
       "taintKeyRequired": "污点 Key 不能为空",
       "taintRemoved": "已移除 {{resource}} 的污点",
-      "nodeDrained": "节点 {{name}} 驱逐完成",
-      "nodeCordoned": "节点 {{name}} 已封锁",
+      "nodeDrained": "节点 {{name}} 驱逐完成（{{pods}} 个 Pod）",
+      "nodeCordoned": "节点 {{name}} 已停止调度",
       "nodeUncordoned": "节点 {{name}} 已恢复调度",
-      "nodeTainted": "节点 {{name}} 污点已添加"
+      "nodeTainted": "节点 {{name}} 污点已添加",
+      "nodeTaintRemoved": "节点 {{name}} 的污点已移除"
     },
     "dialogs": {
       "drainNode": {
@@ -1141,14 +1169,14 @@
         "description": "安全驱逐此节点上的所有 Pod。",
         "forceDrain": "强制驱逐",
         "deleteLocalData": "删除本地数据",
-        "ignoreDaemonSets": "忽略 DaemonSets",
-        "gracePeriod": "Grace Period（秒）",
+        "ignoreDaemonSets": "忽略 DaemonSet",
+        "gracePeriod": "优雅终止时间（秒）",
         "drainButton": "驱逐"
       },
       "cordonNode": {
-        "title": "Cordon Node",
+        "title": "停止节点调度",
         "description": "标记此 Node 为不可调度。",
-        "cordonButton": "Cordon"
+        "cordonButton": "停止调度"
       },
       "taintNode": {
         "title": "添加污点",
@@ -1182,7 +1210,9 @@
       "conditions": "状况"
     },
     "fields": {
-      "schedulingDisabled": "（已禁止调度）"
+      "schedulingDisabled": "已停止调度",
+      "podCapacity": "Pod 容量",
+      "noMessage": "无消息"
     }
   },
   "log": {

--- a/ui/src/lib/api/core.ts
+++ b/ui/src/lib/api/core.ts
@@ -558,6 +558,25 @@ export const patchResource = async <T extends ResourceType>(
   await apiClient.patch(`${endpoint}`, body)
 }
 
+export const restartWorkload = async (
+  resource: 'deployments' | 'statefulsets',
+  name: string,
+  namespace: string
+): Promise<void> => {
+  const endpoint = `/${resource}/${namespace}/${name}`
+  await apiClient.patch(endpoint, {
+    spec: {
+      template: {
+        metadata: {
+          annotations: {
+            'kite.kubernetes.io/restartedAt': new Date().toISOString(),
+          },
+        },
+      },
+    },
+  })
+}
+
 export const createResource = async <T extends ResourceType>(
   resource: T,
   namespace: string | undefined,

--- a/ui/src/pages/deployment-list-page.tsx
+++ b/ui/src/pages/deployment-list-page.tsx
@@ -1,15 +1,22 @@
 import { useMemo, useState } from 'react'
+import { IconReload } from '@tabler/icons-react'
+import { useQueryClient } from '@tanstack/react-query'
 import { createColumnHelper } from '@tanstack/react-table'
 import { Deployment } from 'kubernetes-types/apps/v1'
 import { useTranslation } from 'react-i18next'
 import { Link, useNavigate } from 'react-router-dom'
 
+import { restartWorkload } from '@/lib/api'
 import { createSearchFilter, getDeploymentStatus } from '@/lib/k8s'
 import { formatDate } from '@/lib/utils'
 import { Badge } from '@/components/ui/badge'
 import { DeploymentStatusIcon } from '@/components/deployment-status-icon'
 import { DeploymentCreateDialog } from '@/components/editors/deployment-create-dialog'
-import { ResourceTable } from '@/components/resource-table'
+import { ResourceBatchActionDialog } from '@/components/resource-batch-action-dialog'
+import {
+  ResourceTable,
+  type ResourceTableBatchAction,
+} from '@/components/resource-table'
 
 const deploymentSearchFilter = createSearchFilter<Deployment>(
   (d) => d.metadata?.name,
@@ -21,7 +28,25 @@ const columnHelper = createColumnHelper<Deployment>()
 export function DeploymentListPage() {
   const { t } = useTranslation()
   const navigate = useNavigate()
+  const queryClient = useQueryClient()
   const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false)
+  const [isRestartDialogOpen, setIsRestartDialogOpen] = useState(false)
+  const [batchDeployments, setBatchDeployments] = useState<Deployment[]>([])
+
+  const batchActions = useMemo<ResourceTableBatchAction<Deployment>[]>(
+    () => [
+      {
+        id: 'restart',
+        label: t('common.actions.restart'),
+        icon: <IconReload className="size-4" />,
+        onSelect: (deployments) => {
+          setBatchDeployments(deployments)
+          setIsRestartDialogOpen(true)
+        },
+      },
+    ],
+    [t]
+  )
 
   // Define columns for the deployment table
   const columns = useMemo(
@@ -98,12 +123,39 @@ export function DeploymentListPage() {
         searchQueryFilter={deploymentSearchFilter}
         showCreateButton={true}
         onCreateClick={handleCreateClick}
+        batchActions={batchActions}
       />
 
       <DeploymentCreateDialog
         open={isCreateDialogOpen}
         onOpenChange={setIsCreateDialogOpen}
         onSuccess={handleCreateSuccess}
+      />
+
+      <ResourceBatchActionDialog
+        open={isRestartDialogOpen}
+        onOpenChange={setIsRestartDialogOpen}
+        resources={batchDeployments}
+        title={t('resourceTable.batchActions.restartResourcesTitle', {
+          count: batchDeployments.length,
+          resource: t('nav.deployments'),
+        })}
+        description={t(
+          'resourceTable.batchActions.restartResourcesDescription',
+          { resource: t('nav.deployments') }
+        )}
+        actionLabel={t('common.actions.restart')}
+        onExecute={(deployment) =>
+          restartWorkload(
+            'deployments',
+            deployment.metadata!.name!,
+            deployment.metadata!.namespace!
+          )
+        }
+        onComplete={() =>
+          queryClient.invalidateQueries({ queryKey: ['deployments'] })
+        }
+        destructive={true}
       />
     </>
   )

--- a/ui/src/pages/node-detail.tsx
+++ b/ui/src/pages/node-detail.tsx
@@ -107,7 +107,7 @@ export function NodeDetail(props: { name: string }) {
 
   const handleSaveYaml = async (content: Node) => {
     await updateResource('nodes', name, undefined, content)
-    toast.success('YAML saved successfully')
+    toast.success(t('common.messages.yamlSaved'))
   }
 
   const handleRefresh = async () => {
@@ -119,7 +119,10 @@ export function NodeDetail(props: { name: string }) {
     try {
       const result = await drainNode(name, drainOptions)
       toast.success(
-        `Node ${name} drained successfully (${result.pods} pod${result.pods === 1 ? '' : 's'})`
+        t('detail.status.nodeDrained', {
+          name,
+          pods: result.pods,
+        })
       )
       if (result.warnings) toast.warning(result.warnings)
       setIsDrainPopoverOpen(false)
@@ -133,7 +136,7 @@ export function NodeDetail(props: { name: string }) {
   const handleCordon = async () => {
     try {
       await cordonNode(name)
-      toast.success(`Node ${name} cordoned successfully`)
+      toast.success(t('detail.status.nodeCordoned', { name }))
       setIsCordonPopoverOpen(false)
       refetch()
     } catch (err) {
@@ -144,7 +147,7 @@ export function NodeDetail(props: { name: string }) {
   const handleUncordon = async () => {
     try {
       await uncordonNode(name)
-      toast.success(`Node ${name} uncordoned successfully`)
+      toast.success(t('detail.status.nodeUncordoned', { name }))
       setIsCordonPopoverOpen(false)
       refetch()
     } catch (err) {
@@ -154,12 +157,12 @@ export function NodeDetail(props: { name: string }) {
 
   const handleTaint = async () => {
     if (!taintData.key.trim()) {
-      toast.error('Taint key is required')
+      toast.error(t('detail.status.taintKeyRequired'))
       return
     }
     try {
       await taintNode(name, taintData)
-      toast.success(`Node ${name} tainted successfully`)
+      toast.success(t('detail.status.nodeTainted', { name }))
       setIsTaintPopoverOpen(false)
       setTaintData({ key: '', value: '', effect: 'NoSchedule' })
       refetch()
@@ -171,12 +174,12 @@ export function NodeDetail(props: { name: string }) {
   const handleUntaint = async (key?: string) => {
     const taintKey = key || untaintKey
     if (!taintKey.trim()) {
-      toast.error('Taint key is required')
+      toast.error(t('detail.status.taintKeyRequired'))
       return
     }
     try {
       await untaintNode(name, taintKey)
-      toast.success(`Taint removed from node ${name} successfully`)
+      toast.success(t('detail.status.nodeTaintRemoved', { name }))
       if (!key) setUntaintKey('')
       refetch()
     } catch (err) {
@@ -191,7 +194,8 @@ export function NodeDetail(props: { name: string }) {
             value: 'pods',
             label: (
               <>
-                Pods <Badge variant="secondary">{relatedPods.length}</Badge>
+                {t('common.tabs.pods')}{' '}
+                <Badge variant="secondary">{relatedPods.length}</Badge>
               </>
             ),
             content: (
@@ -206,17 +210,17 @@ export function NodeDetail(props: { name: string }) {
       : []),
     {
       value: 'monitor',
-      label: 'Monitor',
+      label: t('common.tabs.monitor'),
       content: <NodeMonitoring name={name} />,
     },
     {
       value: 'terminal',
-      label: 'Terminal',
+      label: t('common.tabs.terminal'),
       content: <Terminal type="node" nodeName={name} />,
     },
     {
       value: 'events',
-      label: 'Events',
+      label: t('common.tabs.events'),
       content: (
         <EventTable resource="nodes" namespace={undefined} name={name} />
       ),
@@ -226,7 +230,7 @@ export function NodeDetail(props: { name: string }) {
   return (
     <ResourceDetailShell
       resourceType="nodes"
-      resourceLabel="Node"
+      resourceLabel={t('common.fields.node')}
       name={name}
       data={data}
       isLoading={isLoading}
@@ -252,15 +256,17 @@ export function NodeDetail(props: { name: string }) {
             <PopoverTrigger asChild>
               <Button variant="outline" size="sm">
                 <IconDroplet className="w-4 h-4" />
-                Drain
+                {t('common.actions.drain')}
               </Button>
             </PopoverTrigger>
             <PopoverContent className="w-80">
               <div className="space-y-4">
                 <div>
-                  <h4 className="font-medium">Drain Node</h4>
+                  <h4 className="font-medium">
+                    {t('detail.dialogs.drainNode.title')}
+                  </h4>
                   <p className="text-sm text-muted-foreground">
-                    Safely evict all pods from this node.
+                    {t('detail.dialogs.drainNode.description')}
                   </p>
                 </div>
                 <div className="space-y-3">
@@ -277,7 +283,7 @@ export function NodeDetail(props: { name: string }) {
                       }
                     />
                     <Label htmlFor="force" className="text-sm">
-                      Force drain
+                      {t('detail.dialogs.drainNode.forceDrain')}
                     </Label>
                   </div>
                   <div className="flex items-center space-x-2">
@@ -293,7 +299,7 @@ export function NodeDetail(props: { name: string }) {
                       }
                     />
                     <Label htmlFor="deleteLocalData" className="text-sm">
-                      Delete local data
+                      {t('detail.dialogs.drainNode.deleteLocalData')}
                     </Label>
                   </div>
                   <div className="flex items-center space-x-2">
@@ -309,12 +315,12 @@ export function NodeDetail(props: { name: string }) {
                       }
                     />
                     <Label htmlFor="ignoreDaemonsets" className="text-sm">
-                      Ignore DaemonSets
+                      {t('detail.dialogs.drainNode.ignoreDaemonSets')}
                     </Label>
                   </div>
                   <div className="space-y-2">
                     <Label htmlFor="gracePeriod" className="text-sm">
-                      Grace Period (seconds)
+                      {t('detail.dialogs.drainNode.gracePeriod')}
                     </Label>
                     <Input
                       id="gracePeriod"
@@ -332,14 +338,14 @@ export function NodeDetail(props: { name: string }) {
                 </div>
                 <div className="flex gap-2">
                   <Button onClick={handleDrain} size="sm" variant="destructive">
-                    Drain Node
+                    {t('detail.dialogs.drainNode.drainButton')}
                   </Button>
                   <Button
                     onClick={() => setIsDrainPopoverOpen(false)}
                     size="sm"
                     variant="outline"
                   >
-                    Cancel
+                    {t('common.actions.cancel')}
                   </Button>
                 </div>
               </div>
@@ -349,7 +355,7 @@ export function NodeDetail(props: { name: string }) {
           {data?.spec?.unschedulable ? (
             <Button onClick={handleUncordon} variant="outline" size="sm">
               <IconReload className="w-4 h-4" />
-              Uncordon
+              {t('common.actions.uncordon')}
             </Button>
           ) : (
             <Popover
@@ -359,15 +365,17 @@ export function NodeDetail(props: { name: string }) {
               <PopoverTrigger asChild>
                 <Button variant="outline" size="sm">
                   <IconBan className="w-4 h-4" />
-                  Cordon
+                  {t('common.actions.cordon')}
                 </Button>
               </PopoverTrigger>
               <PopoverContent className="w-64">
                 <div className="space-y-4">
                   <div>
-                    <h4 className="font-medium">Cordon Node</h4>
+                    <h4 className="font-medium">
+                      {t('detail.dialogs.cordonNode.title')}
+                    </h4>
                     <p className="text-sm text-muted-foreground">
-                      Mark this node as unschedulable.
+                      {t('detail.dialogs.cordonNode.description')}
                     </p>
                   </div>
                   <div className="flex gap-2">
@@ -376,14 +384,14 @@ export function NodeDetail(props: { name: string }) {
                       size="sm"
                       variant="destructive"
                     >
-                      Cordon Node
+                      {t('detail.dialogs.cordonNode.cordonButton')}
                     </Button>
                     <Button
                       onClick={() => setIsCordonPopoverOpen(false)}
                       size="sm"
                       variant="outline"
                     >
-                      Cancel
+                      {t('common.actions.cancel')}
                     </Button>
                   </div>
                 </div>
@@ -398,21 +406,23 @@ export function NodeDetail(props: { name: string }) {
             <PopoverTrigger asChild>
               <Button variant="outline" size="sm">
                 <IconLock className="w-4 h-4" />
-                Taint
+                {t('common.actions.taint')}
               </Button>
             </PopoverTrigger>
             <PopoverContent className="w-80">
               <div className="space-y-4">
                 <div>
-                  <h4 className="font-medium">Taint Node</h4>
+                  <h4 className="font-medium">
+                    {t('detail.dialogs.taintNode.title')}
+                  </h4>
                   <p className="text-sm text-muted-foreground">
-                    Add a taint to prevent pods from being scheduled.
+                    {t('detail.dialogs.taintNode.description')}
                   </p>
                 </div>
                 <div className="space-y-3">
                   <div className="space-y-2">
                     <Label htmlFor="taintKey" className="text-sm">
-                      Key *
+                      {t('detail.dialogs.taintNode.key')}
                     </Label>
                     <Input
                       id="taintKey"
@@ -420,12 +430,12 @@ export function NodeDetail(props: { name: string }) {
                       onChange={(e) =>
                         setTaintData({ ...taintData, key: e.target.value })
                       }
-                      placeholder="e.g., node.kubernetes.io/maintenance"
+                      placeholder={t('detail.dialogs.taintNode.keyPlaceholder')}
                     />
                   </div>
                   <div className="space-y-2">
                     <Label htmlFor="taintValue" className="text-sm">
-                      Value
+                      {t('detail.dialogs.taintNode.value')}
                     </Label>
                     <Input
                       id="taintValue"
@@ -433,12 +443,14 @@ export function NodeDetail(props: { name: string }) {
                       onChange={(e) =>
                         setTaintData({ ...taintData, value: e.target.value })
                       }
-                      placeholder="Optional value"
+                      placeholder={t(
+                        'detail.dialogs.taintNode.valuePlaceholder'
+                      )}
                     />
                   </div>
                   <div className="space-y-2">
                     <Label htmlFor="taintEffect" className="text-sm">
-                      Effect
+                      {t('detail.dialogs.taintNode.effect')}
                     </Label>
                     <Select
                       value={taintData.effect}
@@ -461,14 +473,14 @@ export function NodeDetail(props: { name: string }) {
                 </div>
                 <div className="flex gap-2">
                   <Button onClick={handleTaint} size="sm" variant="destructive">
-                    Add Taint
+                    {t('detail.dialogs.taintNode.addTaintButton')}
                   </Button>
                   <Button
                     onClick={() => setIsTaintPopoverOpen(false)}
                     size="sm"
                     variant="outline"
                   >
-                    Cancel
+                    {t('common.actions.cancel')}
                   </Button>
                 </div>
               </div>
@@ -547,21 +559,31 @@ function NodeOverview({
                 <IconExclamationCircle className="size-4 shrink-0 fill-red-500" />
               )}
               <span className="truncate">
-                {isReady ? 'Ready' : 'Not Ready'}
+                {isReady
+                  ? t('common.fields.ready')
+                  : t('common.messages.notReady')}
               </span>
             </span>
           }
-          detail={node.spec?.unschedulable ? 'SchedulingDisabled' : undefined}
+          detail={
+            node.spec?.unschedulable
+              ? t('detail.fields.schedulingDisabled')
+              : undefined
+          }
         />
-        <WorkloadSummaryCard label="Role" value={role} />
-        <WorkloadSummaryCard label="Internal IP" value={internalIP} mono />
+        <WorkloadSummaryCard label={t('common.fields.role')} value={role} />
         <WorkloadSummaryCard
-          label="Pods"
+          label={t('common.fields.internalIP')}
+          value={internalIP}
+          mono
+        />
+        <WorkloadSummaryCard
+          label={t('common.fields.pods')}
           value={`${podCount} / ${podAllocatable}`}
-          detail="Assigned / Allocatable"
+          detail={`${t('common.messages.assigned')} / ${t('common.fields.allocatable')}`}
         />
         <WorkloadSummaryCard
-          label="CPU"
+          label={t('common.fields.cpu')}
           value={
             node.status?.allocatable?.cpu
               ? formatCPU(node.status.allocatable.cpu)
@@ -569,12 +591,12 @@ function NodeOverview({
           }
           detail={
             node.status?.capacity?.cpu
-              ? `Capacity ${formatCPU(node.status.capacity.cpu)}`
+              ? `${t('common.fields.capacity')} ${formatCPU(node.status.capacity.cpu)}`
               : undefined
           }
         />
         <WorkloadSummaryCard
-          label="Memory"
+          label={t('common.fields.memory')}
           value={
             node.status?.allocatable?.memory
               ? formatMemory(node.status.allocatable.memory)
@@ -582,7 +604,7 @@ function NodeOverview({
           }
           detail={
             node.status?.capacity?.memory
-              ? `Capacity ${formatMemory(node.status.capacity.memory)}`
+              ? `${t('common.fields.capacity')} ${formatMemory(node.status.capacity.memory)}`
               : undefined
           }
         />
@@ -604,40 +626,46 @@ function NodeOverview({
                       ? formatDate(node.metadata.creationTimestamp)
                       : '-'}
                   </WorkloadInfoBlock>
-                  <WorkloadInfoBlock label="Hostname" mono>
+                  <WorkloadInfoBlock label={t('common.fields.hostname')} mono>
                     {hostname}
                   </WorkloadInfoBlock>
                 </div>
 
                 <div className="grid gap-x-8 gap-y-2 border-t border-border/60 pt-3 md:grid-cols-2">
-                  <WorkloadInfoRow label="External IP" mono>
+                  <WorkloadInfoRow label={t('common.fields.externalIP')} mono>
                     {externalIP}
                   </WorkloadInfoRow>
-                  <WorkloadInfoRow label="Pod CIDR" mono>
+                  <WorkloadInfoRow label={t('common.fields.podCIDR')} mono>
                     {node.spec?.podCIDR || '-'}
                   </WorkloadInfoRow>
-                  <WorkloadInfoRow label="Kubelet Version" mono>
+                  <WorkloadInfoRow
+                    label={t('common.fields.kubeletVersion')}
+                    mono
+                  >
                     {node.status?.nodeInfo?.kubeletVersion || '-'}
                   </WorkloadInfoRow>
-                  <WorkloadInfoRow label="Kube Proxy Version">
+                  <WorkloadInfoRow label={t('common.fields.kubeProxyVersion')}>
                     {node.status?.nodeInfo?.kubeProxyVersion || '-'}
                   </WorkloadInfoRow>
-                  <WorkloadInfoRow label="OS Image" truncate={false}>
+                  <WorkloadInfoRow
+                    label={t('common.fields.osImage')}
+                    truncate={false}
+                  >
                     {node.status?.nodeInfo?.osImage || '-'}
                   </WorkloadInfoRow>
-                  <WorkloadInfoRow label="Kernel Version">
+                  <WorkloadInfoRow label={t('common.fields.kernelVersion')}>
                     {node.status?.nodeInfo?.kernelVersion || '-'}
                   </WorkloadInfoRow>
-                  <WorkloadInfoRow label="Architecture">
+                  <WorkloadInfoRow label={t('common.fields.architecture')}>
                     {node.status?.nodeInfo?.architecture || '-'}
                   </WorkloadInfoRow>
-                  <WorkloadInfoRow label="Container Runtime">
+                  <WorkloadInfoRow label={t('common.fields.containerRuntime')}>
                     {node.status?.nodeInfo?.containerRuntimeVersion || '-'}
                   </WorkloadInfoRow>
-                  <WorkloadInfoRow label="Pod Capacity">
+                  <WorkloadInfoRow label={t('detail.fields.podCapacity')}>
                     {podAllocatable} / {podCapacity}
                   </WorkloadInfoRow>
-                  <WorkloadInfoRow label="Storage">
+                  <WorkloadInfoRow label={t('common.fields.storage')}>
                     {node.status?.allocatable?.['ephemeral-storage']
                       ? formatMemory(
                           node.status.allocatable['ephemeral-storage']
@@ -651,7 +679,12 @@ function NodeOverview({
                 </div>
 
                 <div className="border-t border-border/60 pt-2">
-                  <WorkloadInfoRow label="UID" mono truncate={false} compact>
+                  <WorkloadInfoRow
+                    label={t('common.fields.uid')}
+                    mono
+                    truncate={false}
+                    compact
+                  >
                     <span className="break-all">
                       {node.metadata?.uid || '-'}
                     </span>
@@ -665,7 +698,7 @@ function NodeOverview({
             <Card className="gap-0 overflow-hidden rounded-lg border-border/70 py-0 shadow-none">
               <CardHeader className="px-3 py-2.5 !pb-2.5">
                 <CardTitle className="text-balance text-sm">
-                  Node Taints ({node.spec.taints.length})
+                  {t('detail.sections.nodeTaints')} ({node.spec.taints.length})
                 </CardTitle>
               </CardHeader>
               <CardContent className="divide-y divide-border/70 p-0">
@@ -695,7 +728,7 @@ function NodeOverview({
                       size="sm"
                       onClick={() => onUntaint(taint.key)}
                     >
-                      Remove
+                      {t('common.actions.remove')}
                     </Button>
                   </div>
                 ))}
@@ -707,7 +740,7 @@ function NodeOverview({
             <Card className="gap-0 overflow-hidden rounded-lg border-border/70 py-0 shadow-none">
               <CardHeader className="px-3 py-2.5 !pb-2.5">
                 <CardTitle className="text-balance text-sm">
-                  Node Conditions ({conditions.length})
+                  {t('detail.sections.nodeConditions')} ({conditions.length})
                 </CardTitle>
               </CardHeader>
               <CardContent className="divide-y divide-border/70 p-0">
@@ -732,7 +765,9 @@ function NodeOverview({
                       </span>
                     </span>
                     <span className="truncate text-muted-foreground">
-                      {condition.message || condition.reason || 'No message'}
+                      {condition.message ||
+                        condition.reason ||
+                        t('detail.fields.noMessage')}
                     </span>
                     <span className="text-right text-muted-foreground">
                       {condition.status}

--- a/ui/src/pages/node-list-page.tsx
+++ b/ui/src/pages/node-list-page.tsx
@@ -1,15 +1,29 @@
-import { useMemo } from 'react'
+import { useMemo, useState } from 'react'
+import {
+  IconBan,
+  IconCircleCheckFilled,
+  IconDroplet,
+} from '@tabler/icons-react'
+import { useQueryClient } from '@tanstack/react-query'
 import { createColumnHelper } from '@tanstack/react-table'
 import { useTranslation } from 'react-i18next'
 import { Link } from 'react-router-dom'
 
 import { NodeWithMetrics } from '@/types/api'
+import { cordonNode, drainNode, uncordonNode } from '@/lib/api'
 import { createSearchFilter } from '@/lib/k8s'
 import { formatDate } from '@/lib/utils'
 import { Badge } from '@/components/ui/badge'
+import { Checkbox } from '@/components/ui/checkbox'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
 import { MetricCell } from '@/components/metrics-cell'
 import { NodeStatusIcon } from '@/components/node-status-icon'
-import { ResourceTable } from '@/components/resource-table'
+import { ResourceBatchActionDialog } from '@/components/resource-batch-action-dialog'
+import {
+  ResourceTable,
+  type ResourceTableBatchAction,
+} from '@/components/resource-table'
 
 function getNodeStatus(node: NodeWithMetrics): string {
   const conditions = node.status?.conditions || []
@@ -125,6 +139,50 @@ const columnHelper = createColumnHelper<NodeWithMetrics>()
 
 export function NodeListPage() {
   const { t } = useTranslation()
+  const queryClient = useQueryClient()
+  const [activeBatchAction, setActiveBatchAction] = useState<
+    'cordon' | 'uncordon' | 'drain' | null
+  >(null)
+  const [batchNodes, setBatchNodes] = useState<NodeWithMetrics[]>([])
+  const [drainOptions, setDrainOptions] = useState({
+    force: false,
+    gracePeriod: 30,
+    deleteLocalData: false,
+    ignoreDaemonsets: true,
+  })
+
+  const batchActions = useMemo<ResourceTableBatchAction<NodeWithMetrics>[]>(
+    () => [
+      {
+        id: 'cordon',
+        label: t('common.actions.cordon'),
+        icon: <IconBan className="size-4" />,
+        onSelect: (nodes) => {
+          setBatchNodes(nodes)
+          setActiveBatchAction('cordon')
+        },
+      },
+      {
+        id: 'uncordon',
+        label: t('common.actions.uncordon'),
+        icon: <IconCircleCheckFilled className="size-4" />,
+        onSelect: (nodes) => {
+          setBatchNodes(nodes)
+          setActiveBatchAction('uncordon')
+        },
+      },
+      {
+        id: 'drain',
+        label: t('common.actions.drain'),
+        icon: <IconDroplet className="size-4" />,
+        onSelect: (nodes) => {
+          setBatchNodes(nodes)
+          setActiveBatchAction('drain')
+        },
+      },
+    ],
+    [t]
+  )
 
   // Define columns for the node table
   const columns = useMemo(
@@ -267,18 +325,132 @@ export function NodeListPage() {
     [t]
   )
 
+  const executeBatchAction = async (node: NodeWithMetrics) => {
+    const name = node.metadata!.name!
+    if (activeBatchAction === 'cordon') return cordonNode(name)
+    if (activeBatchAction === 'uncordon') return uncordonNode(name)
+    return drainNode(name, drainOptions)
+  }
+
+  const activeActionLabel = activeBatchAction
+    ? t(`common.actions.${activeBatchAction}`)
+    : ''
+
   return (
-    <ResourceTable
-      resourceName="Nodes"
-      resourceType="nodes"
-      columns={columns}
-      clusterScope={true}
-      searchQueryFilter={nodeSearchFilter}
-      showCreateButton={false}
-      defaultHiddenColumns={[
-        'status_nodeInfo_kernelVersion',
-        'status_nodeInfo_osImage',
-      ]}
-    />
+    <>
+      <ResourceTable
+        resourceName="Nodes"
+        resourceType="nodes"
+        columns={columns}
+        clusterScope={true}
+        searchQueryFilter={nodeSearchFilter}
+        showCreateButton={false}
+        batchActions={batchActions}
+        defaultHiddenColumns={[
+          'status_nodeInfo_kernelVersion',
+          'status_nodeInfo_osImage',
+        ]}
+      />
+
+      {activeBatchAction && (
+        <ResourceBatchActionDialog
+          open={true}
+          onOpenChange={(open) => {
+            if (!open) setActiveBatchAction(null)
+          }}
+          resources={batchNodes}
+          title={t(
+            `resourceTable.batchActions.${activeBatchAction}NodesTitle`,
+            { count: batchNodes.length }
+          )}
+          description={t(
+            `resourceTable.batchActions.${activeBatchAction}NodesDescription`,
+            { count: batchNodes.length }
+          )}
+          actionLabel={activeActionLabel}
+          onExecute={executeBatchAction}
+          onComplete={() =>
+            queryClient.invalidateQueries({ queryKey: ['nodes'] })
+          }
+          sequential={activeBatchAction === 'drain'}
+          destructive={activeBatchAction === 'drain'}
+          options={
+            activeBatchAction === 'drain'
+              ? (disabled) => (
+                  <div className="space-y-3">
+                    <div className="flex items-center gap-2">
+                      <Checkbox
+                        id="batch-drain-force"
+                        checked={drainOptions.force}
+                        onCheckedChange={(checked) =>
+                          setDrainOptions((current) => ({
+                            ...current,
+                            force: checked === true,
+                          }))
+                        }
+                        disabled={disabled}
+                      />
+                      <Label htmlFor="batch-drain-force">
+                        {t('detail.dialogs.drainNode.forceDrain')}
+                      </Label>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <Checkbox
+                        id="batch-drain-local-data"
+                        checked={drainOptions.deleteLocalData}
+                        onCheckedChange={(checked) =>
+                          setDrainOptions((current) => ({
+                            ...current,
+                            deleteLocalData: checked === true,
+                          }))
+                        }
+                        disabled={disabled}
+                      />
+                      <Label htmlFor="batch-drain-local-data">
+                        {t('detail.dialogs.drainNode.deleteLocalData')}
+                      </Label>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <Checkbox
+                        id="batch-drain-daemonsets"
+                        checked={drainOptions.ignoreDaemonsets}
+                        onCheckedChange={(checked) =>
+                          setDrainOptions((current) => ({
+                            ...current,
+                            ignoreDaemonsets: checked === true,
+                          }))
+                        }
+                        disabled={disabled}
+                      />
+                      <Label htmlFor="batch-drain-daemonsets">
+                        {t('detail.dialogs.drainNode.ignoreDaemonSets')}
+                      </Label>
+                    </div>
+                    <div className="flex items-center justify-between gap-3">
+                      <Label htmlFor="batch-drain-grace-period">
+                        {t('detail.dialogs.drainNode.gracePeriod')}
+                      </Label>
+                      <Input
+                        id="batch-drain-grace-period"
+                        type="number"
+                        min={0}
+                        value={drainOptions.gracePeriod}
+                        onChange={(event) =>
+                          setDrainOptions((current) => ({
+                            ...current,
+                            gracePeriod: Number(event.target.value),
+                          }))
+                        }
+                        disabled={disabled}
+                        className="w-28 tabular-nums"
+                      />
+                    </div>
+                  </div>
+                )
+              : undefined
+          }
+        />
+      )}
+    </>
   )
 }

--- a/ui/src/pages/resource-detail-shell.tsx
+++ b/ui/src/pages/resource-detail-shell.tsx
@@ -206,7 +206,7 @@ export function ResourceDetailShell<T>({
               <IconLoader className="animate-spin" />
               <span>
                 {loadingMessage ||
-                  `Loading ${resourceLabel.toLowerCase()} details...`}
+                  t('detail.status.loading', { resource: resourceLabel })}
               </span>
             </div>
           </CardContent>
@@ -222,7 +222,9 @@ export function ResourceDetailShell<T>({
           <Card>
             <CardContent className="pt-6">
               <div className="flex items-center justify-center gap-2 text-muted-foreground">
-                {resourceLabel} not found
+                {t('common.messages.resourceNotFound', {
+                  resource: resourceLabel,
+                })}
               </div>
             </CardContent>
           </Card>

--- a/ui/src/pages/statefulset-list-page.tsx
+++ b/ui/src/pages/statefulset-list-page.tsx
@@ -1,14 +1,24 @@
-import { useMemo } from 'react'
-import { IconCircleCheckFilled, IconLoader } from '@tabler/icons-react'
+import { useMemo, useState } from 'react'
+import {
+  IconCircleCheckFilled,
+  IconLoader,
+  IconReload,
+} from '@tabler/icons-react'
+import { useQueryClient } from '@tanstack/react-query'
 import { createColumnHelper } from '@tanstack/react-table'
 import { StatefulSet } from 'kubernetes-types/apps/v1'
 import { useTranslation } from 'react-i18next'
 import { Link } from 'react-router-dom'
 
+import { restartWorkload } from '@/lib/api'
 import { createSearchFilter } from '@/lib/k8s'
 import { formatDate } from '@/lib/utils'
 import { Badge } from '@/components/ui/badge'
-import { ResourceTable } from '@/components/resource-table'
+import { ResourceBatchActionDialog } from '@/components/resource-batch-action-dialog'
+import {
+  ResourceTable,
+  type ResourceTableBatchAction,
+} from '@/components/resource-table'
 
 const statefulSetSearchFilter = createSearchFilter<StatefulSet>(
   (s) => s.metadata?.name,
@@ -20,6 +30,24 @@ const columnHelper = createColumnHelper<StatefulSet>()
 
 export function StatefulSetListPage() {
   const { t } = useTranslation()
+  const queryClient = useQueryClient()
+  const [isRestartDialogOpen, setIsRestartDialogOpen] = useState(false)
+  const [batchStatefulSets, setBatchStatefulSets] = useState<StatefulSet[]>([])
+
+  const batchActions = useMemo<ResourceTableBatchAction<StatefulSet>[]>(
+    () => [
+      {
+        id: 'restart',
+        label: t('common.actions.restart'),
+        icon: <IconReload className="size-4" />,
+        onSelect: (statefulSets) => {
+          setBatchStatefulSets(statefulSets)
+          setIsRestartDialogOpen(true)
+        },
+      },
+    ],
+    [t]
+  )
 
   // Define columns for the statefulset table
   const columns = useMemo(
@@ -112,11 +140,40 @@ export function StatefulSetListPage() {
   )
 
   return (
-    <ResourceTable
-      resourceName={'StatefulSets'}
-      resourceType="statefulsets"
-      columns={columns}
-      searchQueryFilter={statefulSetSearchFilter}
-    />
+    <>
+      <ResourceTable
+        resourceName={'StatefulSets'}
+        resourceType="statefulsets"
+        columns={columns}
+        searchQueryFilter={statefulSetSearchFilter}
+        batchActions={batchActions}
+      />
+
+      <ResourceBatchActionDialog
+        open={isRestartDialogOpen}
+        onOpenChange={setIsRestartDialogOpen}
+        resources={batchStatefulSets}
+        title={t('resourceTable.batchActions.restartResourcesTitle', {
+          count: batchStatefulSets.length,
+          resource: t('nav.statefulsets'),
+        })}
+        description={t(
+          'resourceTable.batchActions.restartResourcesDescription',
+          { resource: t('nav.statefulsets') }
+        )}
+        actionLabel={t('common.actions.restart')}
+        onExecute={(statefulSet) =>
+          restartWorkload(
+            'statefulsets',
+            statefulSet.metadata!.name!,
+            statefulSet.metadata!.namespace!
+          )
+        }
+        onComplete={() =>
+          queryClient.invalidateQueries({ queryKey: ['statefulsets'] })
+        }
+        destructive={true}
+      />
+    </>
   )
 }


### PR DESCRIPTION
## Summary

- add reusable bulk-action controls and progress/error reporting to resource tables
- support batch cordon, uncordon, and sequential drain for nodes
- support batch rollout restarts for Deployments and StatefulSets
- localize node detail and monitoring text in English and Chinese
- allow node drain requests with `force: false`

## Why

Operators need to apply common maintenance actions to multiple resources without opening each detail page. The node drain request also marked a boolean field as required, which rejected the normal `false` value.

## Impact

Selected resources can now be maintained in bulk with confirmation, progress, partial-failure reporting, and refreshed list data. Node and monitoring views consistently follow the selected language.

## Validation

- `make pre-commit`
- `pnpm --dir ui run type-check`
- `git diff --check`
