### PR TITLE
feat(ui): add deployment revisions management with rollback functiona…

### DIFF
--- a/pkg/resources/deployment_handler.go
+++ b/pkg/resources/deployment_handler.go
@@ -84,12 +84,7 @@ func (h *DeploymentHandler) Revisions(c *gin.Context) {
 		return
 	}
 
-	currentRevision := int64(0)
-	if deployment.Annotations != nil {
-		if v, err := strconv.ParseInt(deployment.Annotations[deploymentRevisionAnnotation], 10, 64); err == nil {
-			currentRevision = v
-		}
-	}
+	_, currentIndex := deploymentCurrentRevision(&deployment, replicaSets)
 
 	items := make([]deploymentRevisionItem, 0, len(replicaSets))
 	for i, rs := range replicaSets {
@@ -97,17 +92,15 @@ func (h *DeploymentHandler) Revisions(c *gin.Context) {
 		for _, container := range rs.Spec.Template.Spec.Containers {
 			images = append(images, container.Image)
 		}
-		rsRevision := deploymentRevisionOf(rs)
-		isCurrent := rsRevision == currentRevision || (currentRevision == 0 && i == 0)
 
 		items = append(items, deploymentRevisionItem{
-			Revision:    rsRevision,
+			Revision:    deploymentRevisionOf(rs),
 			ReplicaSet:  rs.Name,
 			ChangeCause: rs.Annotations[deploymentChangeCauseAnnotation],
 			Images:      images,
 			Replicas:    rs.Status.Replicas,
 			CreatedAt:   rs.CreationTimestamp,
-			Current:     isCurrent,
+			Current:     i == currentIndex,
 		})
 	}
 	c.JSON(http.StatusOK, gin.H{"items": items})
@@ -131,6 +124,10 @@ func (h *DeploymentHandler) Rollback(c *gin.Context) {
 
 	var deployment appsv1.Deployment
 	if err := cs.K8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, &deployment); err != nil {
+		if client.IgnoreNotFound(err) == nil {
+			c.JSON(http.StatusNotFound, gin.H{"error": "not found"})
+			return
+		}
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
@@ -148,11 +145,12 @@ func (h *DeploymentHandler) Rollback(c *gin.Context) {
 
 	targetRevision := req.Revision
 	if targetRevision == 0 {
-		if len(replicaSets) < 2 {
+		_, currentIndex := deploymentCurrentRevision(&deployment, replicaSets)
+		if currentIndex < 0 || currentIndex+1 >= len(replicaSets) {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "no previous revision found"})
 			return
 		}
-		targetRevision = deploymentRevisionOf(replicaSets[1])
+		targetRevision = deploymentRevisionOf(replicaSets[currentIndex+1])
 	}
 
 	var target *appsv1.ReplicaSet
@@ -227,4 +225,27 @@ func listDeploymentReplicaSets(ctx context.Context, cs *cluster.ClientSet, deplo
 func deploymentRevisionOf(rs *appsv1.ReplicaSet) int64 {
 	v, _ := strconv.ParseInt(rs.Annotations[deploymentRevisionAnnotation], 10, 64)
 	return v
+}
+
+// deploymentCurrentRevision resolves which entry in replicaSets (sorted by
+// descending revision) is the Deployment's current revision, using the
+// Deployment's own deployment.kubernetes.io/revision annotation as the
+// source of truth. It falls back to the highest revision (index 0) when the
+// annotation is missing or doesn't match any ReplicaSet in the list.
+func deploymentCurrentRevision(deployment *appsv1.Deployment, replicaSets []*appsv1.ReplicaSet) (revision int64, index int) {
+	index = -1
+	if deployment.Annotations != nil {
+		if v, err := strconv.ParseInt(deployment.Annotations[deploymentRevisionAnnotation], 10, 64); err == nil {
+			for i, rs := range replicaSets {
+				if deploymentRevisionOf(rs) == v {
+					revision, index = v, i
+					break
+				}
+			}
+		}
+	}
+	if index == -1 && len(replicaSets) > 0 {
+		revision, index = deploymentRevisionOf(replicaSets[0]), 0
+	}
+	return revision, index
 }

--- a/pkg/resources/deployment_handler.go
+++ b/pkg/resources/deployment_handler.go
@@ -1,13 +1,28 @@
 package resources
 
 import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/zxh326/kite/pkg/cluster"
 	"github.com/zxh326/kite/pkg/common"
 	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	deploymentRevisionAnnotation    = "deployment.kubernetes.io/revision"
+	deploymentChangeCauseAnnotation = "kubernetes.io/change-cause"
 )
 
 type DeploymentHandler struct {
@@ -31,4 +46,171 @@ func (h *DeploymentHandler) Restart(c *gin.Context, namespace, name string) erro
 	}
 	deployment.Spec.Template.Annotations["kite.kubernetes.io/restartedAt"] = time.Now().Format(time.RFC3339)
 	return cs.K8sClient.Update(c.Request.Context(), &deployment)
+}
+
+func (h *DeploymentHandler) registerCustomRoutes(group *gin.RouterGroup) {
+	group.GET("/:namespace/:name/revisions", h.Revisions)
+	group.PUT("/:namespace/:name/rollback", h.Rollback)
+}
+
+type deploymentRevisionItem struct {
+	Revision    int64       `json:"revision"`
+	ReplicaSet  string      `json:"replicaSet"`
+	ChangeCause string      `json:"changeCause,omitempty"`
+	Images      []string    `json:"images"`
+	Replicas    int32       `json:"replicas"`
+	CreatedAt   metav1.Time `json:"createdAt"`
+	Current     bool        `json:"current"`
+}
+
+func (h *DeploymentHandler) Revisions(c *gin.Context) {
+	namespace, name := c.Param("namespace"), c.Param("name")
+	cs := c.MustGet("cluster").(*cluster.ClientSet)
+	ctx := c.Request.Context()
+
+	var deployment appsv1.Deployment
+	if err := cs.K8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, &deployment); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	replicaSets, err := listDeploymentReplicaSets(ctx, cs, &deployment)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	items := make([]deploymentRevisionItem, 0, len(replicaSets))
+	for i, rs := range replicaSets {
+		images := make([]string, 0, len(rs.Spec.Template.Spec.Containers))
+		for _, container := range rs.Spec.Template.Spec.Containers {
+			images = append(images, container.Image)
+		}
+		items = append(items, deploymentRevisionItem{
+			Revision:    deploymentRevisionOf(rs),
+			ReplicaSet:  rs.Name,
+			ChangeCause: rs.Annotations[deploymentChangeCauseAnnotation],
+			Images:      images,
+			Replicas:    rs.Status.Replicas,
+			CreatedAt:   rs.CreationTimestamp,
+			Current:     i == 0,
+		})
+	}
+	c.JSON(http.StatusOK, gin.H{"items": items})
+}
+
+type deploymentRollbackRequest struct {
+	Revision    int64  `json:"revision"`
+	ChangeCause string `json:"changeCause"`
+}
+
+func (h *DeploymentHandler) Rollback(c *gin.Context) {
+	namespace, name := c.Param("namespace"), c.Param("name")
+	cs := c.MustGet("cluster").(*cluster.ClientSet)
+	ctx := c.Request.Context()
+
+	var req deploymentRollbackRequest
+	if err := c.ShouldBindJSON(&req); err != nil && !errors.Is(err, io.EOF) {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	var deployment appsv1.Deployment
+	if err := cs.K8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, &deployment); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	oldDeployment := deployment.DeepCopy()
+
+	replicaSets, err := listDeploymentReplicaSets(ctx, cs, &deployment)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	if len(replicaSets) == 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "no revision history found for this deployment"})
+		return
+	}
+
+	targetRevision := req.Revision
+	if targetRevision == 0 {
+		if len(replicaSets) < 2 {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "no previous revision found"})
+			return
+		}
+		targetRevision = deploymentRevisionOf(replicaSets[1])
+	}
+
+	var target *appsv1.ReplicaSet
+	for _, rs := range replicaSets {
+		if deploymentRevisionOf(rs) == targetRevision {
+			target = rs
+			break
+		}
+	}
+	if target == nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("revision %d not found", targetRevision)})
+		return
+	}
+
+	var success bool
+	var errMsg string
+	defer func() {
+		h.recordHistory(c, "rollback", oldDeployment, &deployment, success, errMsg)
+	}()
+
+	template := target.Spec.Template.DeepCopy()
+	delete(template.Labels, appsv1.DefaultDeploymentUniqueLabelKey)
+	deployment.Spec.Template = *template
+
+	if deployment.Annotations == nil {
+		deployment.Annotations = make(map[string]string)
+	}
+	changeCause := strings.TrimSpace(req.ChangeCause)
+	if changeCause == "" {
+		changeCause = fmt.Sprintf("Rolled back to revision %d via Kite", targetRevision)
+	}
+	deployment.Annotations[deploymentChangeCauseAnnotation] = changeCause
+
+	if err := cs.K8sClient.Update(ctx, &deployment); err != nil {
+		errMsg = err.Error()
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	success = true
+	c.JSON(http.StatusOK, gin.H{"message": "deployment rolled back", "revision": targetRevision})
+}
+
+func listDeploymentReplicaSets(ctx context.Context, cs *cluster.ClientSet, deployment *appsv1.Deployment) ([]*appsv1.ReplicaSet, error) {
+	selector, err := metav1.LabelSelectorAsSelector(deployment.Spec.Selector)
+	if err != nil {
+		return nil, err
+	}
+
+	var rsList appsv1.ReplicaSetList
+	if err := cs.K8sClient.List(ctx, &rsList, client.InNamespace(deployment.Namespace), client.MatchingLabelsSelector{Selector: selector}); err != nil {
+		return nil, err
+	}
+
+	owned := make([]*appsv1.ReplicaSet, 0, len(rsList.Items))
+	for i := range rsList.Items {
+		rs := &rsList.Items[i]
+		owner := metav1.GetControllerOf(rs)
+		if owner == nil || owner.UID != deployment.UID {
+			continue
+		}
+		if _, ok := rs.Annotations[deploymentRevisionAnnotation]; !ok {
+			continue
+		}
+		owned = append(owned, rs)
+	}
+	sort.Slice(owned, func(i, j int) bool {
+		return deploymentRevisionOf(owned[i]) > deploymentRevisionOf(owned[j])
+	})
+	return owned, nil
+}
+
+func deploymentRevisionOf(rs *appsv1.ReplicaSet) int64 {
+	v, _ := strconv.ParseInt(rs.Annotations[deploymentRevisionAnnotation], 10, 64)
+	return v
 }

--- a/pkg/resources/deployment_handler.go
+++ b/pkg/resources/deployment_handler.go
@@ -70,6 +70,10 @@ func (h *DeploymentHandler) Revisions(c *gin.Context) {
 
 	var deployment appsv1.Deployment
 	if err := cs.K8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, &deployment); err != nil {
+		if client.IgnoreNotFound(err) == nil {
+			c.JSON(http.StatusNotFound, gin.H{"error": "not found"})
+			return
+		}
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}

--- a/pkg/resources/deployment_handler.go
+++ b/pkg/resources/deployment_handler.go
@@ -84,20 +84,30 @@ func (h *DeploymentHandler) Revisions(c *gin.Context) {
 		return
 	}
 
+	currentRevision := int64(0)
+	if deployment.Annotations != nil {
+		if v, err := strconv.ParseInt(deployment.Annotations[deploymentRevisionAnnotation], 10, 64); err == nil {
+			currentRevision = v
+		}
+	}
+
 	items := make([]deploymentRevisionItem, 0, len(replicaSets))
 	for i, rs := range replicaSets {
 		images := make([]string, 0, len(rs.Spec.Template.Spec.Containers))
 		for _, container := range rs.Spec.Template.Spec.Containers {
 			images = append(images, container.Image)
 		}
+		rsRevision := deploymentRevisionOf(rs)
+		isCurrent := rsRevision == currentRevision || (currentRevision == 0 && i == 0)
+
 		items = append(items, deploymentRevisionItem{
-			Revision:    deploymentRevisionOf(rs),
+			Revision:    rsRevision,
 			ReplicaSet:  rs.Name,
 			ChangeCause: rs.Annotations[deploymentChangeCauseAnnotation],
 			Images:      images,
 			Replicas:    rs.Status.Replicas,
 			CreatedAt:   rs.CreationTimestamp,
-			Current:     i == 0,
+			Current:     isCurrent,
 		})
 	}
 	c.JSON(http.StatusOK, gin.H{"items": items})

--- a/pkg/resources/deployment_handler_test.go
+++ b/pkg/resources/deployment_handler_test.go
@@ -290,6 +290,61 @@ func TestDeploymentHandlerRollback_ExplicitRevision(t *testing.T) {
 	}
 }
 
+func TestDeploymentHandlerRollback_NotFound(t *testing.T) {
+	setupDeploymentHandlerTestDB(t)
+
+	cs := newDeploymentHandlerTestClientSet(t)
+	router := newDeploymentHandlerTestRouter(t, cs)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPut, "/deployments/default/missing/rollback", strings.NewReader("{}"))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestDeploymentHandlerRollback_DefaultUsesRevisionBeforeCurrentAnnotation covers
+// the case where the Deployment's own revision annotation does not point at the
+// highest-numbered ReplicaSet (e.g. it lags behind due to eventual consistency, or
+// a stale RS was left with a higher revision number). The default rollback target
+// must be the revision immediately before the Deployment's *actual* current
+// revision, not just replicaSets[1] in sorted order.
+func TestDeploymentHandlerRollback_DefaultUsesRevisionBeforeCurrentAnnotation(t *testing.T) {
+	setupDeploymentHandlerTestDB(t)
+
+	// Deployment says its current revision is 2, but a ReplicaSet with the
+	// numerically higher revision 3 also exists (e.g. stale/orphaned).
+	deployment := makeTestDeployment("2")
+	rs1 := makeTestReplicaSet("demo-app-1", 1, "initial deploy", "nginx:1.25")
+	rs2 := makeTestReplicaSet("demo-app-2", 2, "bump to 1.26", "nginx:1.26")
+	rs3 := makeTestReplicaSet("demo-app-3", 3, "bump to 1.27", "nginx:1.27")
+
+	cs := newDeploymentHandlerTestClientSet(t, deployment, rs1, rs2, rs3)
+	router := newDeploymentHandlerTestRouter(t, cs)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPut, "/deployments/default/demo-app/rollback", strings.NewReader("{}"))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var updated appsv1.Deployment
+	if err := cs.K8sClient.Get(t.Context(), types.NamespacedName{Namespace: "default", Name: "demo-app"}, &updated); err != nil {
+		t.Fatalf("get updated deployment: %v", err)
+	}
+	// The revision before the *current* revision (2) is 1, not the RS after
+	// index 1 in the sorted list (which would have picked revision 2 itself).
+	if got := updated.Spec.Template.Spec.Containers[0].Image; got != "nginx:1.25" {
+		t.Fatalf("expected rollback to revision 1's image nginx:1.25, got %s", got)
+	}
+}
+
 func TestDeploymentHandlerRollback_RevisionNotFound(t *testing.T) {
 	setupDeploymentHandlerTestDB(t)
 

--- a/pkg/resources/deployment_handler_test.go
+++ b/pkg/resources/deployment_handler_test.go
@@ -1,0 +1,328 @@
+package resources
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/glebarez/sqlite"
+	"github.com/zxh326/kite/pkg/cluster"
+	"github.com/zxh326/kite/pkg/kube"
+	"github.com/zxh326/kite/pkg/model"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+const deploymentTestUID = types.UID("demo-deployment-uid")
+
+func setupDeploymentHandlerTestDB(t *testing.T) {
+	t.Helper()
+	oldDB := model.DB
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{Logger: logger.Default.LogMode(logger.Silent)})
+	if err != nil {
+		t.Fatalf("open database: %v", err)
+	}
+	sqlDB, err := db.DB()
+	if err != nil {
+		t.Fatalf("get database: %v", err)
+	}
+	sqlDB.SetMaxOpenConns(1)
+	if err := db.AutoMigrate(&model.User{}, &model.ResourceHistory{}); err != nil {
+		t.Fatalf("migrate database: %v", err)
+	}
+	model.DB = db
+	t.Cleanup(func() {
+		model.DB = oldDB
+		_ = sqlDB.Close()
+	})
+}
+
+func makeTestDeployment(revisionAnnotation string) *appsv1.Deployment {
+	d := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo-app",
+			Namespace: "default",
+			UID:       deploymentTestUID,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "demo-app"},
+			},
+		},
+	}
+	if revisionAnnotation != "" {
+		d.Annotations = map[string]string{deploymentRevisionAnnotation: revisionAnnotation}
+	}
+	return d
+}
+
+func makeTestReplicaSet(name string, revision int64, changeCause, image string) *appsv1.ReplicaSet {
+	isController := true
+	rs := &appsv1.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+			Labels:    map[string]string{"app": "demo-app"},
+			Annotations: map[string]string{
+				deploymentRevisionAnnotation: strconv.FormatInt(revision, 10),
+			},
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "apps/v1",
+					Kind:       "Deployment",
+					Name:       "demo-app",
+					UID:        deploymentTestUID,
+					Controller: &isController,
+				},
+			},
+		},
+		Spec: appsv1.ReplicaSetSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "demo-app"}},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "demo-app"}},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "nginx", Image: image}},
+				},
+			},
+		},
+	}
+	if changeCause != "" {
+		rs.Annotations[deploymentChangeCauseAnnotation] = changeCause
+	}
+	return rs
+}
+
+func newDeploymentHandlerTestRouter(t *testing.T, cs *cluster.ClientSet) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	handler := NewDeploymentHandler()
+	router := gin.New()
+	router.GET("/deployments/:namespace/:name/revisions", func(c *gin.Context) {
+		c.Set("cluster", cs)
+		c.Set("user", model.User{Username: "alice"})
+		handler.Revisions(c)
+	})
+	router.PUT("/deployments/:namespace/:name/rollback", func(c *gin.Context) {
+		c.Set("cluster", cs)
+		c.Set("user", model.User{Username: "alice"})
+		handler.Rollback(c)
+	})
+	return router
+}
+
+func newDeploymentHandlerTestClientSet(t *testing.T, objs ...client.Object) *cluster.ClientSet {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := appsv1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+	return &cluster.ClientSet{
+		Name:      "test",
+		K8sClient: &kube.K8sClient{Client: fakeClient},
+	}
+}
+
+func decodeRevisionsResponse(t *testing.T, rec *httptest.ResponseRecorder) []deploymentRevisionItem {
+	t.Helper()
+	var body struct {
+		Items []deploymentRevisionItem `json:"items"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v; body=%s", err, rec.Body.String())
+	}
+	return body.Items
+}
+
+func TestDeploymentHandlerRevisions_CurrentFollowsDeploymentAnnotation(t *testing.T) {
+	setupDeploymentHandlerTestDB(t)
+
+	// The Deployment's own bookkeeping says revision 2 is current, even though
+	// a ReplicaSet with the numerically higher revision 3 also exists. The
+	// "current" flag must follow the Deployment's annotation, not just pick
+	// the highest revision number in the list.
+	deployment := makeTestDeployment("2")
+	rs1 := makeTestReplicaSet("demo-app-1", 1, "initial deploy", "nginx:1.25")
+	rs2 := makeTestReplicaSet("demo-app-2", 2, "bump to 1.26", "nginx:1.26")
+	rs3 := makeTestReplicaSet("demo-app-3", 3, "bump to 1.27", "nginx:1.27")
+
+	cs := newDeploymentHandlerTestClientSet(t, deployment, rs1, rs2, rs3)
+	router := newDeploymentHandlerTestRouter(t, cs)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/deployments/default/demo-app/revisions", nil)
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	items := decodeRevisionsResponse(t, rec)
+	if len(items) != 3 {
+		t.Fatalf("expected 3 items, got %d", len(items))
+	}
+
+	// Sorted descending by revision.
+	if items[0].Revision != 3 || items[1].Revision != 2 || items[2].Revision != 1 {
+		t.Fatalf("unexpected revision order: %+v", items)
+	}
+
+	for _, item := range items {
+		wantCurrent := item.Revision == 2
+		if item.Current != wantCurrent {
+			t.Errorf("revision %d: current=%v, want %v", item.Revision, item.Current, wantCurrent)
+		}
+	}
+}
+
+func TestDeploymentHandlerRevisions_FallsBackToHighestWhenAnnotationMissing(t *testing.T) {
+	setupDeploymentHandlerTestDB(t)
+
+	deployment := makeTestDeployment("")
+	rs1 := makeTestReplicaSet("demo-app-1", 1, "", "nginx:1.25")
+	rs2 := makeTestReplicaSet("demo-app-2", 2, "", "nginx:1.26")
+
+	cs := newDeploymentHandlerTestClientSet(t, deployment, rs1, rs2)
+	router := newDeploymentHandlerTestRouter(t, cs)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/deployments/default/demo-app/revisions", nil)
+	router.ServeHTTP(rec, req)
+
+	items := decodeRevisionsResponse(t, rec)
+	if len(items) != 2 {
+		t.Fatalf("expected 2 items, got %d", len(items))
+	}
+	if !items[0].Current || items[0].Revision != 2 {
+		t.Fatalf("expected highest revision (2) to be marked current, got %+v", items[0])
+	}
+	if items[1].Current {
+		t.Fatalf("expected revision 1 to not be current: %+v", items[1])
+	}
+}
+
+func TestDeploymentHandlerRevisions_NotFound(t *testing.T) {
+	setupDeploymentHandlerTestDB(t)
+
+	cs := newDeploymentHandlerTestClientSet(t)
+	router := newDeploymentHandlerTestRouter(t, cs)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/deployments/default/missing/revisions", nil)
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestDeploymentHandlerRollback_DefaultsToPreviousRevision(t *testing.T) {
+	setupDeploymentHandlerTestDB(t)
+
+	deployment := makeTestDeployment("3")
+	rs1 := makeTestReplicaSet("demo-app-1", 1, "initial deploy", "nginx:1.25")
+	rs2 := makeTestReplicaSet("demo-app-2", 2, "bump to 1.26", "nginx:1.26")
+	rs3 := makeTestReplicaSet("demo-app-3", 3, "bump to 1.27", "nginx:1.27")
+
+	cs := newDeploymentHandlerTestClientSet(t, deployment, rs1, rs2, rs3)
+	router := newDeploymentHandlerTestRouter(t, cs)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPut, "/deployments/default/demo-app/rollback", strings.NewReader("{}"))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var updated appsv1.Deployment
+	if err := cs.K8sClient.Get(t.Context(), types.NamespacedName{Namespace: "default", Name: "demo-app"}, &updated); err != nil {
+		t.Fatalf("get updated deployment: %v", err)
+	}
+	if got := updated.Spec.Template.Spec.Containers[0].Image; got != "nginx:1.26" {
+		t.Fatalf("expected rollback to revision 2's image nginx:1.26, got %s", got)
+	}
+}
+
+func TestDeploymentHandlerRollback_ExplicitRevision(t *testing.T) {
+	setupDeploymentHandlerTestDB(t)
+
+	deployment := makeTestDeployment("3")
+	rs1 := makeTestReplicaSet("demo-app-1", 1, "initial deploy", "nginx:1.25")
+	rs2 := makeTestReplicaSet("demo-app-2", 2, "bump to 1.26", "nginx:1.26")
+	rs3 := makeTestReplicaSet("demo-app-3", 3, "bump to 1.27", "nginx:1.27")
+
+	cs := newDeploymentHandlerTestClientSet(t, deployment, rs1, rs2, rs3)
+	router := newDeploymentHandlerTestRouter(t, cs)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPut, "/deployments/default/demo-app/rollback", strings.NewReader(`{"revision":1}`))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var updated appsv1.Deployment
+	if err := cs.K8sClient.Get(t.Context(), types.NamespacedName{Namespace: "default", Name: "demo-app"}, &updated); err != nil {
+		t.Fatalf("get updated deployment: %v", err)
+	}
+	if got := updated.Spec.Template.Spec.Containers[0].Image; got != "nginx:1.25" {
+		t.Fatalf("expected rollback to revision 1's image nginx:1.25, got %s", got)
+	}
+	if got := updated.Annotations[deploymentChangeCauseAnnotation]; got != "Rolled back to revision 1 via Kite" {
+		t.Fatalf("unexpected change-cause annotation: %s", got)
+	}
+}
+
+func TestDeploymentHandlerRollback_RevisionNotFound(t *testing.T) {
+	setupDeploymentHandlerTestDB(t)
+
+	deployment := makeTestDeployment("2")
+	rs1 := makeTestReplicaSet("demo-app-1", 1, "", "nginx:1.25")
+	rs2 := makeTestReplicaSet("demo-app-2", 2, "", "nginx:1.26")
+
+	cs := newDeploymentHandlerTestClientSet(t, deployment, rs1, rs2)
+	router := newDeploymentHandlerTestRouter(t, cs)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPut, "/deployments/default/demo-app/rollback", strings.NewReader(`{"revision":99}`))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestDeploymentHandlerRollback_NoHistory(t *testing.T) {
+	setupDeploymentHandlerTestDB(t)
+
+	deployment := makeTestDeployment("")
+	cs := newDeploymentHandlerTestClientSet(t, deployment)
+	router := newDeploymentHandlerTestRouter(t, cs)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPut, "/deployments/default/demo-app/rollback", strings.NewReader("{}"))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+}

--- a/ui/src/components/deployment-revisions-table.tsx
+++ b/ui/src/components/deployment-revisions-table.tsx
@@ -40,7 +40,7 @@ function DeploymentRollbackButton({
       await onRollback(item.revision)
       setOpen(false)
     } catch (error) {
-      toast.error(translateError(error, t))
+      // onRollback is responsible for surfacing errors
     }
   }
 

--- a/ui/src/components/deployment-revisions-table.tsx
+++ b/ui/src/components/deployment-revisions-table.tsx
@@ -1,0 +1,236 @@
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { toast } from 'sonner'
+
+import { DeploymentRevisionItem } from '@/types/api'
+import { rollbackDeployment, useDeploymentRevisions } from '@/lib/api'
+import { formatDate, translateError } from '@/lib/utils'
+
+import { SimpleTable } from './simple-table'
+import { Button } from './ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from './ui/card'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from './ui/dialog'
+
+function DeploymentRollbackButton({
+  item,
+  namespace,
+  name,
+  disabled,
+  onRollback,
+}: {
+  item: DeploymentRevisionItem
+  namespace: string
+  name: string
+  disabled: boolean
+  onRollback: (revision: number) => Promise<void>
+}) {
+  const { t } = useTranslation()
+  const [open, setOpen] = useState(false)
+
+  const handleConfirm = async () => {
+    await onRollback(item.revision)
+    setOpen(false)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button
+          variant="outline"
+          size="sm"
+          className="w-24"
+          disabled={disabled}
+        >
+          {t('deployments.actions.rollback')}
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="!max-w-md sm:!max-w-md">
+        <DialogHeader>
+          <DialogTitle>
+            {t('deployments.messages.rollbackConfirmTitle')}
+          </DialogTitle>
+          <DialogDescription>
+            {t('deployments.messages.rollbackConfirmDescription', {
+              namespace,
+              name,
+              revision: item.revision,
+            })}
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => setOpen(false)}
+            disabled={disabled}
+          >
+            {t('common.actions.cancel')}
+          </Button>
+          <Button
+            type="button"
+            variant="destructive"
+            onClick={() => void handleConfirm()}
+            disabled={disabled}
+          >
+            {t('deployments.actions.rollback')}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+export function DeploymentRevisionsTable({
+  namespace,
+  name,
+  onRollbackComplete,
+}: {
+  namespace: string
+  name: string
+  onRollbackComplete: () => Promise<unknown>
+}) {
+  const { t } = useTranslation()
+  const [rollingBackRevision, setRollingBackRevision] = useState<number | null>(
+    null
+  )
+  const {
+    data,
+    isLoading,
+    isError,
+    error,
+    refetch: refetchRevisions,
+  } = useDeploymentRevisions(namespace, name)
+
+  const handleRollback = async (revision: number) => {
+    setRollingBackRevision(revision)
+    try {
+      await rollbackDeployment(namespace, name, revision)
+      toast.success(t('deployments.messages.rollbackStarted'))
+      await Promise.all([refetchRevisions(), onRollbackComplete()])
+    } catch (err) {
+      toast.error(translateError(err, t))
+    } finally {
+      setRollingBackRevision(null)
+    }
+  }
+
+  if (isLoading) {
+    return (
+      <Card>
+        <CardContent className="pt-6 text-sm text-muted-foreground">
+          {t('common.messages.loading')}
+        </CardContent>
+      </Card>
+    )
+  }
+
+  if (isError) {
+    return (
+      <Card>
+        <CardContent className="pt-6 text-sm text-destructive">
+          {translateError(error, t)}
+        </CardContent>
+      </Card>
+    )
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{t('common.tabs.revisions')}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <SimpleTable
+          data={data?.items || []}
+          emptyMessage={t('deployments.messages.noRevisions')}
+          columns={[
+            {
+              header: t('common.fields.revision'),
+              accessor: (item) => item.revision,
+              cell: (value) => (
+                <span className="font-medium tabular-nums">
+                  {value as number}
+                </span>
+              ),
+            },
+            {
+              header: t('deployments.fields.replicaSet'),
+              accessor: (item) => item.replicaSet,
+              cell: (value) => value as string,
+              align: 'left',
+            },
+            {
+              header: t('common.fields.updated'),
+              accessor: (item) => item.createdAt,
+              cell: (value) => (
+                <span className="text-sm text-muted-foreground">
+                  {value ? formatDate(value as string) : '-'}
+                </span>
+              ),
+              align: 'left',
+            },
+            {
+              header: t('common.tabs.containers'),
+              accessor: (item) => item.images,
+              cell: (value) => (
+                <div className="max-w-md whitespace-pre-wrap break-words text-xs text-muted-foreground">
+                  {((value as string[]) || []).join(', ') || '-'}
+                </div>
+              ),
+              align: 'left',
+            },
+            {
+              header: t('deployments.fields.changeCause'),
+              accessor: (item) => item.changeCause || '-',
+              cell: (value) => (
+                <span className="text-sm text-muted-foreground">
+                  {value as string}
+                </span>
+              ),
+              align: 'left',
+            },
+            {
+              header: t('common.fields.actions'),
+              accessor: (item) => item,
+              cell: (value) => {
+                const item = value as DeploymentRevisionItem
+                return (
+                  <div className="ml-auto w-max">
+                    {item.current ? (
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        className="w-24"
+                        disabled
+                      >
+                        {t('common.fields.current')}
+                      </Button>
+                    ) : (
+                      <DeploymentRollbackButton
+                        item={item}
+                        namespace={namespace}
+                        name={name}
+                        disabled={rollingBackRevision !== null}
+                        onRollback={handleRollback}
+                      />
+                    )}
+                  </div>
+                )
+              },
+              align: 'right',
+            },
+          ]}
+          pagination={{ enabled: true, pageSize: 10 }}
+        />
+      </CardContent>
+    </Card>
+  )
+}

--- a/ui/src/components/deployment-revisions-table.tsx
+++ b/ui/src/components/deployment-revisions-table.tsx
@@ -36,12 +36,8 @@ function DeploymentRollbackButton({
   const [open, setOpen] = useState(false)
 
   const handleConfirm = async () => {
-    try {
-      await onRollback(item.revision)
-      setOpen(false)
-    } catch (error) {
-      // onRollback is responsible for surfacing errors
-    }
+    await onRollback(item.revision)
+    setOpen(false)
   }
 
   return (

--- a/ui/src/components/deployment-revisions-table.tsx
+++ b/ui/src/components/deployment-revisions-table.tsx
@@ -36,8 +36,12 @@ function DeploymentRollbackButton({
   const [open, setOpen] = useState(false)
 
   const handleConfirm = async () => {
-    await onRollback(item.revision)
-    setOpen(false)
+    try {
+      await onRollback(item.revision)
+      setOpen(false)
+    } catch (error) {
+      toast.error(translateError(error, t))
+    }
   }
 
   return (

--- a/ui/src/components/deployment-revisions-table.tsx
+++ b/ui/src/components/deployment-revisions-table.tsx
@@ -168,7 +168,7 @@ export function DeploymentRevisionsTable({
               align: 'left',
             },
             {
-              header: t('common.fields.updated'),
+              header: t('common.fields.created'),
               accessor: (item) => item.createdAt,
               cell: (value) => (
                 <span className="text-sm text-muted-foreground">

--- a/ui/src/components/deployment-revisions-table.tsx
+++ b/ui/src/components/deployment-revisions-table.tsx
@@ -168,6 +168,14 @@ export function DeploymentRevisionsTable({
               align: 'left',
             },
             {
+              header: t('common.fields.replicas'),
+              accessor: (item) => item.replicas,
+              cell: (value) => (
+                <span className="tabular-nums">{value as number}</span>
+              ),
+              align: 'left',
+            },
+            {
               header: t('common.fields.created'),
               accessor: (item) => item.createdAt,
               cell: (value) => (

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -292,6 +292,7 @@
       "overview": "Overview",
       "pods": "Pods",
       "related": "Related",
+      "revisions": "Revisions",
       "terminal": "Terminal",
       "volumes": "Volumes",
       "yaml": "YAML"
@@ -500,7 +501,20 @@
     "servicePort": "Service Port",
     "targetPort": "Target Port",
     "exposeInvalidPort": "Port must be between 1 and 65535",
-    "exposeNoSelector": "No Deployment selector labels found to expose"
+    "exposeNoSelector": "No Deployment selector labels found to expose",
+    "actions": {
+      "rollback": "Rollback"
+    },
+    "fields": {
+      "replicaSet": "ReplicaSet",
+      "changeCause": "Change Cause"
+    },
+    "messages": {
+      "noRevisions": "No revision history found",
+      "rollbackStarted": "Rollback requested",
+      "rollbackConfirmTitle": "Rollback deployment?",
+      "rollbackConfirmDescription": "Rollback {{namespace}}/{{name}} to revision {{revision}}."
+    }
   },
   "daemonsets": {
     "title": "DaemonSets"

--- a/ui/src/i18n/locales/zh.json
+++ b/ui/src/i18n/locales/zh.json
@@ -292,6 +292,7 @@
       "overview": "概览",
       "pods": "Pods",
       "related": "相关资源",
+      "revisions": "版本历史",
       "terminal": "终端",
       "volumes": "卷",
       "yaml": "YAML"
@@ -505,7 +506,20 @@
     "servicePort": "Service 端口",
     "targetPort": "目标端口",
     "exposeInvalidPort": "端口必须在 1 到 65535 之间",
-    "exposeNoSelector": "Deployment 没有可用于暴露的 selector 标签"
+    "exposeNoSelector": "Deployment 没有可用于暴露的 selector 标签",
+    "actions": {
+      "rollback": "回滚"
+    },
+    "fields": {
+      "replicaSet": "ReplicaSet",
+      "changeCause": "变更原因"
+    },
+    "messages": {
+      "noRevisions": "未找到版本历史",
+      "rollbackStarted": "已发起回滚",
+      "rollbackConfirmTitle": "回滚 Deployment？",
+      "rollbackConfirmDescription": "将 {{namespace}}/{{name}} 回滚到版本 {{revision}}。"
+    }
   },
   "daemonsets": {
     "title": "DaemonSets"

--- a/ui/src/lib/api/core.ts
+++ b/ui/src/lib/api/core.ts
@@ -1072,7 +1072,7 @@ export const useDeploymentRevisions = (
     queryKey: ['deployment-revisions', namespace, name],
     queryFn: () => fetchDeploymentRevisions(namespace, name),
     enabled: options?.enabled ?? true,
-    staleTime: options?.staleTime || 30000,
+    staleTime: options?.staleTime ?? 30000,
   })
 }
 
@@ -1083,7 +1083,7 @@ export const rollbackDeployment = async (
 ): Promise<{ message?: string }> => {
   return apiClient.put<{ message?: string }>(
     `/deployments/${encodeURIComponent(namespace)}/${encodeURIComponent(name)}/rollback`,
-    revision ? { revision } : {}
+    revision !== undefined ? { revision } : {}
   )
 }
 

--- a/ui/src/lib/api/core.ts
+++ b/ui/src/lib/api/core.ts
@@ -1080,8 +1080,8 @@ export const rollbackDeployment = async (
   namespace: string,
   name: string,
   revision?: number
-): Promise<{ message?: string }> => {
-  return apiClient.put<{ message?: string }>(
+): Promise<{ message?: string; revision?: number }> => {
+  return apiClient.put<{ message?: string; revision?: number }>(
     `/deployments/${encodeURIComponent(namespace)}/${encodeURIComponent(name)}/rollback`,
     revision !== undefined ? { revision } : {}
   )

--- a/ui/src/lib/api/core.ts
+++ b/ui/src/lib/api/core.ts
@@ -3,6 +3,7 @@ import { useQuery } from '@tanstack/react-query'
 import { Pod } from 'kubernetes-types/core/v1'
 
 import {
+  DeploymentRevisionsResponse,
   HelmChartContent,
   HelmChartContentType,
   HelmChartDetail,
@@ -1051,6 +1052,39 @@ export const fetchResourceHistory = (
 ): Promise<ResourceHistoryResponse> => {
   const endpoint = `/${resourceType}/${namespace}/${name}/history?page=${page}&pageSize=${pageSize}`
   return fetchAPI<ResourceHistoryResponse>(endpoint)
+}
+
+export const fetchDeploymentRevisions = (
+  namespace: string,
+  name: string
+): Promise<DeploymentRevisionsResponse> => {
+  return fetchAPI<DeploymentRevisionsResponse>(
+    `/deployments/${encodeURIComponent(namespace)}/${encodeURIComponent(name)}/revisions`
+  )
+}
+
+export const useDeploymentRevisions = (
+  namespace: string,
+  name: string,
+  options?: { enabled?: boolean; staleTime?: number }
+) => {
+  return useQuery({
+    queryKey: ['deployment-revisions', namespace, name],
+    queryFn: () => fetchDeploymentRevisions(namespace, name),
+    enabled: options?.enabled ?? true,
+    staleTime: options?.staleTime || 30000,
+  })
+}
+
+export const rollbackDeployment = async (
+  namespace: string,
+  name: string,
+  revision?: number
+): Promise<{ message?: string }> => {
+  return apiClient.put<{ message?: string }>(
+    `/deployments/${encodeURIComponent(namespace)}/${encodeURIComponent(name)}/rollback`,
+    revision ? { revision } : {}
+  )
 }
 
 export const useResourceHistory = (

--- a/ui/src/pages/deployment-detail.tsx
+++ b/ui/src/pages/deployment-detail.tsx
@@ -42,6 +42,7 @@ import {
 } from '@/components/ui/select'
 import { ContainerInfoCard } from '@/components/container-info-card'
 import { DeploymentOverview } from '@/components/deployment-overview'
+import { DeploymentRevisionsTable } from '@/components/deployment-revisions-table'
 import { EventTable } from '@/components/event-table'
 import { LogViewer } from '@/components/log-viewer'
 import { PodMonitoring } from '@/components/pod-monitoring'
@@ -386,6 +387,17 @@ export function DeploymentDetail(props: { namespace: string; name: string }) {
         ),
       },
       {
+        value: 'revisions',
+        label: t('common.tabs.revisions'),
+        content: (
+          <DeploymentRevisionsTable
+            namespace={namespace}
+            name={name}
+            onRollbackComplete={refetch}
+          />
+        ),
+      },
+      {
         value: 'history',
         label: t('common.tabs.history'),
         content: deployment ? (
@@ -460,6 +472,7 @@ export function DeploymentDetail(props: { namespace: string; name: string }) {
     handleContainerUpdate,
     name,
     namespace,
+    refetch,
     relatedPods,
     t,
   ])

--- a/ui/src/types/api.ts
+++ b/ui/src/types/api.ts
@@ -745,6 +745,20 @@ export interface ResourceHistoryResponse {
   }
 }
 
+export interface DeploymentRevisionItem {
+  revision: number
+  replicaSet: string
+  changeCause?: string
+  images: string[]
+  replicas: number
+  createdAt: string
+  current: boolean
+}
+
+export interface DeploymentRevisionsResponse {
+  items: DeploymentRevisionItem[]
+}
+
 export interface AuditLogResponse {
   data: ResourceHistory[]
   total: number


### PR DESCRIPTION
## Summary

Adds a **Revisions** tab to the Deployment detail page showing real Kubernetes rollout history (`kubectl rollout history`-equivalent), with a **Rollback** action to revert to any previous revision (`kubectl rollout undo`-equivalent).

- Backend: `GET /deployments/:namespace/:name/revisions` lists the ReplicaSets owned by a Deployment, sorted by the `deployment.kubernetes.io/revision` annotation, with images, replica count, and the `kubernetes.io/change-cause` annotation. `PUT /deployments/:namespace/:name/rollback` reverts the Deployment's pod template to a target revision (or the previous one by default), mirroring `kubectl rollout undo`. Rollbacks are recorded in Kite's existing audit history.
- Frontend: new `DeploymentRevisionsTable` component wired into the Deployment detail page's "Revisions" tab, with a confirmation dialog before rolling back, following the same pattern as the existing HelmRelease rollback UI.

## Why

Kite's existing "History" tab only shows Kite's own internal audit log of changes made through Kite itself. It doesn't surface revisions created by external tools (e.g. a Jenkins pipeline deploying directly to the cluster), so there was no way to see or roll back to a prior deployment state without re-running the external pipeline.

## Related issue


## Validation

- `go build ./...`, `go vet ./pkg/resources/...`, `go test ./pkg/resources/...` all pass.
- Frontend `pnpm run type-check`, `pnpm run lint`, `pnpm run test`, `pnpm run build` all pass.
- Manually verified end-to-end against a local k3d cluster: created a Deployment with 3 revisions (distinct images + `change-cause` annotations, simulating external/Jenkins deploys), confirmed `GET .../revisions` returns them in the correct order with `current` flagged correctly, and confirmed `PUT .../rollback` correctly reverts the Deployment's image and that Kubernetes reuses/bumps the matching old ReplicaSet's revision, matching `kubectl rollout undo` semantics.

## Checklist

- [x] I reviewed this PR myself before requesting review.
- [x] I understand the changes, including AI-generated parts (if any).
- [x] For new features, a feature request issue is linked.
- [ ] I cleaned up AI noise (unnecessary comments, dead code, and unrelated changes).
- [x] This PR is reasonably scoped (or split into smaller PRs).
