### PR TITLE
Add kubeconfig cluster import

### DIFF
--- a/internal/load.go
+++ b/internal/load.go
@@ -64,7 +64,7 @@ func loadClusters() error {
 	}
 
 	klog.Infof("Importing clusters from kubeconfig: %s", kubeconfigpath)
-	cluster.ImportClustersFromKubeconfig(kubeconfig)
+	cluster.ImportClustersFromKubeconfig(kubeconfig, true)
 	return nil
 }
 

--- a/pkg/cluster/cluster_handler.go
+++ b/pkg/cluster/cluster_handler.go
@@ -270,8 +270,8 @@ func (cm *ClusterManager) ImportClustersFromKubeconfig(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
-	if cc > 0 {
-		c.JSON(http.StatusForbidden, gin.H{"error": "import not allowed when clusters exist"})
+	if clusterReq.InCluster && cc > 0 {
+		c.JSON(http.StatusForbidden, gin.H{"error": "in-cluster import not allowed when clusters exist"})
 		return
 	}
 
@@ -291,7 +291,10 @@ func (cm *ClusterManager) ImportClustersFromKubeconfig(c *gin.Context) {
 		TriggerClusterSync()
 		// wait for sync to complete
 		time.Sleep(1 * time.Second)
-		c.JSON(http.StatusCreated, gin.H{"message": fmt.Sprintf("imported %d clusters successfully", 1)})
+		c.JSON(http.StatusCreated, gin.H{
+			"message":       fmt.Sprintf("imported %d clusters successfully", 1),
+			"importedCount": 1,
+		})
 		return
 	}
 
@@ -301,9 +304,12 @@ func (cm *ClusterManager) ImportClustersFromKubeconfig(c *gin.Context) {
 		return
 	}
 
-	importedCount := ImportClustersFromKubeconfig(kubeconfig)
+	importedCount := ImportClustersFromKubeconfig(kubeconfig, cc == 0)
 	TriggerClusterSync()
 	// wait for sync to complete
 	time.Sleep(1 * time.Second)
-	c.JSON(http.StatusCreated, gin.H{"message": fmt.Sprintf("imported %d clusters successfully", importedCount)})
+	c.JSON(http.StatusCreated, gin.H{
+		"message":       fmt.Sprintf("imported %d clusters successfully", importedCount),
+		"importedCount": importedCount,
+	})
 }

--- a/pkg/cluster/cluster_manager.go
+++ b/pkg/cluster/cluster_manager.go
@@ -195,7 +195,7 @@ func (cm *ClusterManager) GetClientSet(clusterName string) (*ClientSet, error) {
 	return nil, fmt.Errorf("cluster not found: %s", clusterName)
 }
 
-func ImportClustersFromKubeconfig(kubeconfig *clientcmdapi.Config) int64 {
+func ImportClustersFromKubeconfig(kubeconfig *clientcmdapi.Config, setDefault bool) int64 {
 	if len(kubeconfig.Contexts) == 0 {
 		return 0
 	}
@@ -220,9 +220,10 @@ func ImportClustersFromKubeconfig(kubeconfig *clientcmdapi.Config) int64 {
 		cluster := model.Cluster{
 			Name:      contextName,
 			Config:    model.SecretString(configStr),
-			IsDefault: contextName == kubeconfig.CurrentContext,
+			IsDefault: setDefault && contextName == kubeconfig.CurrentContext,
 		}
-		if _, err := model.GetClusterByName(contextName); err != nil {
+		existingCluster, err := model.GetClusterByName(contextName)
+		if err != nil {
 			if errors.Is(err, gorm.ErrRecordNotFound) {
 				if err := model.AddCluster(&cluster); err != nil {
 					continue
@@ -232,6 +233,13 @@ func ImportClustersFromKubeconfig(kubeconfig *clientcmdapi.Config) int64 {
 			}
 			continue
 		}
+		if err := model.UpdateCluster(existingCluster, map[string]interface{}{
+			"config": model.SecretString(configStr),
+		}); err != nil {
+			continue
+		}
+		importedCount++
+		klog.Infof("Updated cluster config success: %s", contextName)
 	}
 	return int64(importedCount)
 }

--- a/ui/src/components/settings/cluster-import-dialog.tsx
+++ b/ui/src/components/settings/cluster-import-dialog.tsx
@@ -1,0 +1,158 @@
+import { useState } from 'react'
+import { IconUpload } from '@tabler/icons-react'
+import { useTranslation } from 'react-i18next'
+
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Textarea } from '@/components/ui/textarea'
+
+interface ClusterImportDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onSubmit: (config: string) => void
+  isSubmitting: boolean
+  error?: string
+}
+
+export function ClusterImportDialog({
+  open,
+  onOpenChange,
+  onSubmit,
+  isSubmitting,
+  error,
+}: ClusterImportDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      {open ? (
+        <ClusterImportDialogContent
+          onOpenChange={onOpenChange}
+          onSubmit={onSubmit}
+          isSubmitting={isSubmitting}
+          error={error}
+        />
+      ) : null}
+    </Dialog>
+  )
+}
+
+function ClusterImportDialogContent({
+  onOpenChange,
+  onSubmit,
+  isSubmitting,
+  error,
+}: Omit<ClusterImportDialogProps, 'open'>) {
+  const { t } = useTranslation()
+  const [config, setConfig] = useState('')
+  const [fileError, setFileError] = useState('')
+
+  const handleFileSelect = async (
+    event: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    const file = event.target.files?.[0]
+    if (!file) return
+
+    try {
+      setConfig(await file.text())
+      setFileError('')
+    } catch {
+      setFileError(
+        t(
+          'clusterManagement.messages.fileReadError',
+          'Failed to read kubeconfig file'
+        )
+      )
+    }
+  }
+
+  const handleSubmit = (event: React.FormEvent) => {
+    event.preventDefault()
+    onSubmit(config)
+  }
+
+  return (
+    <DialogContent className="sm:max-w-[600px]">
+      <DialogHeader>
+        <DialogTitle className="flex items-center gap-2 text-balance">
+          <IconUpload className="size-5" />
+          {t('clusterManagement.dialog.importTitle', 'Import Clusters')}
+        </DialogTitle>
+        <DialogDescription className="text-pretty">
+          {t(
+            'clusterManagement.dialog.importDescription',
+            'Import all Kubernetes contexts from a kubeconfig file.'
+          )}
+        </DialogDescription>
+      </DialogHeader>
+
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div className="space-y-2">
+          <Label htmlFor="cluster-import-file">
+            {t('clusterManagement.dialog.importFile', 'Kubeconfig File')}
+          </Label>
+          <Input
+            id="cluster-import-file"
+            type="file"
+            onChange={handleFileSelect}
+          />
+          <p className="text-xs text-muted-foreground text-pretty">
+            {t(
+              'clusterManagement.dialog.importFileHint',
+              'Choose a kubeconfig file, or paste its content below.'
+            )}
+          </p>
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="cluster-import-config">
+            {t('clusterManagement.dialog.config', 'Kubeconfig')} *
+          </Label>
+          <Textarea
+            id="cluster-import-config"
+            value={config}
+            onChange={(event) => {
+              setConfig(event.target.value)
+              setFileError('')
+            }}
+            placeholder={t(
+              'clusterManagement.dialog.configPlaceholder',
+              'Paste kubeconfig content here...'
+            )}
+            rows={10}
+            className="font-mono text-sm"
+            required
+          />
+        </div>
+
+        {(fileError || error) && (
+          <p role="alert" className="text-sm text-destructive text-pretty">
+            {fileError || error}
+          </p>
+        )}
+
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+          >
+            {t('common.actions.cancel', 'Cancel')}
+          </Button>
+          <Button type="submit" disabled={isSubmitting || !config.trim()}>
+            {isSubmitting
+              ? t('clusterManagement.actions.importing', 'Importing...')
+              : t('clusterManagement.actions.import', 'Import Clusters')}
+          </Button>
+        </DialogFooter>
+      </form>
+    </DialogContent>
+  )
+}

--- a/ui/src/components/settings/cluster-management.tsx
+++ b/ui/src/components/settings/cluster-management.tsx
@@ -1,5 +1,11 @@
 import { useCallback, useMemo, useState } from 'react'
-import { IconEdit, IconPlus, IconServer, IconTrash } from '@tabler/icons-react'
+import {
+  IconEdit,
+  IconPlus,
+  IconServer,
+  IconTrash,
+  IconUpload,
+} from '@tabler/icons-react'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { ColumnDef } from '@tanstack/react-table'
 import { useTranslation } from 'react-i18next'
@@ -11,6 +17,7 @@ import {
   ClusterUpdateRequest,
   createCluster,
   deleteCluster,
+  importClusters,
   updateCluster,
   useClusterList,
 } from '@/lib/api'
@@ -26,6 +33,7 @@ import { DeleteConfirmationDialog } from '@/components/delete-confirmation-dialo
 
 import { Action, ActionTable } from '../action-table'
 import { ClusterDialog } from './cluster-dialog'
+import { ClusterImportDialog } from './cluster-import-dialog'
 
 export function ClusterManagement() {
   const { t } = useTranslation()
@@ -34,6 +42,7 @@ export function ClusterManagement() {
   const { data: clusters = [], isLoading, error } = useClusterList()
 
   const [showClusterDialog, setShowClusterDialog] = useState(false)
+  const [showImportDialog, setShowImportDialog] = useState(false)
   const [editingCluster, setEditingCluster] = useState<Cluster | null>(null)
   const [deletingCluster, setDeletingCluster] = useState<Cluster | null>(null)
 
@@ -192,6 +201,22 @@ export function ClusterManagement() {
     },
   })
 
+  const importMutation = useMutation({
+    mutationFn: (config: string) => importClusters({ config }),
+    onSuccess: ({ importedCount }) => {
+      queryClient.invalidateQueries({ queryKey: ['cluster-list'] })
+      queryClient.invalidateQueries({ queryKey: ['clusters'] })
+      toast.success(
+        t(
+          'clusterManagement.messages.imported',
+          'Imported or updated {{count}} clusters successfully',
+          { count: importedCount }
+        )
+      )
+      setShowImportDialog(false)
+    },
+  })
+
   // Update cluster mutation
   const updateMutation = useMutation({
     mutationFn: ({ id, data }: { id: number; data: ClusterUpdateRequest }) =>
@@ -285,16 +310,29 @@ export function ClusterManagement() {
                 {t('clusterManagement.title', 'Cluster Management')}
               </CardTitle>
             </div>
-            <Button
-              onClick={() => {
-                setEditingCluster(null)
-                setShowClusterDialog(true)
-              }}
-              className="gap-2"
-            >
-              <IconPlus className="h-4 w-4" />
-              {t('clusterManagement.actions.add', 'Add Cluster')}
-            </Button>
+            <div className="flex items-center gap-2">
+              <Button
+                variant="outline"
+                onClick={() => {
+                  importMutation.reset()
+                  setShowImportDialog(true)
+                }}
+                className="gap-2"
+              >
+                <IconUpload className="size-4" />
+                {t('clusterManagement.actions.import', 'Import Clusters')}
+              </Button>
+              <Button
+                onClick={() => {
+                  setEditingCluster(null)
+                  setShowClusterDialog(true)
+                }}
+                className="gap-2"
+              >
+                <IconPlus className="h-4 w-4" />
+                {t('clusterManagement.actions.add', 'Add Cluster')}
+              </Button>
+            </div>
           </div>
         </CardHeader>
         <CardContent>
@@ -327,6 +365,17 @@ export function ClusterManagement() {
         }}
         cluster={editingCluster}
         onSubmit={handleSubmitCluster}
+      />
+
+      <ClusterImportDialog
+        open={showImportDialog}
+        onOpenChange={(open) => {
+          setShowImportDialog(open)
+          if (!open) importMutation.reset()
+        }}
+        onSubmit={(config) => importMutation.mutate(config)}
+        isSubmitting={importMutation.isPending}
+        error={importMutation.error?.message}
       />
 
       {/* Delete Confirmation Dialog */}

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -864,7 +864,9 @@
   "clusterManagement": {
     "title": "Cluster Management",
     "actions": {
-      "add": "Add Cluster"
+      "add": "Add Cluster",
+      "import": "Import Clusters",
+      "importing": "Importing..."
     },
     "table": {
       "prometheus": "Prometheus"
@@ -881,9 +883,11 @@
       "created": "Cluster created successfully",
       "updated": "Cluster updated successfully",
       "deleted": "Cluster deleted successfully",
+      "imported": "Imported or updated {{count}} clusters successfully",
       "createError": "Failed to create cluster",
       "updateError": "Failed to update cluster",
-      "deleteError": "Failed to delete cluster"
+      "deleteError": "Failed to delete cluster",
+      "fileReadError": "Failed to read kubeconfig file"
     },
     "errors": {
       "loadFailed": "Failed to load clusters"
@@ -892,6 +896,10 @@
     "dialog": {
       "createTitle": "Add Cluster",
       "editTitle": "Edit Cluster",
+      "importTitle": "Import Clusters",
+      "importDescription": "Import the cluster list from a kubeconfig file. Clusters with the same name will be updated.",
+      "importFile": "Kubeconfig File",
+      "importFileHint": "Choose a kubeconfig file, or paste its content below.",
       "name": "Name",
       "namePlaceholder": "Enter cluster name",
       "description": "Description",

--- a/ui/src/i18n/locales/zh.json
+++ b/ui/src/i18n/locales/zh.json
@@ -875,7 +875,9 @@
   "clusterManagement": {
     "title": "集群管理",
     "actions": {
-      "add": "添加集群"
+      "add": "添加集群",
+      "import": "导入集群",
+      "importing": "导入中..."
     },
     "table": {
       "prometheus": "Prometheus"
@@ -892,9 +894,11 @@
       "created": "集群创建成功",
       "updated": "集群更新成功",
       "deleted": "集群删除成功",
+      "imported": "成功导入或更新 {{count}} 个集群",
       "createError": "创建集群失败",
       "updateError": "更新集群失败",
-      "deleteError": "删除集群失败"
+      "deleteError": "删除集群失败",
+      "fileReadError": "无法读取 kubeconfig 文件"
     },
     "errors": {
       "loadFailed": "加载集群失败"
@@ -903,6 +907,10 @@
     "dialog": {
       "createTitle": "添加集群",
       "editTitle": "编辑集群",
+      "importTitle": "导入集群",
+      "importDescription": "从 kubeconfig 文件导入集群列表，同名集群将被更新。",
+      "importFile": "Kubeconfig 文件",
+      "importFileHint": "选择 kubeconfig 文件，或在下方粘贴文件内容。",
       "name": "名称",
       "namePlaceholder": "输入集群名称",
       "description": "描述",

--- a/ui/src/lib/api/system.ts
+++ b/ui/src/lib/api/system.ts
@@ -66,6 +66,6 @@ export interface ImportClustersRequest {
 
 export const importClusters = async (
   request: ImportClustersRequest
-): Promise<void> => {
-  await apiClient.post('/admin/clusters/import', request)
+): Promise<{ message: string; importedCount: number }> => {
+  return await apiClient.post('/admin/clusters/import', request)
 }


### PR DESCRIPTION
## What changed

- Add an **Import Clusters** action and dialog to cluster settings.
- Support selecting the extensionless default `~/.kube/config` file or pasting kubeconfig content.
- Import every kubeconfig context into the cluster list.
- Update the kubeconfig for clusters with matching names while preserving their default-cluster and Prometheus settings.
- Keep the existing default cluster unchanged when importing into an already configured installation.
- Refresh cluster queries and provide localized success and error messaging.

## Why

Administrators previously had to add clusters one at a time after initialization. The existing import endpoint also rejected imports once clusters existed and skipped matching contexts, so it could not support ongoing kubeconfig synchronization.

## Impact

Administrators can bulk import or refresh clusters from a kubeconfig directly from the cluster settings page. Existing cluster-specific settings are retained.

close：https://github.com/kite-org/kite/issues/650