### PR TITLE
fix(ui): render control characters and long node names

### DIFF
--- a/ui/src/components/pod-overview.tsx
+++ b/ui/src/components/pod-overview.tsx
@@ -180,11 +180,13 @@ function PodSummaryGrid({
       />
       <PodSummaryCard
         label={t('common.fields.node')}
+        truncateValue={false}
         value={
           pod.spec?.nodeName ? (
             <Link
               to={`/nodes/${pod.spec.nodeName}`}
-              className="app-link inline-block max-w-full truncate"
+              className="app-link line-clamp-2 max-w-full break-all leading-snug"
+              title={pod.spec.nodeName}
             >
               {pod.spec.nodeName}
             </Link>
@@ -333,11 +335,13 @@ function PodSummaryCard({
   value,
   detail,
   mono,
+  truncateValue = true,
 }: {
   label: string
   value: ReactNode
   detail?: ReactNode
   mono?: boolean
+  truncateValue?: boolean
 }) {
   return (
     <Card className="gap-0 rounded-lg border-border/70 py-0 shadow-none">
@@ -345,7 +349,8 @@ function PodSummaryCard({
         <div className="text-xs text-muted-foreground">{label}</div>
         <div
           className={cn(
-            'mt-2 min-w-0 truncate text-lg font-semibold tabular-nums',
+            'mt-2 min-w-0 text-lg font-semibold tabular-nums',
+            truncateValue && 'truncate',
             mono && 'font-mono'
           )}
           title={typeof value === 'string' ? value : undefined}

--- a/ui/src/lib/ansi-parser.ts
+++ b/ui/src/lib/ansi-parser.ts
@@ -115,7 +115,52 @@ export function parseAnsi(
     })
   }
 
-  return { segments, finalState: currentState }
+  if (!text.includes('\b') && !text.includes('\r')) {
+    return { segments, finalState: currentState }
+  }
+
+  const cells: ParsedSegment[] = []
+  let cursor = 0
+
+  for (const segment of segments) {
+    for (const character of segment.text) {
+      if (character === '\b') {
+        cursor = Math.max(0, cursor - 1)
+        continue
+      }
+      if (character === '\r') {
+        cursor = 0
+        continue
+      }
+
+      const cell = { text: character, styles: segment.styles }
+      if (cursor < cells.length) {
+        cells[cursor] = cell
+      } else {
+        cells.push(cell)
+      }
+      cursor++
+    }
+  }
+
+  const normalizedSegments: ParsedSegment[] = []
+  for (const cell of cells) {
+    const previous = normalizedSegments[normalizedSegments.length - 1]
+    if (
+      previous &&
+      previous.styles.color === cell.styles.color &&
+      previous.styles.backgroundColor === cell.styles.backgroundColor &&
+      previous.styles.bold === cell.styles.bold &&
+      previous.styles.italic === cell.styles.italic &&
+      previous.styles.underline === cell.styles.underline
+    ) {
+      previous.text += cell.text
+    } else {
+      normalizedSegments.push({ text: cell.text, styles: cell.styles })
+    }
+  }
+
+  return { segments: normalizedSegments, finalState: currentState }
 }
 
 /**


### PR DESCRIPTION
## Summary

- Interpret backspace and carriage-return characters as cursor movement when parsing ANSI log output, then merge adjacent cells with matching styles.
- Let long Pod node names wrap to two lines while preserving the full value in the link tooltip.

## Why

Terminal-style log output can use backspace and carriage return to rewrite characters in place. The previous parser left those control characters in the rendered text. Pod summary cards also always truncated their primary value, which made long node names hard to read.

## Impact

Log lines that rewrite content now display their resulting text and ANSI styles correctly. Long node names remain readable and clickable without changing truncation behavior for the other summary cards.

## Validation

- `make pre-commit`
- `pnpm --dir ui run type-check`