### PR TITLE
fix(ui): persist page size preference to localStorage instead of sessionStorage

### DIFF
--- a/ui/src/hooks/use-resource-table-state.ts
+++ b/ui/src/hooks/use-resource-table-state.ts
@@ -70,7 +70,7 @@ export function useResourceTableState({
     return initialVisibility
   })
   const [pagination, setPagination] = useState<PaginationState>(() => {
-    const savedPageSize = sessionStorage.getItem(
+    const savedPageSize = localStorage.getItem(
       getClusterScopedStorageKey(`-${resourceName}-pageSize`)
     )
     return {
@@ -136,7 +136,7 @@ export function useResourceTableState({
   }, [columnVisibility, resourceName])
 
   useEffect(() => {
-    sessionStorage.setItem(
+    localStorage.setItem(
       getClusterScopedStorageKey(`-${resourceName}-pageSize`),
       pagination.pageSize.toString()
     )


### PR DESCRIPTION
## Summary

Change the storage mechanism for page size preference from `sessionStorage` to `localStorage`, so the user's page size selection persists across browser sessions.

## Why

Previously, the page size selection (e.g., 20, 50, 100) was stored in `sessionStorage`, which is cleared when the browser tab is closed. This caused the page size to reset to the default value of 20 every time the user reopened the dashboard.

Note that `columnVisibility` in the same file already uses `localStorage` for persistence (line 130), so this change makes the behavior consistent.

## Validation

- Verified that changing page size to 50/100 persists after closing and reopening the browser tab
- - Verified that different resources (Pods, Deployments, etc.) maintain their own page size preferences independently
- - No regression in column visibility persistence
## Checklist
- [x] I reviewed this PR myself before requesting review.
- [ ] - [x] I understand the changes, including AI-generated parts (if any).
- [ ] - [x] I cleaned up AI noise (unnecessary comments, dead code, and unrelated changes).
- [ ] - [x] This PR is reasonably scoped (or split into smaller PRs).