### PR TITLE
Deployment revision v1

### DIFF
--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -132,7 +132,7 @@ func (l controllerRuntimeLogSink) WithCallDepth(depth int) logr.LogSink {
 // K8sClient holds the Kubernetes client instances
 type K8sClient struct {
 	client.Client
-	ClientSet     *kubernetes.Clientset
+	ClientSet     kubernetes.Interface
 	Configuration *rest.Config
 	MetricsClient *metricsclient.Clientset
 	CacheEnabled  bool // true when using controller-runtime informer cache

--- a/pkg/resources/daemonset_handler.go
+++ b/pkg/resources/daemonset_handler.go
@@ -11,6 +11,7 @@ import (
 	"github.com/zxh326/kite/pkg/cluster"
 	"github.com/zxh326/kite/pkg/common"
 	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -114,14 +115,14 @@ func (h *DaemonSetHandler) Rollback(c *gin.Context) {
 		targetRevision = revisions[1].Revision
 	}
 
-	var target *appsv1.ControllerRevision
+	found := false
 	for _, rev := range revisions {
 		if rev.Revision == targetRevision {
-			target = rev
+			found = true
 			break
 		}
 	}
-	if target == nil {
+	if !found {
 		c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("revision %d not found", targetRevision)})
 		return
 	}
@@ -132,22 +133,37 @@ func (h *DaemonSetHandler) Rollback(c *gin.Context) {
 		h.recordHistory(c, "rollback", oldDs, &ds, success, errMsg)
 	}()
 
-	changeCause := strings.TrimSpace(req.ChangeCause)
-	if changeCause == "" {
-		changeCause = fmt.Sprintf("Rolled back to revision %d via Kite", targetRevision)
-	}
-	patch, err := withChangeCauseAnnotation(target.Data.Raw, changeCause)
-	if err != nil {
+	if err := rollbackWorkload(cs, daemonSetGroupKind, &ds, targetRevision); err != nil {
 		errMsg = err.Error()
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
 
-	if err := cs.K8sClient.Patch(ctx, &ds, client.RawPatch(types.StrategicMergePatchType, patch)); err != nil {
+	// Re-fetch and annotate through the same typed clientset kubectl's
+	// Rollbacker just wrote through (rather than controller-runtime's
+	// client), so this read is guaranteed to see the rollback it just
+	// applied.
+	updated, err := cs.K8sClient.ClientSet.AppsV1().DaemonSets(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
 		errMsg = err.Error()
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
+	if updated.Annotations == nil {
+		updated.Annotations = make(map[string]string)
+	}
+	changeCause := strings.TrimSpace(req.ChangeCause)
+	if changeCause == "" {
+		changeCause = fmt.Sprintf("Rolled back to revision %d via Kite", targetRevision)
+	}
+	updated.Annotations[deploymentChangeCauseAnnotation] = changeCause
+	updated, err = cs.K8sClient.ClientSet.AppsV1().DaemonSets(namespace).Update(ctx, updated, metav1.UpdateOptions{})
+	if err != nil {
+		errMsg = err.Error()
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	ds = *updated
 
 	success = true
 	c.JSON(http.StatusOK, gin.H{"message": "daemonset rolled back", "revision": targetRevision})

--- a/pkg/resources/daemonset_handler.go
+++ b/pkg/resources/daemonset_handler.go
@@ -1,19 +1,14 @@
 package resources
 
 import (
-	"errors"
-	"fmt"
-	"io"
 	"net/http"
-	"strings"
 
 	"github.com/gin-gonic/gin"
 	"github.com/zxh326/kite/pkg/cluster"
 	"github.com/zxh326/kite/pkg/common"
 	appsv1 "k8s.io/api/apps/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type DaemonSetHandler struct {
@@ -26,19 +21,14 @@ func NewDaemonSetHandler() *DaemonSetHandler {
 	}
 }
 
-func (h *DaemonSetHandler) registerCustomRoutes(group *gin.RouterGroup) {
-	group.GET("/:namespace/:name/revisions", h.Revisions)
-	group.PUT("/:namespace/:name/rollback", h.Rollback)
-}
-
 func (h *DaemonSetHandler) Revisions(c *gin.Context) {
 	namespace, name := c.Param("namespace"), c.Param("name")
 	cs := c.MustGet("cluster").(*cluster.ClientSet)
 	ctx := c.Request.Context()
 
-	var ds appsv1.DaemonSet
-	if err := cs.K8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, &ds); err != nil {
-		if client.IgnoreNotFound(err) == nil {
+	ds, err := cs.K8sClient.ClientSet.AppsV1().DaemonSets(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
 			c.JSON(http.StatusNotFound, gin.H{"error": "not found"})
 			return
 		}
@@ -46,125 +36,11 @@ func (h *DaemonSetHandler) Revisions(c *gin.Context) {
 		return
 	}
 
-	revisions, err := listControllerRevisions(ctx, cs, namespace, ds.Spec.Selector, &ds)
+	revisions, err := listControllerRevisions(ctx, cs, namespace, ds.Spec.Selector, ds)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
 
-	// DaemonSet has no authoritative "current revision" status field (unlike
-	// StatefulSet's status.currentRevision), so the highest revision number
-	// is the only signal available - same fallback Deployment uses.
-	currentIndex := -1
-	if len(revisions) > 0 {
-		currentIndex = 0
-	}
-
-	items := make([]WorkloadRevisionItem, 0, len(revisions))
-	for i, rev := range revisions {
-		items = append(items, WorkloadRevisionItem{
-			Revision:       rev.Revision,
-			RevisionObject: rev.Name,
-			ChangeCause:    rev.Annotations[deploymentChangeCauseAnnotation],
-			Images:         controllerRevisionImages(rev.Data.Raw),
-			CreatedAt:      rev.CreationTimestamp,
-			Current:        i == currentIndex,
-		})
-	}
-	c.JSON(http.StatusOK, gin.H{"items": items})
-}
-
-func (h *DaemonSetHandler) Rollback(c *gin.Context) {
-	namespace, name := c.Param("namespace"), c.Param("name")
-	cs := c.MustGet("cluster").(*cluster.ClientSet)
-	ctx := c.Request.Context()
-
-	var req workloadRollbackRequest
-	if err := c.ShouldBindJSON(&req); err != nil && !errors.Is(err, io.EOF) {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
-		return
-	}
-
-	var ds appsv1.DaemonSet
-	if err := cs.K8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, &ds); err != nil {
-		if client.IgnoreNotFound(err) == nil {
-			c.JSON(http.StatusNotFound, gin.H{"error": "not found"})
-			return
-		}
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-		return
-	}
-	oldDs := ds.DeepCopy()
-
-	revisions, err := listControllerRevisions(ctx, cs, namespace, ds.Spec.Selector, &ds)
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-		return
-	}
-	if len(revisions) == 0 {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "no revision history found for this daemonset"})
-		return
-	}
-
-	targetRevision := req.Revision
-	if targetRevision == 0 {
-		if len(revisions) < 2 {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "no previous revision found"})
-			return
-		}
-		targetRevision = revisions[1].Revision
-	}
-
-	found := false
-	for _, rev := range revisions {
-		if rev.Revision == targetRevision {
-			found = true
-			break
-		}
-	}
-	if !found {
-		c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("revision %d not found", targetRevision)})
-		return
-	}
-
-	var success bool
-	var errMsg string
-	defer func() {
-		h.recordHistory(c, "rollback", oldDs, &ds, success, errMsg)
-	}()
-
-	if err := rollbackWorkload(cs, daemonSetGroupKind, &ds, targetRevision); err != nil {
-		errMsg = err.Error()
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-		return
-	}
-
-	// Re-fetch and annotate through the same typed clientset kubectl's
-	// Rollbacker just wrote through (rather than controller-runtime's
-	// client), so this read is guaranteed to see the rollback it just
-	// applied.
-	updated, err := cs.K8sClient.ClientSet.AppsV1().DaemonSets(namespace).Get(ctx, name, metav1.GetOptions{})
-	if err != nil {
-		errMsg = err.Error()
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-		return
-	}
-	if updated.Annotations == nil {
-		updated.Annotations = make(map[string]string)
-	}
-	changeCause := strings.TrimSpace(req.ChangeCause)
-	if changeCause == "" {
-		changeCause = fmt.Sprintf("Rolled back to revision %d via Kite", targetRevision)
-	}
-	updated.Annotations[deploymentChangeCauseAnnotation] = changeCause
-	updated, err = cs.K8sClient.ClientSet.AppsV1().DaemonSets(namespace).Update(ctx, updated, metav1.UpdateOptions{})
-	if err != nil {
-		errMsg = err.Error()
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-		return
-	}
-	ds = *updated
-
-	success = true
-	c.JSON(http.StatusOK, gin.H{"message": "daemonset rolled back", "revision": targetRevision})
+	c.JSON(http.StatusOK, gin.H{"items": controllerRevisionItems(revisions, 0)})
 }

--- a/pkg/resources/daemonset_handler.go
+++ b/pkg/resources/daemonset_handler.go
@@ -1,0 +1,154 @@
+package resources
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/zxh326/kite/pkg/cluster"
+	"github.com/zxh326/kite/pkg/common"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type DaemonSetHandler struct {
+	*GenericResourceHandler[*appsv1.DaemonSet, *appsv1.DaemonSetList]
+}
+
+func NewDaemonSetHandler() *DaemonSetHandler {
+	return &DaemonSetHandler{
+		GenericResourceHandler: NewGenericResourceHandler[*appsv1.DaemonSet, *appsv1.DaemonSetList](common.DaemonSets),
+	}
+}
+
+func (h *DaemonSetHandler) registerCustomRoutes(group *gin.RouterGroup) {
+	group.GET("/:namespace/:name/revisions", h.Revisions)
+	group.PUT("/:namespace/:name/rollback", h.Rollback)
+}
+
+func (h *DaemonSetHandler) Revisions(c *gin.Context) {
+	namespace, name := c.Param("namespace"), c.Param("name")
+	cs := c.MustGet("cluster").(*cluster.ClientSet)
+	ctx := c.Request.Context()
+
+	var ds appsv1.DaemonSet
+	if err := cs.K8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, &ds); err != nil {
+		if client.IgnoreNotFound(err) == nil {
+			c.JSON(http.StatusNotFound, gin.H{"error": "not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	revisions, err := listControllerRevisions(ctx, cs, namespace, ds.Spec.Selector, &ds)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	// DaemonSet has no authoritative "current revision" status field (unlike
+	// StatefulSet's status.currentRevision), so the highest revision number
+	// is the only signal available - same fallback Deployment uses.
+	currentIndex := -1
+	if len(revisions) > 0 {
+		currentIndex = 0
+	}
+
+	items := make([]WorkloadRevisionItem, 0, len(revisions))
+	for i, rev := range revisions {
+		items = append(items, WorkloadRevisionItem{
+			Revision:       rev.Revision,
+			RevisionObject: rev.Name,
+			ChangeCause:    rev.Annotations[deploymentChangeCauseAnnotation],
+			Images:         controllerRevisionImages(rev.Data.Raw),
+			CreatedAt:      rev.CreationTimestamp,
+			Current:        i == currentIndex,
+		})
+	}
+	c.JSON(http.StatusOK, gin.H{"items": items})
+}
+
+func (h *DaemonSetHandler) Rollback(c *gin.Context) {
+	namespace, name := c.Param("namespace"), c.Param("name")
+	cs := c.MustGet("cluster").(*cluster.ClientSet)
+	ctx := c.Request.Context()
+
+	var req workloadRollbackRequest
+	if err := c.ShouldBindJSON(&req); err != nil && !errors.Is(err, io.EOF) {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	var ds appsv1.DaemonSet
+	if err := cs.K8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, &ds); err != nil {
+		if client.IgnoreNotFound(err) == nil {
+			c.JSON(http.StatusNotFound, gin.H{"error": "not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	oldDs := ds.DeepCopy()
+
+	revisions, err := listControllerRevisions(ctx, cs, namespace, ds.Spec.Selector, &ds)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	if len(revisions) == 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "no revision history found for this daemonset"})
+		return
+	}
+
+	targetRevision := req.Revision
+	if targetRevision == 0 {
+		if len(revisions) < 2 {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "no previous revision found"})
+			return
+		}
+		targetRevision = revisions[1].Revision
+	}
+
+	var target *appsv1.ControllerRevision
+	for _, rev := range revisions {
+		if rev.Revision == targetRevision {
+			target = rev
+			break
+		}
+	}
+	if target == nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("revision %d not found", targetRevision)})
+		return
+	}
+
+	var success bool
+	var errMsg string
+	defer func() {
+		h.recordHistory(c, "rollback", oldDs, &ds, success, errMsg)
+	}()
+
+	changeCause := strings.TrimSpace(req.ChangeCause)
+	if changeCause == "" {
+		changeCause = fmt.Sprintf("Rolled back to revision %d via Kite", targetRevision)
+	}
+	patch, err := withChangeCauseAnnotation(target.Data.Raw, changeCause)
+	if err != nil {
+		errMsg = err.Error()
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	if err := cs.K8sClient.Patch(ctx, &ds, client.RawPatch(types.StrategicMergePatchType, patch)); err != nil {
+		errMsg = err.Error()
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	success = true
+	c.JSON(http.StatusOK, gin.H{"message": "daemonset rolled back", "revision": targetRevision})
+}

--- a/pkg/resources/daemonset_handler_test.go
+++ b/pkg/resources/daemonset_handler_test.go
@@ -1,0 +1,212 @@
+package resources
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/zxh326/kite/pkg/cluster"
+	"github.com/zxh326/kite/pkg/model"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+const daemonSetTestUID = types.UID("demo-daemonset-uid")
+
+func makeTestDaemonSet() *appsv1.DaemonSet {
+	return &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo-ds",
+			Namespace: "default",
+			UID:       daemonSetTestUID,
+		},
+		Spec: appsv1.DaemonSetSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "demo-ds"},
+			},
+		},
+	}
+}
+
+func newDaemonSetHandlerTestRouter(t *testing.T, cs *cluster.ClientSet) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	handler := NewDaemonSetHandler()
+	router := gin.New()
+	router.GET("/daemonsets/:namespace/:name/revisions", func(c *gin.Context) {
+		c.Set("cluster", cs)
+		c.Set("user", model.User{Username: "alice"})
+		handler.Revisions(c)
+	})
+	router.PUT("/daemonsets/:namespace/:name/rollback", func(c *gin.Context) {
+		c.Set("cluster", cs)
+		c.Set("user", model.User{Username: "alice"})
+		handler.Rollback(c)
+	})
+	return router
+}
+
+func TestDaemonSetHandlerRevisions_CurrentIsHighestRevision(t *testing.T) {
+	setupDeploymentHandlerTestDB(t)
+
+	ds := makeTestDaemonSet()
+	cr1 := makeTestControllerRevision(t, "demo-ds-cr1", 1, "initial deploy", "fluentd:1.14", daemonSetTestUID, "DaemonSet")
+	cr2 := makeTestControllerRevision(t, "demo-ds-cr2", 2, "bump to 1.15", "fluentd:1.15", daemonSetTestUID, "DaemonSet")
+
+	cs := newDeploymentHandlerTestClientSet(t, ds, cr1, cr2)
+	router := newDaemonSetHandlerTestRouter(t, cs)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/daemonsets/default/demo-ds/revisions", nil)
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	items := decodeRevisionsResponse(t, rec)
+	if len(items) != 2 {
+		t.Fatalf("expected 2 items, got %d", len(items))
+	}
+	if items[0].Revision != 2 || !items[0].Current {
+		t.Fatalf("expected highest revision (2) to be current, got %+v", items[0])
+	}
+	if items[1].Current {
+		t.Fatalf("expected revision 1 to not be current: %+v", items[1])
+	}
+	if got := items[0].Images; len(got) != 1 || got[0] != "fluentd:1.15" {
+		t.Fatalf("expected images [fluentd:1.15], got %v", got)
+	}
+}
+
+func TestDaemonSetHandlerRevisions_NotFound(t *testing.T) {
+	setupDeploymentHandlerTestDB(t)
+
+	cs := newDeploymentHandlerTestClientSet(t)
+	router := newDaemonSetHandlerTestRouter(t, cs)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/daemonsets/default/missing/revisions", nil)
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestDaemonSetHandlerRollback_DefaultsToPreviousRevision(t *testing.T) {
+	setupDeploymentHandlerTestDB(t)
+
+	ds := makeTestDaemonSet()
+	cr1 := makeTestControllerRevision(t, "demo-ds-cr1", 1, "initial deploy", "fluentd:1.14", daemonSetTestUID, "DaemonSet")
+	cr2 := makeTestControllerRevision(t, "demo-ds-cr2", 2, "bump to 1.15", "fluentd:1.15", daemonSetTestUID, "DaemonSet")
+
+	cs := newDeploymentHandlerTestClientSet(t, ds, cr1, cr2)
+	router := newDaemonSetHandlerTestRouter(t, cs)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPut, "/daemonsets/default/demo-ds/rollback", strings.NewReader("{}"))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var updated appsv1.DaemonSet
+	if err := cs.K8sClient.Get(t.Context(), types.NamespacedName{Namespace: "default", Name: "demo-ds"}, &updated); err != nil {
+		t.Fatalf("get updated daemonset: %v", err)
+	}
+	if got := updated.Spec.Template.Spec.Containers[0].Image; got != "fluentd:1.14" {
+		t.Fatalf("expected rollback to revision 1's image fluentd:1.14, got %s", got)
+	}
+	if got := updated.Annotations[deploymentChangeCauseAnnotation]; got != "Rolled back to revision 1 via Kite" {
+		t.Fatalf("unexpected change-cause annotation: %s", got)
+	}
+}
+
+func TestDaemonSetHandlerRollback_ExplicitRevision(t *testing.T) {
+	setupDeploymentHandlerTestDB(t)
+
+	ds := makeTestDaemonSet()
+	cr1 := makeTestControllerRevision(t, "demo-ds-cr1", 1, "initial deploy", "fluentd:1.14", daemonSetTestUID, "DaemonSet")
+	cr2 := makeTestControllerRevision(t, "demo-ds-cr2", 2, "bump to 1.15", "fluentd:1.15", daemonSetTestUID, "DaemonSet")
+
+	cs := newDeploymentHandlerTestClientSet(t, ds, cr1, cr2)
+	router := newDaemonSetHandlerTestRouter(t, cs)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPut, "/daemonsets/default/demo-ds/rollback", strings.NewReader(`{"revision":1,"changeCause":"manual rollback"}`))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var updated appsv1.DaemonSet
+	if err := cs.K8sClient.Get(t.Context(), types.NamespacedName{Namespace: "default", Name: "demo-ds"}, &updated); err != nil {
+		t.Fatalf("get updated daemonset: %v", err)
+	}
+	if got := updated.Spec.Template.Spec.Containers[0].Image; got != "fluentd:1.14" {
+		t.Fatalf("expected rollback to revision 1's image fluentd:1.14, got %s", got)
+	}
+	if got := updated.Annotations[deploymentChangeCauseAnnotation]; got != "manual rollback" {
+		t.Fatalf("expected custom change-cause to be preserved, got %s", got)
+	}
+}
+
+func TestDaemonSetHandlerRollback_NotFound(t *testing.T) {
+	setupDeploymentHandlerTestDB(t)
+
+	cs := newDeploymentHandlerTestClientSet(t)
+	router := newDaemonSetHandlerTestRouter(t, cs)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPut, "/daemonsets/default/missing/rollback", strings.NewReader("{}"))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestDaemonSetHandlerRollback_RevisionNotFound(t *testing.T) {
+	setupDeploymentHandlerTestDB(t)
+
+	ds := makeTestDaemonSet()
+	cr1 := makeTestControllerRevision(t, "demo-ds-cr1", 1, "", "fluentd:1.14", daemonSetTestUID, "DaemonSet")
+	cr2 := makeTestControllerRevision(t, "demo-ds-cr2", 2, "", "fluentd:1.15", daemonSetTestUID, "DaemonSet")
+
+	cs := newDeploymentHandlerTestClientSet(t, ds, cr1, cr2)
+	router := newDaemonSetHandlerTestRouter(t, cs)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPut, "/daemonsets/default/demo-ds/rollback", strings.NewReader(`{"revision":99}`))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestDaemonSetHandlerRollback_NoHistory(t *testing.T) {
+	setupDeploymentHandlerTestDB(t)
+
+	ds := makeTestDaemonSet()
+	cs := newDeploymentHandlerTestClientSet(t, ds)
+	router := newDaemonSetHandlerTestRouter(t, cs)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPut, "/daemonsets/default/demo-ds/rollback", strings.NewReader("{}"))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+}

--- a/pkg/resources/daemonset_handler_test.go
+++ b/pkg/resources/daemonset_handler_test.go
@@ -96,65 +96,59 @@ func TestDaemonSetHandlerRevisions_NotFound(t *testing.T) {
 	}
 }
 
-func TestDaemonSetHandlerRollback_DefaultsToPreviousRevision(t *testing.T) {
-	setupDeploymentHandlerTestDB(t)
-
-	ds := makeTestDaemonSet()
-	cr1 := makeTestControllerRevision(t, "demo-ds-cr1", 1, "initial deploy", "fluentd:1.14", daemonSetTestUID, "DaemonSet")
-	cr2 := makeTestControllerRevision(t, "demo-ds-cr2", 2, "bump to 1.15", "fluentd:1.15", daemonSetTestUID, "DaemonSet")
-
-	cs := newDeploymentHandlerTestClientSet(t, ds, cr1, cr2)
-	router := newDaemonSetHandlerTestRouter(t, cs)
-
-	rec := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPut, "/daemonsets/default/demo-ds/rollback", strings.NewReader("{}"))
-	req.Header.Set("Content-Type", "application/json")
-	router.ServeHTTP(rec, req)
-
-	if rec.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+// TestDaemonSetHandlerRollback_Revision covers both the default (no
+// explicit revision, "{}") and explicit-revision rollback request shapes,
+// which share identical scaffolding and only differ in the request body and
+// the resulting change-cause annotation.
+func TestDaemonSetHandlerRollback_Revision(t *testing.T) {
+	tests := []struct {
+		name            string
+		body            string
+		wantChangeCause string
+	}{
+		{
+			name:            "defaults to the previous revision",
+			body:            "{}",
+			wantChangeCause: "Rolled back to revision 1 via Kite",
+		},
+		{
+			name:            "explicit revision with custom change cause",
+			body:            `{"revision":1,"changeCause":"manual rollback"}`,
+			wantChangeCause: "manual rollback",
+		},
 	}
 
-	var updated appsv1.DaemonSet
-	if err := cs.K8sClient.Get(t.Context(), types.NamespacedName{Namespace: "default", Name: "demo-ds"}, &updated); err != nil {
-		t.Fatalf("get updated daemonset: %v", err)
-	}
-	if got := updated.Spec.Template.Spec.Containers[0].Image; got != "fluentd:1.14" {
-		t.Fatalf("expected rollback to revision 1's image fluentd:1.14, got %s", got)
-	}
-	if got := updated.Annotations[deploymentChangeCauseAnnotation]; got != "Rolled back to revision 1 via Kite" {
-		t.Fatalf("unexpected change-cause annotation: %s", got)
-	}
-}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setupDeploymentHandlerTestDB(t)
 
-func TestDaemonSetHandlerRollback_ExplicitRevision(t *testing.T) {
-	setupDeploymentHandlerTestDB(t)
+			ds := makeTestDaemonSet()
+			cr1 := makeTestControllerRevision(t, "demo-ds-cr1", 1, "initial deploy", "fluentd:1.14", daemonSetTestUID, "DaemonSet")
+			cr2 := makeTestControllerRevision(t, "demo-ds-cr2", 2, "bump to 1.15", "fluentd:1.15", daemonSetTestUID, "DaemonSet")
 
-	ds := makeTestDaemonSet()
-	cr1 := makeTestControllerRevision(t, "demo-ds-cr1", 1, "initial deploy", "fluentd:1.14", daemonSetTestUID, "DaemonSet")
-	cr2 := makeTestControllerRevision(t, "demo-ds-cr2", 2, "bump to 1.15", "fluentd:1.15", daemonSetTestUID, "DaemonSet")
+			cs := newDeploymentHandlerTestClientSet(t, ds, cr1, cr2)
+			router := newDaemonSetHandlerTestRouter(t, cs)
 
-	cs := newDeploymentHandlerTestClientSet(t, ds, cr1, cr2)
-	router := newDaemonSetHandlerTestRouter(t, cs)
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodPut, "/daemonsets/default/demo-ds/rollback", strings.NewReader(tt.body))
+			req.Header.Set("Content-Type", "application/json")
+			router.ServeHTTP(rec, req)
 
-	rec := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPut, "/daemonsets/default/demo-ds/rollback", strings.NewReader(`{"revision":1,"changeCause":"manual rollback"}`))
-	req.Header.Set("Content-Type", "application/json")
-	router.ServeHTTP(rec, req)
+			if rec.Code != http.StatusOK {
+				t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+			}
 
-	if rec.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
-	}
-
-	var updated appsv1.DaemonSet
-	if err := cs.K8sClient.Get(t.Context(), types.NamespacedName{Namespace: "default", Name: "demo-ds"}, &updated); err != nil {
-		t.Fatalf("get updated daemonset: %v", err)
-	}
-	if got := updated.Spec.Template.Spec.Containers[0].Image; got != "fluentd:1.14" {
-		t.Fatalf("expected rollback to revision 1's image fluentd:1.14, got %s", got)
-	}
-	if got := updated.Annotations[deploymentChangeCauseAnnotation]; got != "manual rollback" {
-		t.Fatalf("expected custom change-cause to be preserved, got %s", got)
+			var updated appsv1.DaemonSet
+			if err := cs.K8sClient.Get(t.Context(), types.NamespacedName{Namespace: "default", Name: "demo-ds"}, &updated); err != nil {
+				t.Fatalf("get updated daemonset: %v", err)
+			}
+			if got := updated.Spec.Template.Spec.Containers[0].Image; got != "fluentd:1.14" {
+				t.Fatalf("expected rollback to revision 1's image fluentd:1.14, got %s", got)
+			}
+			if got := updated.Annotations[deploymentChangeCauseAnnotation]; got != tt.wantChangeCause {
+				t.Fatalf("expected change-cause %q, got %q", tt.wantChangeCause, got)
+			}
+		})
 	}
 }
 

--- a/pkg/resources/daemonset_handler_test.go
+++ b/pkg/resources/daemonset_handler_test.go
@@ -50,13 +50,13 @@ func newDaemonSetHandlerTestRouter(t *testing.T, cs *cluster.ClientSet) *gin.Eng
 }
 
 func TestDaemonSetHandlerRevisions_CurrentIsHighestRevision(t *testing.T) {
-	setupDeploymentHandlerTestDB(t)
+	setupWorkloadHandlerTestDB(t)
 
 	ds := makeTestDaemonSet()
 	cr1 := makeTestControllerRevision(t, "demo-ds-cr1", 1, "initial deploy", "fluentd:1.14", daemonSetTestUID, "DaemonSet")
 	cr2 := makeTestControllerRevision(t, "demo-ds-cr2", 2, "bump to 1.15", "fluentd:1.15", daemonSetTestUID, "DaemonSet")
 
-	cs := newDeploymentHandlerTestClientSet(t, ds, cr1, cr2)
+	cs := newWorkloadHandlerTestClientSet(t, ds, cr1, cr2)
 	router := newDaemonSetHandlerTestRouter(t, cs)
 
 	rec := httptest.NewRecorder()
@@ -82,9 +82,9 @@ func TestDaemonSetHandlerRevisions_CurrentIsHighestRevision(t *testing.T) {
 }
 
 func TestDaemonSetHandlerRevisions_NotFound(t *testing.T) {
-	setupDeploymentHandlerTestDB(t)
+	setupWorkloadHandlerTestDB(t)
 
-	cs := newDeploymentHandlerTestClientSet(t)
+	cs := newWorkloadHandlerTestClientSet(t)
 	router := newDaemonSetHandlerTestRouter(t, cs)
 
 	rec := httptest.NewRecorder()
@@ -97,36 +97,31 @@ func TestDaemonSetHandlerRevisions_NotFound(t *testing.T) {
 }
 
 // TestDaemonSetHandlerRollback_Revision covers both the default (no
-// explicit revision, "{}") and explicit-revision rollback request shapes,
-// which share identical scaffolding and only differ in the request body and
-// the resulting change-cause annotation.
+// explicit revision, "{}") and explicit-revision rollback request shapes.
 func TestDaemonSetHandlerRollback_Revision(t *testing.T) {
 	tests := []struct {
-		name            string
-		body            string
-		wantChangeCause string
+		name string
+		body string
 	}{
 		{
-			name:            "defaults to the previous revision",
-			body:            "{}",
-			wantChangeCause: "Rolled back to revision 1 via Kite",
+			name: "defaults to the previous revision",
+			body: "{}",
 		},
 		{
-			name:            "explicit revision with custom change cause",
-			body:            `{"revision":1,"changeCause":"manual rollback"}`,
-			wantChangeCause: "manual rollback",
+			name: "uses the explicit revision",
+			body: `{"revision":1}`,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			setupDeploymentHandlerTestDB(t)
+			setupWorkloadHandlerTestDB(t)
 
 			ds := makeTestDaemonSet()
 			cr1 := makeTestControllerRevision(t, "demo-ds-cr1", 1, "initial deploy", "fluentd:1.14", daemonSetTestUID, "DaemonSet")
 			cr2 := makeTestControllerRevision(t, "demo-ds-cr2", 2, "bump to 1.15", "fluentd:1.15", daemonSetTestUID, "DaemonSet")
 
-			cs := newDeploymentHandlerTestClientSet(t, ds, cr1, cr2)
+			cs := newWorkloadHandlerTestClientSet(t, ds, cr1, cr2)
 			router := newDaemonSetHandlerTestRouter(t, cs)
 
 			rec := httptest.NewRecorder()
@@ -145,17 +140,14 @@ func TestDaemonSetHandlerRollback_Revision(t *testing.T) {
 			if got := updated.Spec.Template.Spec.Containers[0].Image; got != "fluentd:1.14" {
 				t.Fatalf("expected rollback to revision 1's image fluentd:1.14, got %s", got)
 			}
-			if got := updated.Annotations[deploymentChangeCauseAnnotation]; got != tt.wantChangeCause {
-				t.Fatalf("expected change-cause %q, got %q", tt.wantChangeCause, got)
-			}
 		})
 	}
 }
 
 func TestDaemonSetHandlerRollback_NotFound(t *testing.T) {
-	setupDeploymentHandlerTestDB(t)
+	setupWorkloadHandlerTestDB(t)
 
-	cs := newDeploymentHandlerTestClientSet(t)
+	cs := newWorkloadHandlerTestClientSet(t)
 	router := newDaemonSetHandlerTestRouter(t, cs)
 
 	rec := httptest.NewRecorder()
@@ -169,13 +161,13 @@ func TestDaemonSetHandlerRollback_NotFound(t *testing.T) {
 }
 
 func TestDaemonSetHandlerRollback_RevisionNotFound(t *testing.T) {
-	setupDeploymentHandlerTestDB(t)
+	setupWorkloadHandlerTestDB(t)
 
 	ds := makeTestDaemonSet()
 	cr1 := makeTestControllerRevision(t, "demo-ds-cr1", 1, "", "fluentd:1.14", daemonSetTestUID, "DaemonSet")
 	cr2 := makeTestControllerRevision(t, "demo-ds-cr2", 2, "", "fluentd:1.15", daemonSetTestUID, "DaemonSet")
 
-	cs := newDeploymentHandlerTestClientSet(t, ds, cr1, cr2)
+	cs := newWorkloadHandlerTestClientSet(t, ds, cr1, cr2)
 	router := newDaemonSetHandlerTestRouter(t, cs)
 
 	rec := httptest.NewRecorder()
@@ -189,10 +181,10 @@ func TestDaemonSetHandlerRollback_RevisionNotFound(t *testing.T) {
 }
 
 func TestDaemonSetHandlerRollback_NoHistory(t *testing.T) {
-	setupDeploymentHandlerTestDB(t)
+	setupWorkloadHandlerTestDB(t)
 
 	ds := makeTestDaemonSet()
-	cs := newDeploymentHandlerTestClientSet(t, ds)
+	cs := newWorkloadHandlerTestClientSet(t, ds)
 	router := newDaemonSetHandlerTestRouter(t, cs)
 
 	rec := httptest.NewRecorder()

--- a/pkg/resources/daemonset_handler_test.go
+++ b/pkg/resources/daemonset_handler_test.go
@@ -138,8 +138,8 @@ func TestDaemonSetHandlerRollback_Revision(t *testing.T) {
 				t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
 			}
 
-			var updated appsv1.DaemonSet
-			if err := cs.K8sClient.Get(t.Context(), types.NamespacedName{Namespace: "default", Name: "demo-ds"}, &updated); err != nil {
+			updated, err := cs.K8sClient.ClientSet.AppsV1().DaemonSets("default").Get(t.Context(), "demo-ds", metav1.GetOptions{})
+			if err != nil {
 				t.Fatalf("get updated daemonset: %v", err)
 			}
 			if got := updated.Spec.Template.Spec.Containers[0].Image; got != "fluentd:1.14" {

--- a/pkg/resources/deployment_handler.go
+++ b/pkg/resources/deployment_handler.go
@@ -2,28 +2,21 @@ package resources
 
 import (
 	"context"
-	"errors"
-	"fmt"
-	"io"
 	"net/http"
 	"sort"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/zxh326/kite/pkg/cluster"
 	"github.com/zxh326/kite/pkg/common"
 	appsv1 "k8s.io/api/apps/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-const (
-	deploymentRevisionAnnotation    = "deployment.kubernetes.io/revision"
-	deploymentChangeCauseAnnotation = "kubernetes.io/change-cause"
-)
+const deploymentRevisionAnnotation = "deployment.kubernetes.io/revision"
 
 type DeploymentHandler struct {
 	*GenericResourceHandler[*appsv1.Deployment, *appsv1.DeploymentList]
@@ -48,19 +41,14 @@ func (h *DeploymentHandler) Restart(c *gin.Context, namespace, name string) erro
 	return cs.K8sClient.Update(c.Request.Context(), &deployment)
 }
 
-func (h *DeploymentHandler) registerCustomRoutes(group *gin.RouterGroup) {
-	group.GET("/:namespace/:name/revisions", h.Revisions)
-	group.PUT("/:namespace/:name/rollback", h.Rollback)
-}
-
 func (h *DeploymentHandler) Revisions(c *gin.Context) {
 	namespace, name := c.Param("namespace"), c.Param("name")
 	cs := c.MustGet("cluster").(*cluster.ClientSet)
 	ctx := c.Request.Context()
 
-	var deployment appsv1.Deployment
-	if err := cs.K8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, &deployment); err != nil {
-		if client.IgnoreNotFound(err) == nil {
+	deployment, err := cs.K8sClient.ClientSet.AppsV1().Deployments(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
 			c.JSON(http.StatusNotFound, gin.H{"error": "not found"})
 			return
 		}
@@ -68,13 +56,13 @@ func (h *DeploymentHandler) Revisions(c *gin.Context) {
 		return
 	}
 
-	replicaSets, err := listDeploymentReplicaSets(ctx, cs, &deployment)
+	replicaSets, err := listDeploymentReplicaSets(ctx, cs, deployment)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
 
-	currentIndex := deploymentCurrentRevisionIndex(&deployment, replicaSets)
+	currentIndex := deploymentCurrentRevisionIndex(deployment, replicaSets)
 
 	items := make([]WorkloadRevisionItem, 0, len(replicaSets))
 	for i, rs := range replicaSets {
@@ -87,7 +75,7 @@ func (h *DeploymentHandler) Revisions(c *gin.Context) {
 		items = append(items, WorkloadRevisionItem{
 			Revision:       deploymentRevisionOf(rs),
 			RevisionObject: rs.Name,
-			ChangeCause:    rs.Annotations[deploymentChangeCauseAnnotation],
+			ChangeCause:    rs.Annotations[changeCauseAnnotation],
 			Images:         images,
 			Replicas:       &replicas,
 			CreatedAt:      rs.CreationTimestamp,
@@ -97,110 +85,14 @@ func (h *DeploymentHandler) Revisions(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"items": items})
 }
 
-func (h *DeploymentHandler) Rollback(c *gin.Context) {
-	namespace, name := c.Param("namespace"), c.Param("name")
-	cs := c.MustGet("cluster").(*cluster.ClientSet)
-	ctx := c.Request.Context()
-
-	var req workloadRollbackRequest
-	if err := c.ShouldBindJSON(&req); err != nil && !errors.Is(err, io.EOF) {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
-		return
-	}
-
-	var deployment appsv1.Deployment
-	if err := cs.K8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, &deployment); err != nil {
-		if client.IgnoreNotFound(err) == nil {
-			c.JSON(http.StatusNotFound, gin.H{"error": "not found"})
-			return
-		}
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-		return
-	}
-	oldDeployment := deployment.DeepCopy()
-
-	replicaSets, err := listDeploymentReplicaSets(ctx, cs, &deployment)
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-		return
-	}
-	if len(replicaSets) == 0 {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "no revision history found for this deployment"})
-		return
-	}
-
-	targetRevision := req.Revision
-	if targetRevision == 0 {
-		currentIndex := deploymentCurrentRevisionIndex(&deployment, replicaSets)
-		if currentIndex < 0 || currentIndex+1 >= len(replicaSets) {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "no previous revision found"})
-			return
-		}
-		targetRevision = deploymentRevisionOf(replicaSets[currentIndex+1])
-	}
-
-	found := false
-	for _, rs := range replicaSets {
-		if deploymentRevisionOf(rs) == targetRevision {
-			found = true
-			break
-		}
-	}
-	if !found {
-		c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("revision %d not found", targetRevision)})
-		return
-	}
-
-	var success bool
-	var errMsg string
-	defer func() {
-		h.recordHistory(c, "rollback", oldDeployment, &deployment, success, errMsg)
-	}()
-
-	if err := rollbackWorkload(cs, deploymentGroupKind, &deployment, targetRevision); err != nil {
-		errMsg = err.Error()
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-		return
-	}
-
-	// Re-fetch and annotate through the same typed clientset kubectl's
-	// Rollbacker just wrote through (rather than controller-runtime's
-	// client), so this read is guaranteed to see the rollback it just
-	// applied.
-	updated, err := cs.K8sClient.ClientSet.AppsV1().Deployments(namespace).Get(ctx, name, metav1.GetOptions{})
-	if err != nil {
-		errMsg = err.Error()
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-		return
-	}
-	if updated.Annotations == nil {
-		updated.Annotations = make(map[string]string)
-	}
-	changeCause := strings.TrimSpace(req.ChangeCause)
-	if changeCause == "" {
-		changeCause = fmt.Sprintf("Rolled back to revision %d via Kite", targetRevision)
-	}
-	updated.Annotations[deploymentChangeCauseAnnotation] = changeCause
-	updated, err = cs.K8sClient.ClientSet.AppsV1().Deployments(namespace).Update(ctx, updated, metav1.UpdateOptions{})
-	if err != nil {
-		errMsg = err.Error()
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-		return
-	}
-	deployment = *updated
-
-	success = true
-	c.JSON(http.StatusOK, gin.H{"message": "deployment rolled back", "revision": targetRevision})
-}
-
 func listDeploymentReplicaSets(ctx context.Context, cs *cluster.ClientSet, deployment *appsv1.Deployment) ([]*appsv1.ReplicaSet, error) {
 	selector, err := metav1.LabelSelectorAsSelector(deployment.Spec.Selector)
 	if err != nil {
 		return nil, err
 	}
 
-	var rsList appsv1.ReplicaSetList
-	if err := cs.K8sClient.List(ctx, &rsList, client.InNamespace(deployment.Namespace), client.MatchingLabelsSelector{Selector: selector}); err != nil {
+	rsList, err := cs.K8sClient.ClientSet.AppsV1().ReplicaSets(deployment.Namespace).List(ctx, metav1.ListOptions{LabelSelector: selector.String()})
+	if err != nil {
 		return nil, err
 	}
 
@@ -237,11 +129,6 @@ func deploymentRevisionOf(rs *appsv1.ReplicaSet) int64 {
 	return v
 }
 
-// deploymentCurrentRevisionIndex resolves which entry in replicaSets (sorted
-// by descending revision) is the Deployment's current revision, using the
-// Deployment's own deployment.kubernetes.io/revision annotation as the
-// source of truth. It falls back to the highest revision (index 0) when the
-// annotation is missing or doesn't match any ReplicaSet in the list.
 func deploymentCurrentRevisionIndex(deployment *appsv1.Deployment, replicaSets []*appsv1.ReplicaSet) int {
 	if deployment.Annotations != nil {
 		if v, err := strconv.ParseInt(deployment.Annotations[deploymentRevisionAnnotation], 10, 64); err == nil {

--- a/pkg/resources/deployment_handler.go
+++ b/pkg/resources/deployment_handler.go
@@ -84,12 +84,7 @@ func (h *DeploymentHandler) Revisions(c *gin.Context) {
 		return
 	}
 
-	currentRevision := int64(0)
-	if deployment.Annotations != nil {
-		if v, err := strconv.ParseInt(deployment.Annotations[deploymentRevisionAnnotation], 10, 64); err == nil {
-			currentRevision = v
-		}
-	}
+	_, currentIndex := deploymentCurrentRevision(&deployment, replicaSets)
 
 	items := make([]deploymentRevisionItem, 0, len(replicaSets))
 	for i, rs := range replicaSets {
@@ -97,17 +92,15 @@ func (h *DeploymentHandler) Revisions(c *gin.Context) {
 		for _, container := range rs.Spec.Template.Spec.Containers {
 			images = append(images, container.Image)
 		}
-		rsRevision := deploymentRevisionOf(rs)
-		isCurrent := rsRevision == currentRevision || (currentRevision == 0 && i == 0)
 
 		items = append(items, deploymentRevisionItem{
-			Revision:    rsRevision,
+			Revision:    deploymentRevisionOf(rs),
 			ReplicaSet:  rs.Name,
 			ChangeCause: rs.Annotations[deploymentChangeCauseAnnotation],
 			Images:      images,
 			Replicas:    rs.Status.Replicas,
 			CreatedAt:   rs.CreationTimestamp,
-			Current:     isCurrent,
+			Current:     i == currentIndex,
 		})
 	}
 	c.JSON(http.StatusOK, gin.H{"items": items})
@@ -131,6 +124,10 @@ func (h *DeploymentHandler) Rollback(c *gin.Context) {
 
 	var deployment appsv1.Deployment
 	if err := cs.K8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, &deployment); err != nil {
+		if client.IgnoreNotFound(err) == nil {
+			c.JSON(http.StatusNotFound, gin.H{"error": "not found"})
+			return
+		}
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
@@ -148,11 +145,12 @@ func (h *DeploymentHandler) Rollback(c *gin.Context) {
 
 	targetRevision := req.Revision
 	if targetRevision == 0 {
-		if len(replicaSets) < 2 {
+		_, currentIndex := deploymentCurrentRevision(&deployment, replicaSets)
+		if currentIndex < 0 || currentIndex+1 >= len(replicaSets) {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "no previous revision found"})
 			return
 		}
-		targetRevision = deploymentRevisionOf(replicaSets[1])
+		targetRevision = deploymentRevisionOf(replicaSets[currentIndex+1])
 	}
 
 	var target *appsv1.ReplicaSet
@@ -227,4 +225,27 @@ func listDeploymentReplicaSets(ctx context.Context, cs *cluster.ClientSet, deplo
 func deploymentRevisionOf(rs *appsv1.ReplicaSet) int64 {
 	v, _ := strconv.ParseInt(rs.Annotations[deploymentRevisionAnnotation], 10, 64)
 	return v
+}
+
+// deploymentCurrentRevision resolves which entry in replicaSets (sorted by
+// descending revision) is the Deployment's current revision, using the
+// Deployment's own deployment.kubernetes.io/revision annotation as the
+// source of truth. It falls back to the highest revision (index 0) when the
+// annotation is missing or doesn't match any ReplicaSet in the list.
+func deploymentCurrentRevision(deployment *appsv1.Deployment, replicaSets []*appsv1.ReplicaSet) (revision int64, index int) {
+	index = -1
+	if deployment.Annotations != nil {
+		if v, err := strconv.ParseInt(deployment.Annotations[deploymentRevisionAnnotation], 10, 64); err == nil {
+			for i, rs := range replicaSets {
+				if deploymentRevisionOf(rs) == v {
+					revision, index = v, i
+					break
+				}
+			}
+		}
+	}
+	if index == -1 && len(replicaSets) > 0 {
+		revision, index = deploymentRevisionOf(replicaSets[0]), 0
+	}
+	return revision, index
 }

--- a/pkg/resources/deployment_handler.go
+++ b/pkg/resources/deployment_handler.go
@@ -139,14 +139,14 @@ func (h *DeploymentHandler) Rollback(c *gin.Context) {
 		targetRevision = deploymentRevisionOf(replicaSets[currentIndex+1])
 	}
 
-	var target *appsv1.ReplicaSet
+	found := false
 	for _, rs := range replicaSets {
 		if deploymentRevisionOf(rs) == targetRevision {
-			target = rs
+			found = true
 			break
 		}
 	}
-	if target == nil {
+	if !found {
 		c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("revision %d not found", targetRevision)})
 		return
 	}
@@ -157,24 +157,38 @@ func (h *DeploymentHandler) Rollback(c *gin.Context) {
 		h.recordHistory(c, "rollback", oldDeployment, &deployment, success, errMsg)
 	}()
 
-	template := target.Spec.Template.DeepCopy()
-	delete(template.Labels, appsv1.DefaultDeploymentUniqueLabelKey)
-	deployment.Spec.Template = *template
+	if err := rollbackWorkload(cs, deploymentGroupKind, &deployment, targetRevision); err != nil {
+		errMsg = err.Error()
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
 
-	if deployment.Annotations == nil {
-		deployment.Annotations = make(map[string]string)
+	// Re-fetch and annotate through the same typed clientset kubectl's
+	// Rollbacker just wrote through (rather than controller-runtime's
+	// client), so this read is guaranteed to see the rollback it just
+	// applied.
+	updated, err := cs.K8sClient.ClientSet.AppsV1().Deployments(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		errMsg = err.Error()
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	if updated.Annotations == nil {
+		updated.Annotations = make(map[string]string)
 	}
 	changeCause := strings.TrimSpace(req.ChangeCause)
 	if changeCause == "" {
 		changeCause = fmt.Sprintf("Rolled back to revision %d via Kite", targetRevision)
 	}
-	deployment.Annotations[deploymentChangeCauseAnnotation] = changeCause
-
-	if err := cs.K8sClient.Update(ctx, &deployment); err != nil {
+	updated.Annotations[deploymentChangeCauseAnnotation] = changeCause
+	updated, err = cs.K8sClient.ClientSet.AppsV1().Deployments(namespace).Update(ctx, updated, metav1.UpdateOptions{})
+	if err != nil {
 		errMsg = err.Error()
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
+	deployment = *updated
+
 	success = true
 	c.JSON(http.StatusOK, gin.H{"message": "deployment rolled back", "revision": targetRevision})
 }

--- a/pkg/resources/deployment_handler.go
+++ b/pkg/resources/deployment_handler.go
@@ -1,13 +1,28 @@
 package resources
 
 import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/zxh326/kite/pkg/cluster"
 	"github.com/zxh326/kite/pkg/common"
 	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	deploymentRevisionAnnotation    = "deployment.kubernetes.io/revision"
+	deploymentChangeCauseAnnotation = "kubernetes.io/change-cause"
 )
 
 type DeploymentHandler struct {
@@ -31,4 +46,171 @@ func (h *DeploymentHandler) Restart(c *gin.Context, namespace, name string) erro
 	}
 	deployment.Spec.Template.Annotations["kite.kubernetes.io/restartedAt"] = time.Now().Format(time.RFC3339)
 	return cs.K8sClient.Update(c.Request.Context(), &deployment)
+}
+
+func (h *DeploymentHandler) registerCustomRoutes(group *gin.RouterGroup) {
+	group.GET("/:namespace/:name/revisions", h.Revisions)
+	group.PUT("/:namespace/:name/rollback", h.Rollback)
+}
+
+type deploymentRevisionItem struct {
+	Revision    int64       `json:"revision"`
+	ReplicaSet  string      `json:"replicaSet"`
+	ChangeCause string      `json:"changeCause,omitempty"`
+	Images      []string    `json:"images"`
+	Replicas    int32       `json:"replicas"`
+	CreatedAt   metav1.Time `json:"createdAt"`
+	Current     bool        `json:"current"`
+}
+
+func (h *DeploymentHandler) Revisions(c *gin.Context) {
+	namespace, name := c.Param("namespace"), c.Param("name")
+	cs := c.MustGet("cluster").(*cluster.ClientSet)
+	ctx := c.Request.Context()
+
+	var deployment appsv1.Deployment
+	if err := cs.K8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, &deployment); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	replicaSets, err := listDeploymentReplicaSets(ctx, cs, &deployment)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	items := make([]deploymentRevisionItem, 0, len(replicaSets))
+	for i, rs := range replicaSets {
+		images := make([]string, 0, len(rs.Spec.Template.Spec.Containers))
+		for _, container := range rs.Spec.Template.Spec.Containers {
+			images = append(images, container.Image)
+		}
+		items = append(items, deploymentRevisionItem{
+			Revision:    deploymentRevisionOf(rs),
+			ReplicaSet:  rs.Name,
+			ChangeCause: rs.Annotations[deploymentChangeCauseAnnotation],
+			Images:      images,
+			Replicas:    rs.Status.Replicas,
+			CreatedAt:   rs.CreationTimestamp,
+			Current:     i == 0,
+		})
+	}
+	c.JSON(http.StatusOK, gin.H{"items": items})
+}
+
+type deploymentRollbackRequest struct {
+	Revision    int64  `json:"revision"`
+	ChangeCause string `json:"changeCause"`
+}
+
+func (h *DeploymentHandler) Rollback(c *gin.Context) {
+	namespace, name := c.Param("namespace"), c.Param("name")
+	cs := c.MustGet("cluster").(*cluster.ClientSet)
+	ctx := c.Request.Context()
+
+	var req deploymentRollbackRequest
+	if err := c.ShouldBindJSON(&req); err != nil && !errors.Is(err, io.EOF) {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	var deployment appsv1.Deployment
+	if err := cs.K8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, &deployment); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	oldDeployment := deployment.DeepCopy()
+
+	replicaSets, err := listDeploymentReplicaSets(ctx, cs, &deployment)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	if len(replicaSets) == 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "no revision history found for this deployment"})
+		return
+	}
+
+	targetRevision := req.Revision
+	if targetRevision == 0 {
+		if len(replicaSets) < 2 {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "no previous revision found"})
+			return
+		}
+		targetRevision = deploymentRevisionOf(replicaSets[1])
+	}
+
+	var target *appsv1.ReplicaSet
+	for _, rs := range replicaSets {
+		if deploymentRevisionOf(rs) == targetRevision {
+			target = rs
+			break
+		}
+	}
+	if target == nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("revision %d not found", targetRevision)})
+		return
+	}
+
+	var success bool
+	var errMsg string
+	defer func() {
+		h.recordHistory(c, "rollback", oldDeployment, &deployment, success, errMsg)
+	}()
+
+	template := target.Spec.Template.DeepCopy()
+	delete(template.Labels, appsv1.DefaultDeploymentUniqueLabelKey)
+	deployment.Spec.Template = *template
+
+	if deployment.Annotations == nil {
+		deployment.Annotations = make(map[string]string)
+	}
+	changeCause := strings.TrimSpace(req.ChangeCause)
+	if changeCause == "" {
+		changeCause = fmt.Sprintf("Rolled back to revision %d via Kite", targetRevision)
+	}
+	deployment.Annotations[deploymentChangeCauseAnnotation] = changeCause
+
+	if err := cs.K8sClient.Update(ctx, &deployment); err != nil {
+		errMsg = err.Error()
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	success = true
+	c.JSON(http.StatusOK, gin.H{"message": "deployment rolled back", "revision": targetRevision})
+}
+
+func listDeploymentReplicaSets(ctx context.Context, cs *cluster.ClientSet, deployment *appsv1.Deployment) ([]*appsv1.ReplicaSet, error) {
+	selector, err := metav1.LabelSelectorAsSelector(deployment.Spec.Selector)
+	if err != nil {
+		return nil, err
+	}
+
+	var rsList appsv1.ReplicaSetList
+	if err := cs.K8sClient.List(ctx, &rsList, client.InNamespace(deployment.Namespace), client.MatchingLabelsSelector{Selector: selector}); err != nil {
+		return nil, err
+	}
+
+	owned := make([]*appsv1.ReplicaSet, 0, len(rsList.Items))
+	for i := range rsList.Items {
+		rs := &rsList.Items[i]
+		owner := metav1.GetControllerOf(rs)
+		if owner == nil || owner.UID != deployment.UID {
+			continue
+		}
+		if _, ok := rs.Annotations[deploymentRevisionAnnotation]; !ok {
+			continue
+		}
+		owned = append(owned, rs)
+	}
+	sort.Slice(owned, func(i, j int) bool {
+		return deploymentRevisionOf(owned[i]) > deploymentRevisionOf(owned[j])
+	})
+	return owned, nil
+}
+
+func deploymentRevisionOf(rs *appsv1.ReplicaSet) int64 {
+	v, _ := strconv.ParseInt(rs.Annotations[deploymentRevisionAnnotation], 10, 64)
+	return v
 }

--- a/pkg/resources/deployment_handler.go
+++ b/pkg/resources/deployment_handler.go
@@ -53,16 +53,6 @@ func (h *DeploymentHandler) registerCustomRoutes(group *gin.RouterGroup) {
 	group.PUT("/:namespace/:name/rollback", h.Rollback)
 }
 
-type deploymentRevisionItem struct {
-	Revision    int64       `json:"revision"`
-	ReplicaSet  string      `json:"replicaSet"`
-	ChangeCause string      `json:"changeCause,omitempty"`
-	Images      []string    `json:"images"`
-	Replicas    int32       `json:"replicas"`
-	CreatedAt   metav1.Time `json:"createdAt"`
-	Current     bool        `json:"current"`
-}
-
 func (h *DeploymentHandler) Revisions(c *gin.Context) {
 	namespace, name := c.Param("namespace"), c.Param("name")
 	cs := c.MustGet("cluster").(*cluster.ClientSet)
@@ -86,29 +76,25 @@ func (h *DeploymentHandler) Revisions(c *gin.Context) {
 
 	_, currentIndex := deploymentCurrentRevision(&deployment, replicaSets)
 
-	items := make([]deploymentRevisionItem, 0, len(replicaSets))
+	items := make([]WorkloadRevisionItem, 0, len(replicaSets))
 	for i, rs := range replicaSets {
 		images := make([]string, 0, len(rs.Spec.Template.Spec.Containers))
 		for _, container := range rs.Spec.Template.Spec.Containers {
 			images = append(images, container.Image)
 		}
+		replicas := rs.Status.Replicas
 
-		items = append(items, deploymentRevisionItem{
-			Revision:    deploymentRevisionOf(rs),
-			ReplicaSet:  rs.Name,
-			ChangeCause: rs.Annotations[deploymentChangeCauseAnnotation],
-			Images:      images,
-			Replicas:    rs.Status.Replicas,
-			CreatedAt:   rs.CreationTimestamp,
-			Current:     i == currentIndex,
+		items = append(items, WorkloadRevisionItem{
+			Revision:       deploymentRevisionOf(rs),
+			RevisionObject: rs.Name,
+			ChangeCause:    rs.Annotations[deploymentChangeCauseAnnotation],
+			Images:         images,
+			Replicas:       &replicas,
+			CreatedAt:      rs.CreationTimestamp,
+			Current:        i == currentIndex,
 		})
 	}
 	c.JSON(http.StatusOK, gin.H{"items": items})
-}
-
-type deploymentRollbackRequest struct {
-	Revision    int64  `json:"revision"`
-	ChangeCause string `json:"changeCause"`
 }
 
 func (h *DeploymentHandler) Rollback(c *gin.Context) {
@@ -116,7 +102,7 @@ func (h *DeploymentHandler) Rollback(c *gin.Context) {
 	cs := c.MustGet("cluster").(*cluster.ClientSet)
 	ctx := c.Request.Context()
 
-	var req deploymentRollbackRequest
+	var req workloadRollbackRequest
 	if err := c.ShouldBindJSON(&req); err != nil && !errors.Is(err, io.EOF) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return

--- a/pkg/resources/deployment_handler.go
+++ b/pkg/resources/deployment_handler.go
@@ -70,6 +70,10 @@ func (h *DeploymentHandler) Revisions(c *gin.Context) {
 
 	var deployment appsv1.Deployment
 	if err := cs.K8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, &deployment); err != nil {
+		if client.IgnoreNotFound(err) == nil {
+			c.JSON(http.StatusNotFound, gin.H{"error": "not found"})
+			return
+		}
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}

--- a/pkg/resources/deployment_handler.go
+++ b/pkg/resources/deployment_handler.go
@@ -74,7 +74,7 @@ func (h *DeploymentHandler) Revisions(c *gin.Context) {
 		return
 	}
 
-	_, currentIndex := deploymentCurrentRevision(&deployment, replicaSets)
+	currentIndex := deploymentCurrentRevisionIndex(&deployment, replicaSets)
 
 	items := make([]WorkloadRevisionItem, 0, len(replicaSets))
 	for i, rs := range replicaSets {
@@ -131,7 +131,7 @@ func (h *DeploymentHandler) Rollback(c *gin.Context) {
 
 	targetRevision := req.Revision
 	if targetRevision == 0 {
-		_, currentIndex := deploymentCurrentRevision(&deployment, replicaSets)
+		currentIndex := deploymentCurrentRevisionIndex(&deployment, replicaSets)
 		if currentIndex < 0 || currentIndex+1 >= len(replicaSets) {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "no previous revision found"})
 			return
@@ -223,25 +223,23 @@ func deploymentRevisionOf(rs *appsv1.ReplicaSet) int64 {
 	return v
 }
 
-// deploymentCurrentRevision resolves which entry in replicaSets (sorted by
-// descending revision) is the Deployment's current revision, using the
+// deploymentCurrentRevisionIndex resolves which entry in replicaSets (sorted
+// by descending revision) is the Deployment's current revision, using the
 // Deployment's own deployment.kubernetes.io/revision annotation as the
 // source of truth. It falls back to the highest revision (index 0) when the
 // annotation is missing or doesn't match any ReplicaSet in the list.
-func deploymentCurrentRevision(deployment *appsv1.Deployment, replicaSets []*appsv1.ReplicaSet) (revision int64, index int) {
-	index = -1
+func deploymentCurrentRevisionIndex(deployment *appsv1.Deployment, replicaSets []*appsv1.ReplicaSet) int {
 	if deployment.Annotations != nil {
 		if v, err := strconv.ParseInt(deployment.Annotations[deploymentRevisionAnnotation], 10, 64); err == nil {
 			for i, rs := range replicaSets {
 				if deploymentRevisionOf(rs) == v {
-					revision, index = v, i
-					break
+					return i
 				}
 			}
 		}
 	}
-	if index == -1 && len(replicaSets) > 0 {
-		revision, index = deploymentRevisionOf(replicaSets[0]), 0
+	if len(replicaSets) > 0 {
+		return 0
 	}
-	return revision, index
+	return -1
 }

--- a/pkg/resources/deployment_handler.go
+++ b/pkg/resources/deployment_handler.go
@@ -211,7 +211,11 @@ func listDeploymentReplicaSets(ctx context.Context, cs *cluster.ClientSet, deplo
 		if owner == nil || owner.UID != deployment.UID {
 			continue
 		}
-		if _, ok := rs.Annotations[deploymentRevisionAnnotation]; !ok {
+		revStr, ok := rs.Annotations[deploymentRevisionAnnotation]
+		if !ok {
+			continue
+		}
+		if _, err := strconv.ParseInt(revStr, 10, 64); err != nil {
 			continue
 		}
 		owned = append(owned, rs)
@@ -223,7 +227,13 @@ func listDeploymentReplicaSets(ctx context.Context, cs *cluster.ClientSet, deplo
 }
 
 func deploymentRevisionOf(rs *appsv1.ReplicaSet) int64 {
-	v, _ := strconv.ParseInt(rs.Annotations[deploymentRevisionAnnotation], 10, 64)
+	if rs.Annotations == nil {
+		return 0
+	}
+	v, err := strconv.ParseInt(rs.Annotations[deploymentRevisionAnnotation], 10, 64)
+	if err != nil {
+		return 0
+	}
 	return v
 }
 

--- a/pkg/resources/deployment_handler.go
+++ b/pkg/resources/deployment_handler.go
@@ -84,20 +84,30 @@ func (h *DeploymentHandler) Revisions(c *gin.Context) {
 		return
 	}
 
+	currentRevision := int64(0)
+	if deployment.Annotations != nil {
+		if v, err := strconv.ParseInt(deployment.Annotations[deploymentRevisionAnnotation], 10, 64); err == nil {
+			currentRevision = v
+		}
+	}
+
 	items := make([]deploymentRevisionItem, 0, len(replicaSets))
 	for i, rs := range replicaSets {
 		images := make([]string, 0, len(rs.Spec.Template.Spec.Containers))
 		for _, container := range rs.Spec.Template.Spec.Containers {
 			images = append(images, container.Image)
 		}
+		rsRevision := deploymentRevisionOf(rs)
+		isCurrent := rsRevision == currentRevision || (currentRevision == 0 && i == 0)
+
 		items = append(items, deploymentRevisionItem{
-			Revision:    deploymentRevisionOf(rs),
+			Revision:    rsRevision,
 			ReplicaSet:  rs.Name,
 			ChangeCause: rs.Annotations[deploymentChangeCauseAnnotation],
 			Images:      images,
 			Replicas:    rs.Status.Replicas,
 			CreatedAt:   rs.CreationTimestamp,
-			Current:     i == 0,
+			Current:     isCurrent,
 		})
 	}
 	c.JSON(http.StatusOK, gin.H{"items": items})

--- a/pkg/resources/deployment_handler_test.go
+++ b/pkg/resources/deployment_handler_test.go
@@ -21,13 +21,11 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	clientgofake "k8s.io/client-go/kubernetes/fake"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 const deploymentTestUID = types.UID("demo-deployment-uid")
 
-func setupDeploymentHandlerTestDB(t *testing.T) {
+func setupWorkloadHandlerTestDB(t *testing.T) {
 	t.Helper()
 	oldDB := model.DB
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{Logger: logger.Default.LogMode(logger.Silent)})
@@ -104,7 +102,7 @@ func makeTestReplicaSet(name string, revision int64, changeCause, image string) 
 		},
 	}
 	if changeCause != "" {
-		rs.Annotations[deploymentChangeCauseAnnotation] = changeCause
+		rs.Annotations[changeCauseAnnotation] = changeCause
 	}
 	return rs
 }
@@ -127,33 +125,12 @@ func newDeploymentHandlerTestRouter(t *testing.T, cs *cluster.ClientSet) *gin.En
 	return router
 }
 
-// newDeploymentHandlerTestClientSet builds a cluster.ClientSet backed by two
-// fakes seeded with the same objects: the controller-runtime fake client
-// (used by Kite's own List/Get calls) and a client-go typed fake Clientset
-// (used internally by kubectl's polymorphichelpers Rollbacker, which the
-// Rollback handlers delegate to and which bypasses controller-runtime
-// entirely).
-func newDeploymentHandlerTestClientSet(t *testing.T, objs ...client.Object) *cluster.ClientSet {
+func newWorkloadHandlerTestClientSet(t *testing.T, objs ...runtime.Object) *cluster.ClientSet {
 	t.Helper()
-	scheme := runtime.NewScheme()
-	if err := appsv1.AddToScheme(scheme); err != nil {
-		t.Fatal(err)
-	}
-	if err := corev1.AddToScheme(scheme); err != nil {
-		t.Fatal(err)
-	}
-	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
-
-	runtimeObjs := make([]runtime.Object, 0, len(objs))
-	for _, obj := range objs {
-		runtimeObjs = append(runtimeObjs, obj)
-	}
-
 	return &cluster.ClientSet{
 		Name: "test",
 		K8sClient: &kube.K8sClient{
-			Client:    fakeClient,
-			ClientSet: clientgofake.NewSimpleClientset(runtimeObjs...),
+			ClientSet: clientgofake.NewSimpleClientset(objs...),
 		},
 	}
 }
@@ -170,7 +147,7 @@ func decodeRevisionsResponse(t *testing.T, rec *httptest.ResponseRecorder) []Wor
 }
 
 func TestDeploymentHandlerRevisions_CurrentFollowsDeploymentAnnotation(t *testing.T) {
-	setupDeploymentHandlerTestDB(t)
+	setupWorkloadHandlerTestDB(t)
 
 	// The Deployment's own bookkeeping says revision 2 is current, even though
 	// a ReplicaSet with the numerically higher revision 3 also exists. The
@@ -181,7 +158,7 @@ func TestDeploymentHandlerRevisions_CurrentFollowsDeploymentAnnotation(t *testin
 	rs2 := makeTestReplicaSet("demo-app-2", 2, "bump to 1.26", "nginx:1.26")
 	rs3 := makeTestReplicaSet("demo-app-3", 3, "bump to 1.27", "nginx:1.27")
 
-	cs := newDeploymentHandlerTestClientSet(t, deployment, rs1, rs2, rs3)
+	cs := newWorkloadHandlerTestClientSet(t, deployment, rs1, rs2, rs3)
 	router := newDeploymentHandlerTestRouter(t, cs)
 
 	rec := httptest.NewRecorder()
@@ -210,13 +187,13 @@ func TestDeploymentHandlerRevisions_CurrentFollowsDeploymentAnnotation(t *testin
 }
 
 func TestDeploymentHandlerRevisions_FallsBackToHighestWhenAnnotationMissing(t *testing.T) {
-	setupDeploymentHandlerTestDB(t)
+	setupWorkloadHandlerTestDB(t)
 
 	deployment := makeTestDeployment("")
 	rs1 := makeTestReplicaSet("demo-app-1", 1, "", "nginx:1.25")
 	rs2 := makeTestReplicaSet("demo-app-2", 2, "", "nginx:1.26")
 
-	cs := newDeploymentHandlerTestClientSet(t, deployment, rs1, rs2)
+	cs := newWorkloadHandlerTestClientSet(t, deployment, rs1, rs2)
 	router := newDeploymentHandlerTestRouter(t, cs)
 
 	rec := httptest.NewRecorder()
@@ -236,7 +213,7 @@ func TestDeploymentHandlerRevisions_FallsBackToHighestWhenAnnotationMissing(t *t
 }
 
 func TestDeploymentHandlerRevisions_SkipsMalformedRevisionAnnotation(t *testing.T) {
-	setupDeploymentHandlerTestDB(t)
+	setupWorkloadHandlerTestDB(t)
 
 	deployment := makeTestDeployment("2")
 	rs1 := makeTestReplicaSet("demo-app-1", 1, "initial deploy", "nginx:1.25")
@@ -246,7 +223,7 @@ func TestDeploymentHandlerRevisions_SkipsMalformedRevisionAnnotation(t *testing.
 	rsMalformed := makeTestReplicaSet("demo-app-bad", 0, "", "nginx:broken")
 	rsMalformed.Annotations[deploymentRevisionAnnotation] = "not-a-number"
 
-	cs := newDeploymentHandlerTestClientSet(t, deployment, rs1, rs2, rsMalformed)
+	cs := newWorkloadHandlerTestClientSet(t, deployment, rs1, rs2, rsMalformed)
 	router := newDeploymentHandlerTestRouter(t, cs)
 
 	rec := httptest.NewRecorder()
@@ -268,9 +245,9 @@ func TestDeploymentHandlerRevisions_SkipsMalformedRevisionAnnotation(t *testing.
 }
 
 func TestDeploymentHandlerRevisions_NotFound(t *testing.T) {
-	setupDeploymentHandlerTestDB(t)
+	setupWorkloadHandlerTestDB(t)
 
-	cs := newDeploymentHandlerTestClientSet(t)
+	cs := newWorkloadHandlerTestClientSet(t)
 	router := newDeploymentHandlerTestRouter(t, cs)
 
 	rec := httptest.NewRecorder()
@@ -283,14 +260,14 @@ func TestDeploymentHandlerRevisions_NotFound(t *testing.T) {
 }
 
 func TestDeploymentHandlerRollback_ExplicitRevision(t *testing.T) {
-	setupDeploymentHandlerTestDB(t)
+	setupWorkloadHandlerTestDB(t)
 
 	deployment := makeTestDeployment("3")
 	rs1 := makeTestReplicaSet("demo-app-1", 1, "initial deploy", "nginx:1.25")
 	rs2 := makeTestReplicaSet("demo-app-2", 2, "bump to 1.26", "nginx:1.26")
 	rs3 := makeTestReplicaSet("demo-app-3", 3, "bump to 1.27", "nginx:1.27")
 
-	cs := newDeploymentHandlerTestClientSet(t, deployment, rs1, rs2, rs3)
+	cs := newWorkloadHandlerTestClientSet(t, deployment, rs1, rs2, rs3)
 	router := newDeploymentHandlerTestRouter(t, cs)
 
 	rec := httptest.NewRecorder()
@@ -302,9 +279,6 @@ func TestDeploymentHandlerRollback_ExplicitRevision(t *testing.T) {
 		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
 	}
 
-	// Read back through the typed clientset, not controller-runtime's client:
-	// kubectl's Rollbacker (and our own change-cause annotate step) both
-	// write through cs.K8sClient.ClientSet.
 	updated, err := cs.K8sClient.ClientSet.AppsV1().Deployments("default").Get(t.Context(), "demo-app", metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("get updated deployment: %v", err)
@@ -312,15 +286,12 @@ func TestDeploymentHandlerRollback_ExplicitRevision(t *testing.T) {
 	if got := updated.Spec.Template.Spec.Containers[0].Image; got != "nginx:1.25" {
 		t.Fatalf("expected rollback to revision 1's image nginx:1.25, got %s", got)
 	}
-	if got := updated.Annotations[deploymentChangeCauseAnnotation]; got != "Rolled back to revision 1 via Kite" {
-		t.Fatalf("unexpected change-cause annotation: %s", got)
-	}
 }
 
 func TestDeploymentHandlerRollback_NotFound(t *testing.T) {
-	setupDeploymentHandlerTestDB(t)
+	setupWorkloadHandlerTestDB(t)
 
-	cs := newDeploymentHandlerTestClientSet(t)
+	cs := newWorkloadHandlerTestClientSet(t)
 	router := newDeploymentHandlerTestRouter(t, cs)
 
 	rec := httptest.NewRecorder()
@@ -333,12 +304,6 @@ func TestDeploymentHandlerRollback_NotFound(t *testing.T) {
 	}
 }
 
-// TestDeploymentHandlerRollback_DefaultRevision covers how the default (no
-// explicit revision requested) rollback target is chosen: the revision
-// immediately before the Deployment's *actual* current revision, not just
-// replicaSets[1] in sorted order. The two cases below share identical
-// scaffolding and only differ in the Deployment's own revision annotation
-// and the resulting expected image, so they're table-driven.
 func TestDeploymentHandlerRollback_DefaultRevision(t *testing.T) {
 	tests := []struct {
 		name              string
@@ -351,28 +316,24 @@ func TestDeploymentHandlerRollback_DefaultRevision(t *testing.T) {
 			wantImage:         "nginx:1.26",
 		},
 		{
-			// Deployment says its current revision is 2, but a ReplicaSet
-			// with the numerically higher revision 3 also exists (e.g.
-			// stale/orphaned). The default target must be the revision
-			// before the Deployment's actual current revision (1), not the
-			// RS after index 1 in the sorted list (which would incorrectly
-			// pick revision 2, the current revision itself).
+			// kubectl chooses the second-highest revision when no explicit
+			// target is provided, regardless of the Deployment annotation.
 			name:              "current lags behind the highest revision",
 			currentAnnotation: "2",
-			wantImage:         "nginx:1.25",
+			wantImage:         "nginx:1.26",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			setupDeploymentHandlerTestDB(t)
+			setupWorkloadHandlerTestDB(t)
 
 			deployment := makeTestDeployment(tt.currentAnnotation)
 			rs1 := makeTestReplicaSet("demo-app-1", 1, "initial deploy", "nginx:1.25")
 			rs2 := makeTestReplicaSet("demo-app-2", 2, "bump to 1.26", "nginx:1.26")
 			rs3 := makeTestReplicaSet("demo-app-3", 3, "bump to 1.27", "nginx:1.27")
 
-			cs := newDeploymentHandlerTestClientSet(t, deployment, rs1, rs2, rs3)
+			cs := newWorkloadHandlerTestClientSet(t, deployment, rs1, rs2, rs3)
 			router := newDeploymentHandlerTestRouter(t, cs)
 
 			rec := httptest.NewRecorder()
@@ -396,13 +357,13 @@ func TestDeploymentHandlerRollback_DefaultRevision(t *testing.T) {
 }
 
 func TestDeploymentHandlerRollback_RevisionNotFound(t *testing.T) {
-	setupDeploymentHandlerTestDB(t)
+	setupWorkloadHandlerTestDB(t)
 
 	deployment := makeTestDeployment("2")
 	rs1 := makeTestReplicaSet("demo-app-1", 1, "", "nginx:1.25")
 	rs2 := makeTestReplicaSet("demo-app-2", 2, "", "nginx:1.26")
 
-	cs := newDeploymentHandlerTestClientSet(t, deployment, rs1, rs2)
+	cs := newWorkloadHandlerTestClientSet(t, deployment, rs1, rs2)
 	router := newDeploymentHandlerTestRouter(t, cs)
 
 	rec := httptest.NewRecorder()
@@ -416,10 +377,10 @@ func TestDeploymentHandlerRollback_RevisionNotFound(t *testing.T) {
 }
 
 func TestDeploymentHandlerRollback_NoHistory(t *testing.T) {
-	setupDeploymentHandlerTestDB(t)
+	setupWorkloadHandlerTestDB(t)
 
 	deployment := makeTestDeployment("")
-	cs := newDeploymentHandlerTestClientSet(t, deployment)
+	cs := newWorkloadHandlerTestClientSet(t, deployment)
 	router := newDeploymentHandlerTestRouter(t, cs)
 
 	rec := httptest.NewRecorder()

--- a/pkg/resources/deployment_handler_test.go
+++ b/pkg/resources/deployment_handler_test.go
@@ -290,6 +290,61 @@ func TestDeploymentHandlerRollback_ExplicitRevision(t *testing.T) {
 	}
 }
 
+func TestDeploymentHandlerRollback_NotFound(t *testing.T) {
+	setupDeploymentHandlerTestDB(t)
+
+	cs := newDeploymentHandlerTestClientSet(t)
+	router := newDeploymentHandlerTestRouter(t, cs)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPut, "/deployments/default/missing/rollback", strings.NewReader("{}"))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestDeploymentHandlerRollback_DefaultUsesRevisionBeforeCurrentAnnotation covers
+// the case where the Deployment's own revision annotation does not point at the
+// highest-numbered ReplicaSet (e.g. it lags behind due to eventual consistency, or
+// a stale RS was left with a higher revision number). The default rollback target
+// must be the revision immediately before the Deployment's *actual* current
+// revision, not just replicaSets[1] in sorted order.
+func TestDeploymentHandlerRollback_DefaultUsesRevisionBeforeCurrentAnnotation(t *testing.T) {
+	setupDeploymentHandlerTestDB(t)
+
+	// Deployment says its current revision is 2, but a ReplicaSet with the
+	// numerically higher revision 3 also exists (e.g. stale/orphaned).
+	deployment := makeTestDeployment("2")
+	rs1 := makeTestReplicaSet("demo-app-1", 1, "initial deploy", "nginx:1.25")
+	rs2 := makeTestReplicaSet("demo-app-2", 2, "bump to 1.26", "nginx:1.26")
+	rs3 := makeTestReplicaSet("demo-app-3", 3, "bump to 1.27", "nginx:1.27")
+
+	cs := newDeploymentHandlerTestClientSet(t, deployment, rs1, rs2, rs3)
+	router := newDeploymentHandlerTestRouter(t, cs)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPut, "/deployments/default/demo-app/rollback", strings.NewReader("{}"))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var updated appsv1.Deployment
+	if err := cs.K8sClient.Get(t.Context(), types.NamespacedName{Namespace: "default", Name: "demo-app"}, &updated); err != nil {
+		t.Fatalf("get updated deployment: %v", err)
+	}
+	// The revision before the *current* revision (2) is 1, not the RS after
+	// index 1 in the sorted list (which would have picked revision 2 itself).
+	if got := updated.Spec.Template.Spec.Containers[0].Image; got != "nginx:1.25" {
+		t.Fatalf("expected rollback to revision 1's image nginx:1.25, got %s", got)
+	}
+}
+
 func TestDeploymentHandlerRollback_RevisionNotFound(t *testing.T) {
 	setupDeploymentHandlerTestDB(t)
 

--- a/pkg/resources/deployment_handler_test.go
+++ b/pkg/resources/deployment_handler_test.go
@@ -261,35 +261,6 @@ func TestDeploymentHandlerRevisions_NotFound(t *testing.T) {
 	}
 }
 
-func TestDeploymentHandlerRollback_DefaultsToPreviousRevision(t *testing.T) {
-	setupDeploymentHandlerTestDB(t)
-
-	deployment := makeTestDeployment("3")
-	rs1 := makeTestReplicaSet("demo-app-1", 1, "initial deploy", "nginx:1.25")
-	rs2 := makeTestReplicaSet("demo-app-2", 2, "bump to 1.26", "nginx:1.26")
-	rs3 := makeTestReplicaSet("demo-app-3", 3, "bump to 1.27", "nginx:1.27")
-
-	cs := newDeploymentHandlerTestClientSet(t, deployment, rs1, rs2, rs3)
-	router := newDeploymentHandlerTestRouter(t, cs)
-
-	rec := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPut, "/deployments/default/demo-app/rollback", strings.NewReader("{}"))
-	req.Header.Set("Content-Type", "application/json")
-	router.ServeHTTP(rec, req)
-
-	if rec.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
-	}
-
-	var updated appsv1.Deployment
-	if err := cs.K8sClient.Get(t.Context(), types.NamespacedName{Namespace: "default", Name: "demo-app"}, &updated); err != nil {
-		t.Fatalf("get updated deployment: %v", err)
-	}
-	if got := updated.Spec.Template.Spec.Containers[0].Image; got != "nginx:1.26" {
-		t.Fatalf("expected rollback to revision 2's image nginx:1.26, got %s", got)
-	}
-}
-
 func TestDeploymentHandlerRollback_ExplicitRevision(t *testing.T) {
 	setupDeploymentHandlerTestDB(t)
 
@@ -338,42 +309,65 @@ func TestDeploymentHandlerRollback_NotFound(t *testing.T) {
 	}
 }
 
-// TestDeploymentHandlerRollback_DefaultUsesRevisionBeforeCurrentAnnotation covers
-// the case where the Deployment's own revision annotation does not point at the
-// highest-numbered ReplicaSet (e.g. it lags behind due to eventual consistency, or
-// a stale RS was left with a higher revision number). The default rollback target
-// must be the revision immediately before the Deployment's *actual* current
-// revision, not just replicaSets[1] in sorted order.
-func TestDeploymentHandlerRollback_DefaultUsesRevisionBeforeCurrentAnnotation(t *testing.T) {
-	setupDeploymentHandlerTestDB(t)
-
-	// Deployment says its current revision is 2, but a ReplicaSet with the
-	// numerically higher revision 3 also exists (e.g. stale/orphaned).
-	deployment := makeTestDeployment("2")
-	rs1 := makeTestReplicaSet("demo-app-1", 1, "initial deploy", "nginx:1.25")
-	rs2 := makeTestReplicaSet("demo-app-2", 2, "bump to 1.26", "nginx:1.26")
-	rs3 := makeTestReplicaSet("demo-app-3", 3, "bump to 1.27", "nginx:1.27")
-
-	cs := newDeploymentHandlerTestClientSet(t, deployment, rs1, rs2, rs3)
-	router := newDeploymentHandlerTestRouter(t, cs)
-
-	rec := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPut, "/deployments/default/demo-app/rollback", strings.NewReader("{}"))
-	req.Header.Set("Content-Type", "application/json")
-	router.ServeHTTP(rec, req)
-
-	if rec.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+// TestDeploymentHandlerRollback_DefaultRevision covers how the default (no
+// explicit revision requested) rollback target is chosen: the revision
+// immediately before the Deployment's *actual* current revision, not just
+// replicaSets[1] in sorted order. The two cases below share identical
+// scaffolding and only differ in the Deployment's own revision annotation
+// and the resulting expected image, so they're table-driven.
+func TestDeploymentHandlerRollback_DefaultRevision(t *testing.T) {
+	tests := []struct {
+		name              string
+		currentAnnotation string
+		wantImage         string
+	}{
+		{
+			name:              "current matches the highest revision",
+			currentAnnotation: "3",
+			wantImage:         "nginx:1.26",
+		},
+		{
+			// Deployment says its current revision is 2, but a ReplicaSet
+			// with the numerically higher revision 3 also exists (e.g.
+			// stale/orphaned). The default target must be the revision
+			// before the Deployment's actual current revision (1), not the
+			// RS after index 1 in the sorted list (which would incorrectly
+			// pick revision 2, the current revision itself).
+			name:              "current lags behind the highest revision",
+			currentAnnotation: "2",
+			wantImage:         "nginx:1.25",
+		},
 	}
 
-	var updated appsv1.Deployment
-	if err := cs.K8sClient.Get(t.Context(), types.NamespacedName{Namespace: "default", Name: "demo-app"}, &updated); err != nil {
-		t.Fatalf("get updated deployment: %v", err)
-	}
-	// The revision before the *current* revision (2) is 1, not the RS after
-	// index 1 in the sorted list (which would have picked revision 2 itself).
-	if got := updated.Spec.Template.Spec.Containers[0].Image; got != "nginx:1.25" {
-		t.Fatalf("expected rollback to revision 1's image nginx:1.25, got %s", got)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setupDeploymentHandlerTestDB(t)
+
+			deployment := makeTestDeployment(tt.currentAnnotation)
+			rs1 := makeTestReplicaSet("demo-app-1", 1, "initial deploy", "nginx:1.25")
+			rs2 := makeTestReplicaSet("demo-app-2", 2, "bump to 1.26", "nginx:1.26")
+			rs3 := makeTestReplicaSet("demo-app-3", 3, "bump to 1.27", "nginx:1.27")
+
+			cs := newDeploymentHandlerTestClientSet(t, deployment, rs1, rs2, rs3)
+			router := newDeploymentHandlerTestRouter(t, cs)
+
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodPut, "/deployments/default/demo-app/rollback", strings.NewReader("{}"))
+			req.Header.Set("Content-Type", "application/json")
+			router.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusOK {
+				t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+			}
+
+			var updated appsv1.Deployment
+			if err := cs.K8sClient.Get(t.Context(), types.NamespacedName{Namespace: "default", Name: "demo-app"}, &updated); err != nil {
+				t.Fatalf("get updated deployment: %v", err)
+			}
+			if got := updated.Spec.Template.Spec.Containers[0].Image; got != tt.wantImage {
+				t.Fatalf("expected rollback image %s, got %s", tt.wantImage, got)
+			}
+		})
 	}
 }
 

--- a/pkg/resources/deployment_handler_test.go
+++ b/pkg/resources/deployment_handler_test.go
@@ -214,6 +214,38 @@ func TestDeploymentHandlerRevisions_FallsBackToHighestWhenAnnotationMissing(t *t
 	}
 }
 
+func TestDeploymentHandlerRevisions_SkipsMalformedRevisionAnnotation(t *testing.T) {
+	setupDeploymentHandlerTestDB(t)
+
+	deployment := makeTestDeployment("2")
+	rs1 := makeTestReplicaSet("demo-app-1", 1, "initial deploy", "nginx:1.25")
+	rs2 := makeTestReplicaSet("demo-app-2", 2, "bump to 1.26", "nginx:1.26")
+	// A ReplicaSet with a non-numeric revision annotation must be excluded
+	// entirely, not silently sorted/matched as revision 0.
+	rsMalformed := makeTestReplicaSet("demo-app-bad", 0, "", "nginx:broken")
+	rsMalformed.Annotations[deploymentRevisionAnnotation] = "not-a-number"
+
+	cs := newDeploymentHandlerTestClientSet(t, deployment, rs1, rs2, rsMalformed)
+	router := newDeploymentHandlerTestRouter(t, cs)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/deployments/default/demo-app/revisions", nil)
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	items := decodeRevisionsResponse(t, rec)
+	if len(items) != 2 {
+		t.Fatalf("expected 2 items (malformed RS excluded), got %d: %+v", len(items), items)
+	}
+	for _, item := range items {
+		if item.ReplicaSet == "demo-app-bad" {
+			t.Fatalf("malformed ReplicaSet should not appear in revisions: %+v", items)
+		}
+	}
+}
+
 func TestDeploymentHandlerRevisions_NotFound(t *testing.T) {
 	setupDeploymentHandlerTestDB(t)
 

--- a/pkg/resources/deployment_handler_test.go
+++ b/pkg/resources/deployment_handler_test.go
@@ -20,6 +20,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	clientgofake "k8s.io/client-go/kubernetes/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -69,6 +70,7 @@ func makeTestDeployment(revisionAnnotation string) *appsv1.Deployment {
 
 func makeTestReplicaSet(name string, revision int64, changeCause, image string) *appsv1.ReplicaSet {
 	isController := true
+	replicas := int32(1)
 	rs := &appsv1.ReplicaSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -88,6 +90,10 @@ func makeTestReplicaSet(name string, revision int64, changeCause, image string) 
 			},
 		},
 		Spec: appsv1.ReplicaSetSpec{
+			// kubectl's own rollback logic (k8s.io/kubectl/pkg/util/deployment)
+			// dereferences Spec.Replicas directly, which the real API server
+			// always defaults to non-nil; our raw fixture must too.
+			Replicas: &replicas,
 			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "demo-app"}},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "demo-app"}},
@@ -121,6 +127,12 @@ func newDeploymentHandlerTestRouter(t *testing.T, cs *cluster.ClientSet) *gin.En
 	return router
 }
 
+// newDeploymentHandlerTestClientSet builds a cluster.ClientSet backed by two
+// fakes seeded with the same objects: the controller-runtime fake client
+// (used by Kite's own List/Get calls) and a client-go typed fake Clientset
+// (used internally by kubectl's polymorphichelpers Rollbacker, which the
+// Rollback handlers delegate to and which bypasses controller-runtime
+// entirely).
 func newDeploymentHandlerTestClientSet(t *testing.T, objs ...client.Object) *cluster.ClientSet {
 	t.Helper()
 	scheme := runtime.NewScheme()
@@ -131,9 +143,18 @@ func newDeploymentHandlerTestClientSet(t *testing.T, objs ...client.Object) *clu
 		t.Fatal(err)
 	}
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+
+	runtimeObjs := make([]runtime.Object, 0, len(objs))
+	for _, obj := range objs {
+		runtimeObjs = append(runtimeObjs, obj)
+	}
+
 	return &cluster.ClientSet{
-		Name:      "test",
-		K8sClient: &kube.K8sClient{Client: fakeClient},
+		Name: "test",
+		K8sClient: &kube.K8sClient{
+			Client:    fakeClient,
+			ClientSet: clientgofake.NewSimpleClientset(runtimeObjs...),
+		},
 	}
 }
 
@@ -281,8 +302,11 @@ func TestDeploymentHandlerRollback_ExplicitRevision(t *testing.T) {
 		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
 	}
 
-	var updated appsv1.Deployment
-	if err := cs.K8sClient.Get(t.Context(), types.NamespacedName{Namespace: "default", Name: "demo-app"}, &updated); err != nil {
+	// Read back through the typed clientset, not controller-runtime's client:
+	// kubectl's Rollbacker (and our own change-cause annotate step) both
+	// write through cs.K8sClient.ClientSet.
+	updated, err := cs.K8sClient.ClientSet.AppsV1().Deployments("default").Get(t.Context(), "demo-app", metav1.GetOptions{})
+	if err != nil {
 		t.Fatalf("get updated deployment: %v", err)
 	}
 	if got := updated.Spec.Template.Spec.Containers[0].Image; got != "nginx:1.25" {
@@ -360,8 +384,8 @@ func TestDeploymentHandlerRollback_DefaultRevision(t *testing.T) {
 				t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
 			}
 
-			var updated appsv1.Deployment
-			if err := cs.K8sClient.Get(t.Context(), types.NamespacedName{Namespace: "default", Name: "demo-app"}, &updated); err != nil {
+			updated, err := cs.K8sClient.ClientSet.AppsV1().Deployments("default").Get(t.Context(), "demo-app", metav1.GetOptions{})
+			if err != nil {
 				t.Fatalf("get updated deployment: %v", err)
 			}
 			if got := updated.Spec.Template.Spec.Containers[0].Image; got != tt.wantImage {

--- a/pkg/resources/deployment_handler_test.go
+++ b/pkg/resources/deployment_handler_test.go
@@ -137,10 +137,10 @@ func newDeploymentHandlerTestClientSet(t *testing.T, objs ...client.Object) *clu
 	}
 }
 
-func decodeRevisionsResponse(t *testing.T, rec *httptest.ResponseRecorder) []deploymentRevisionItem {
+func decodeRevisionsResponse(t *testing.T, rec *httptest.ResponseRecorder) []WorkloadRevisionItem {
 	t.Helper()
 	var body struct {
-		Items []deploymentRevisionItem `json:"items"`
+		Items []WorkloadRevisionItem `json:"items"`
 	}
 	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
 		t.Fatalf("decode response: %v; body=%s", err, rec.Body.String())
@@ -240,7 +240,7 @@ func TestDeploymentHandlerRevisions_SkipsMalformedRevisionAnnotation(t *testing.
 		t.Fatalf("expected 2 items (malformed RS excluded), got %d: %+v", len(items), items)
 	}
 	for _, item := range items {
-		if item.ReplicaSet == "demo-app-bad" {
+		if item.RevisionObject == "demo-app-bad" {
 			t.Fatalf("malformed ReplicaSet should not appear in revisions: %+v", items)
 		}
 	}

--- a/pkg/resources/deployment_handler_test.go
+++ b/pkg/resources/deployment_handler_test.go
@@ -1,0 +1,328 @@
+package resources
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/glebarez/sqlite"
+	"github.com/zxh326/kite/pkg/cluster"
+	"github.com/zxh326/kite/pkg/kube"
+	"github.com/zxh326/kite/pkg/model"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+const deploymentTestUID = types.UID("demo-deployment-uid")
+
+func setupDeploymentHandlerTestDB(t *testing.T) {
+	t.Helper()
+	oldDB := model.DB
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{Logger: logger.Default.LogMode(logger.Silent)})
+	if err != nil {
+		t.Fatalf("open database: %v", err)
+	}
+	sqlDB, err := db.DB()
+	if err != nil {
+		t.Fatalf("get database: %v", err)
+	}
+	sqlDB.SetMaxOpenConns(1)
+	if err := db.AutoMigrate(&model.User{}, &model.ResourceHistory{}); err != nil {
+		t.Fatalf("migrate database: %v", err)
+	}
+	model.DB = db
+	t.Cleanup(func() {
+		model.DB = oldDB
+		_ = sqlDB.Close()
+	})
+}
+
+func makeTestDeployment(revisionAnnotation string) *appsv1.Deployment {
+	d := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo-app",
+			Namespace: "default",
+			UID:       deploymentTestUID,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "demo-app"},
+			},
+		},
+	}
+	if revisionAnnotation != "" {
+		d.Annotations = map[string]string{deploymentRevisionAnnotation: revisionAnnotation}
+	}
+	return d
+}
+
+func makeTestReplicaSet(name string, revision int64, changeCause, image string) *appsv1.ReplicaSet {
+	isController := true
+	rs := &appsv1.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+			Labels:    map[string]string{"app": "demo-app"},
+			Annotations: map[string]string{
+				deploymentRevisionAnnotation: strconv.FormatInt(revision, 10),
+			},
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "apps/v1",
+					Kind:       "Deployment",
+					Name:       "demo-app",
+					UID:        deploymentTestUID,
+					Controller: &isController,
+				},
+			},
+		},
+		Spec: appsv1.ReplicaSetSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "demo-app"}},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "demo-app"}},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "nginx", Image: image}},
+				},
+			},
+		},
+	}
+	if changeCause != "" {
+		rs.Annotations[deploymentChangeCauseAnnotation] = changeCause
+	}
+	return rs
+}
+
+func newDeploymentHandlerTestRouter(t *testing.T, cs *cluster.ClientSet) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	handler := NewDeploymentHandler()
+	router := gin.New()
+	router.GET("/deployments/:namespace/:name/revisions", func(c *gin.Context) {
+		c.Set("cluster", cs)
+		c.Set("user", model.User{Username: "alice"})
+		handler.Revisions(c)
+	})
+	router.PUT("/deployments/:namespace/:name/rollback", func(c *gin.Context) {
+		c.Set("cluster", cs)
+		c.Set("user", model.User{Username: "alice"})
+		handler.Rollback(c)
+	})
+	return router
+}
+
+func newDeploymentHandlerTestClientSet(t *testing.T, objs ...client.Object) *cluster.ClientSet {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := appsv1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+	return &cluster.ClientSet{
+		Name:      "test",
+		K8sClient: &kube.K8sClient{Client: fakeClient},
+	}
+}
+
+func decodeRevisionsResponse(t *testing.T, rec *httptest.ResponseRecorder) []deploymentRevisionItem {
+	t.Helper()
+	var body struct {
+		Items []deploymentRevisionItem `json:"items"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v; body=%s", err, rec.Body.String())
+	}
+	return body.Items
+}
+
+func TestDeploymentHandlerRevisions_CurrentFollowsDeploymentAnnotation(t *testing.T) {
+	setupDeploymentHandlerTestDB(t)
+
+	// The Deployment's own bookkeeping says revision 2 is current, even though
+	// a ReplicaSet with the numerically higher revision 3 also exists. The
+	// "current" flag must follow the Deployment's annotation, not just pick
+	// the highest revision number in the list.
+	deployment := makeTestDeployment("2")
+	rs1 := makeTestReplicaSet("demo-app-1", 1, "initial deploy", "nginx:1.25")
+	rs2 := makeTestReplicaSet("demo-app-2", 2, "bump to 1.26", "nginx:1.26")
+	rs3 := makeTestReplicaSet("demo-app-3", 3, "bump to 1.27", "nginx:1.27")
+
+	cs := newDeploymentHandlerTestClientSet(t, deployment, rs1, rs2, rs3)
+	router := newDeploymentHandlerTestRouter(t, cs)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/deployments/default/demo-app/revisions", nil)
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	items := decodeRevisionsResponse(t, rec)
+	if len(items) != 3 {
+		t.Fatalf("expected 3 items, got %d", len(items))
+	}
+
+	// Sorted descending by revision.
+	if items[0].Revision != 3 || items[1].Revision != 2 || items[2].Revision != 1 {
+		t.Fatalf("unexpected revision order: %+v", items)
+	}
+
+	for _, item := range items {
+		wantCurrent := item.Revision == 2
+		if item.Current != wantCurrent {
+			t.Errorf("revision %d: current=%v, want %v", item.Revision, item.Current, wantCurrent)
+		}
+	}
+}
+
+func TestDeploymentHandlerRevisions_FallsBackToHighestWhenAnnotationMissing(t *testing.T) {
+	setupDeploymentHandlerTestDB(t)
+
+	deployment := makeTestDeployment("")
+	rs1 := makeTestReplicaSet("demo-app-1", 1, "", "nginx:1.25")
+	rs2 := makeTestReplicaSet("demo-app-2", 2, "", "nginx:1.26")
+
+	cs := newDeploymentHandlerTestClientSet(t, deployment, rs1, rs2)
+	router := newDeploymentHandlerTestRouter(t, cs)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/deployments/default/demo-app/revisions", nil)
+	router.ServeHTTP(rec, req)
+
+	items := decodeRevisionsResponse(t, rec)
+	if len(items) != 2 {
+		t.Fatalf("expected 2 items, got %d", len(items))
+	}
+	if !items[0].Current || items[0].Revision != 2 {
+		t.Fatalf("expected highest revision (2) to be marked current, got %+v", items[0])
+	}
+	if items[1].Current {
+		t.Fatalf("expected revision 1 to not be current: %+v", items[1])
+	}
+}
+
+func TestDeploymentHandlerRevisions_NotFound(t *testing.T) {
+	setupDeploymentHandlerTestDB(t)
+
+	cs := newDeploymentHandlerTestClientSet(t)
+	router := newDeploymentHandlerTestRouter(t, cs)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/deployments/default/missing/revisions", nil)
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestDeploymentHandlerRollback_DefaultsToPreviousRevision(t *testing.T) {
+	setupDeploymentHandlerTestDB(t)
+
+	deployment := makeTestDeployment("3")
+	rs1 := makeTestReplicaSet("demo-app-1", 1, "initial deploy", "nginx:1.25")
+	rs2 := makeTestReplicaSet("demo-app-2", 2, "bump to 1.26", "nginx:1.26")
+	rs3 := makeTestReplicaSet("demo-app-3", 3, "bump to 1.27", "nginx:1.27")
+
+	cs := newDeploymentHandlerTestClientSet(t, deployment, rs1, rs2, rs3)
+	router := newDeploymentHandlerTestRouter(t, cs)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPut, "/deployments/default/demo-app/rollback", strings.NewReader("{}"))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var updated appsv1.Deployment
+	if err := cs.K8sClient.Get(t.Context(), types.NamespacedName{Namespace: "default", Name: "demo-app"}, &updated); err != nil {
+		t.Fatalf("get updated deployment: %v", err)
+	}
+	if got := updated.Spec.Template.Spec.Containers[0].Image; got != "nginx:1.26" {
+		t.Fatalf("expected rollback to revision 2's image nginx:1.26, got %s", got)
+	}
+}
+
+func TestDeploymentHandlerRollback_ExplicitRevision(t *testing.T) {
+	setupDeploymentHandlerTestDB(t)
+
+	deployment := makeTestDeployment("3")
+	rs1 := makeTestReplicaSet("demo-app-1", 1, "initial deploy", "nginx:1.25")
+	rs2 := makeTestReplicaSet("demo-app-2", 2, "bump to 1.26", "nginx:1.26")
+	rs3 := makeTestReplicaSet("demo-app-3", 3, "bump to 1.27", "nginx:1.27")
+
+	cs := newDeploymentHandlerTestClientSet(t, deployment, rs1, rs2, rs3)
+	router := newDeploymentHandlerTestRouter(t, cs)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPut, "/deployments/default/demo-app/rollback", strings.NewReader(`{"revision":1}`))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var updated appsv1.Deployment
+	if err := cs.K8sClient.Get(t.Context(), types.NamespacedName{Namespace: "default", Name: "demo-app"}, &updated); err != nil {
+		t.Fatalf("get updated deployment: %v", err)
+	}
+	if got := updated.Spec.Template.Spec.Containers[0].Image; got != "nginx:1.25" {
+		t.Fatalf("expected rollback to revision 1's image nginx:1.25, got %s", got)
+	}
+	if got := updated.Annotations[deploymentChangeCauseAnnotation]; got != "Rolled back to revision 1 via Kite" {
+		t.Fatalf("unexpected change-cause annotation: %s", got)
+	}
+}
+
+func TestDeploymentHandlerRollback_RevisionNotFound(t *testing.T) {
+	setupDeploymentHandlerTestDB(t)
+
+	deployment := makeTestDeployment("2")
+	rs1 := makeTestReplicaSet("demo-app-1", 1, "", "nginx:1.25")
+	rs2 := makeTestReplicaSet("demo-app-2", 2, "", "nginx:1.26")
+
+	cs := newDeploymentHandlerTestClientSet(t, deployment, rs1, rs2)
+	router := newDeploymentHandlerTestRouter(t, cs)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPut, "/deployments/default/demo-app/rollback", strings.NewReader(`{"revision":99}`))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestDeploymentHandlerRollback_NoHistory(t *testing.T) {
+	setupDeploymentHandlerTestDB(t)
+
+	deployment := makeTestDeployment("")
+	cs := newDeploymentHandlerTestClientSet(t, deployment)
+	router := newDeploymentHandlerTestRouter(t, cs)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPut, "/deployments/default/demo-app/rollback", strings.NewReader("{}"))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+}

--- a/pkg/resources/handler.go
+++ b/pkg/resources/handler.go
@@ -101,8 +101,8 @@ func newResourceHandlers() map[string]resourceHandler {
 		string(common.Deployments):            NewDeploymentHandler(),
 		string(common.ReplicaSets):            NewGenericResourceHandler[*appsv1.ReplicaSet, *appsv1.ReplicaSetList](common.ReplicaSets),
 		string(common.ControllerRevisions):    NewGenericResourceHandler[*appsv1.ControllerRevision, *appsv1.ControllerRevisionList](common.ControllerRevisions),
-		string(common.StatefulSets):           NewGenericResourceHandler[*appsv1.StatefulSet, *appsv1.StatefulSetList](common.StatefulSets),
-		string(common.DaemonSets):             NewGenericResourceHandler[*appsv1.DaemonSet, *appsv1.DaemonSetList](common.DaemonSets),
+		string(common.StatefulSets):           NewStatefulSetHandler(),
+		string(common.DaemonSets):             NewDaemonSetHandler(),
 		string(common.PodDisruptionBudgets): newVersionedResourceHandler(
 			newResourceVersionCandidate("policy/v1", string(common.PodDisruptionBudgets), NewGenericResourceHandler[*policyv1.PodDisruptionBudget, *policyv1.PodDisruptionBudgetList](common.PodDisruptionBudgets)),
 			newResourceVersionCandidate("policy/v1beta1", string(common.PodDisruptionBudgets), NewGenericResourceHandler[*policyv1beta1.PodDisruptionBudget, *policyv1beta1.PodDisruptionBudgetList](common.PodDisruptionBudgets)),

--- a/pkg/resources/handler.go
+++ b/pkg/resources/handler.go
@@ -71,6 +71,11 @@ type Restartable interface {
 	Restart(c *gin.Context, namespace, name string) error
 }
 
+type workloadRevisionHandler interface {
+	Revisions(c *gin.Context)
+	Rollback(c *gin.Context)
+}
+
 type SearchFunc func(c *gin.Context, query string, limit int64) ([]common.SearchResult, error)
 
 var handlers = map[string]resourceHandler{}
@@ -199,6 +204,10 @@ func RegisterRoutes(group *gin.RouterGroup) {
 
 	for name, handler := range handlers {
 		g := group.Group("/" + name)
+		if workloadHandler, ok := handler.(workloadRevisionHandler); ok {
+			g.GET("/:namespace/:name/revisions", workloadHandler.Revisions)
+			g.PUT("/:namespace/:name/rollback", workloadHandler.Rollback)
+		}
 		handler.registerCustomRoutes(g)
 		if handler.IsClusterScoped() {
 			registerClusterScopeRoutes(g, handler)

--- a/pkg/resources/statefulset_handler.go
+++ b/pkg/resources/statefulset_handler.go
@@ -2,20 +2,15 @@ package resources
 
 import (
 	"context"
-	"errors"
-	"fmt"
-	"io"
 	"net/http"
 	"sort"
-	"strings"
 
 	"github.com/gin-gonic/gin"
 	"github.com/zxh326/kite/pkg/cluster"
 	"github.com/zxh326/kite/pkg/common"
 	appsv1 "k8s.io/api/apps/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type StatefulSetHandler struct {
@@ -28,19 +23,14 @@ func NewStatefulSetHandler() *StatefulSetHandler {
 	}
 }
 
-func (h *StatefulSetHandler) registerCustomRoutes(group *gin.RouterGroup) {
-	group.GET("/:namespace/:name/revisions", h.Revisions)
-	group.PUT("/:namespace/:name/rollback", h.Rollback)
-}
-
 func (h *StatefulSetHandler) Revisions(c *gin.Context) {
 	namespace, name := c.Param("namespace"), c.Param("name")
 	cs := c.MustGet("cluster").(*cluster.ClientSet)
 	ctx := c.Request.Context()
 
-	var sts appsv1.StatefulSet
-	if err := cs.K8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, &sts); err != nil {
-		if client.IgnoreNotFound(err) == nil {
+	sts, err := cs.K8sClient.ClientSet.AppsV1().StatefulSets(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
 			c.JSON(http.StatusNotFound, gin.H{"error": "not found"})
 			return
 		}
@@ -48,136 +38,25 @@ func (h *StatefulSetHandler) Revisions(c *gin.Context) {
 		return
 	}
 
-	revisions, err := listControllerRevisions(ctx, cs, namespace, sts.Spec.Selector, &sts)
+	revisions, err := listControllerRevisions(ctx, cs, namespace, sts.Spec.Selector, sts)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
 
-	currentIndex := statefulSetCurrentRevisionIndex(&sts, revisions)
+	currentIndex := statefulSetCurrentRevisionIndex(sts, revisions)
 
-	items := make([]WorkloadRevisionItem, 0, len(revisions))
-	for i, rev := range revisions {
-		items = append(items, WorkloadRevisionItem{
-			Revision:       rev.Revision,
-			RevisionObject: rev.Name,
-			ChangeCause:    rev.Annotations[deploymentChangeCauseAnnotation],
-			Images:         controllerRevisionImages(rev.Data.Raw),
-			CreatedAt:      rev.CreationTimestamp,
-			Current:        i == currentIndex,
-		})
-	}
-	c.JSON(http.StatusOK, gin.H{"items": items})
+	c.JSON(http.StatusOK, gin.H{"items": controllerRevisionItems(revisions, currentIndex)})
 }
 
-func (h *StatefulSetHandler) Rollback(c *gin.Context) {
-	namespace, name := c.Param("namespace"), c.Param("name")
-	cs := c.MustGet("cluster").(*cluster.ClientSet)
-	ctx := c.Request.Context()
-
-	var req workloadRollbackRequest
-	if err := c.ShouldBindJSON(&req); err != nil && !errors.Is(err, io.EOF) {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
-		return
-	}
-
-	var sts appsv1.StatefulSet
-	if err := cs.K8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, &sts); err != nil {
-		if client.IgnoreNotFound(err) == nil {
-			c.JSON(http.StatusNotFound, gin.H{"error": "not found"})
-			return
-		}
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-		return
-	}
-	oldSts := sts.DeepCopy()
-
-	revisions, err := listControllerRevisions(ctx, cs, namespace, sts.Spec.Selector, &sts)
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-		return
-	}
-	if len(revisions) == 0 {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "no revision history found for this statefulset"})
-		return
-	}
-
-	targetRevision := req.Revision
-	if targetRevision == 0 {
-		currentIndex := statefulSetCurrentRevisionIndex(&sts, revisions)
-		if currentIndex < 0 || currentIndex+1 >= len(revisions) {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "no previous revision found"})
-			return
-		}
-		targetRevision = revisions[currentIndex+1].Revision
-	}
-
-	found := false
-	for _, rev := range revisions {
-		if rev.Revision == targetRevision {
-			found = true
-			break
-		}
-	}
-	if !found {
-		c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("revision %d not found", targetRevision)})
-		return
-	}
-
-	var success bool
-	var errMsg string
-	defer func() {
-		h.recordHistory(c, "rollback", oldSts, &sts, success, errMsg)
-	}()
-
-	if err := rollbackWorkload(cs, statefulSetGroupKind, &sts, targetRevision); err != nil {
-		errMsg = err.Error()
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-		return
-	}
-
-	// Re-fetch and annotate through the same typed clientset kubectl's
-	// Rollbacker just wrote through (rather than controller-runtime's
-	// client), so this read is guaranteed to see the rollback it just
-	// applied.
-	updated, err := cs.K8sClient.ClientSet.AppsV1().StatefulSets(namespace).Get(ctx, name, metav1.GetOptions{})
-	if err != nil {
-		errMsg = err.Error()
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-		return
-	}
-	if updated.Annotations == nil {
-		updated.Annotations = make(map[string]string)
-	}
-	changeCause := strings.TrimSpace(req.ChangeCause)
-	if changeCause == "" {
-		changeCause = fmt.Sprintf("Rolled back to revision %d via Kite", targetRevision)
-	}
-	updated.Annotations[deploymentChangeCauseAnnotation] = changeCause
-	updated, err = cs.K8sClient.ClientSet.AppsV1().StatefulSets(namespace).Update(ctx, updated, metav1.UpdateOptions{})
-	if err != nil {
-		errMsg = err.Error()
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-		return
-	}
-	sts = *updated
-
-	success = true
-	c.JSON(http.StatusOK, gin.H{"message": "statefulset rolled back", "revision": targetRevision})
-}
-
-// listControllerRevisions lists the ControllerRevisions in namespace matching
-// selector that are controlled by owner, sorted by descending revision. It's
-// shared by StatefulSet and DaemonSet, which both use ControllerRevision to
-// track rollout history (unlike Deployment, which uses ReplicaSet).
 func listControllerRevisions(ctx context.Context, cs *cluster.ClientSet, namespace string, selector *metav1.LabelSelector, owner metav1.Object) ([]*appsv1.ControllerRevision, error) {
 	labelSelector, err := metav1.LabelSelectorAsSelector(selector)
 	if err != nil {
 		return nil, err
 	}
 
-	var list appsv1.ControllerRevisionList
-	if err := cs.K8sClient.List(ctx, &list, client.InNamespace(namespace), client.MatchingLabelsSelector{Selector: labelSelector}); err != nil {
+	list, err := cs.K8sClient.ClientSet.AppsV1().ControllerRevisions(namespace).List(ctx, metav1.ListOptions{LabelSelector: labelSelector.String()})
+	if err != nil {
 		return nil, err
 	}
 
@@ -195,15 +74,10 @@ func listControllerRevisions(ctx context.Context, cs *cluster.ClientSet, namespa
 	return owned, nil
 }
 
-// statefulSetCurrentRevisionIndex resolves which entry in revisions (sorted
-// by descending revision) is the StatefulSet's current revision, using the
-// authoritative status.currentRevision name. It falls back to the highest
-// revision (index 0) when status.currentRevision is empty or doesn't match
-// any ControllerRevision in the list.
 func statefulSetCurrentRevisionIndex(sts *appsv1.StatefulSet, revisions []*appsv1.ControllerRevision) int {
-	if sts.Status.CurrentRevision != "" {
+	for _, revisionName := range []string{sts.Status.UpdateRevision, sts.Status.CurrentRevision} {
 		for i, rev := range revisions {
-			if rev.Name == sts.Status.CurrentRevision {
+			if rev.Name == revisionName {
 				return i
 			}
 		}

--- a/pkg/resources/statefulset_handler.go
+++ b/pkg/resources/statefulset_handler.go
@@ -112,14 +112,14 @@ func (h *StatefulSetHandler) Rollback(c *gin.Context) {
 		targetRevision = revisions[currentIndex+1].Revision
 	}
 
-	var target *appsv1.ControllerRevision
+	found := false
 	for _, rev := range revisions {
 		if rev.Revision == targetRevision {
-			target = rev
+			found = true
 			break
 		}
 	}
-	if target == nil {
+	if !found {
 		c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("revision %d not found", targetRevision)})
 		return
 	}
@@ -130,22 +130,37 @@ func (h *StatefulSetHandler) Rollback(c *gin.Context) {
 		h.recordHistory(c, "rollback", oldSts, &sts, success, errMsg)
 	}()
 
-	changeCause := strings.TrimSpace(req.ChangeCause)
-	if changeCause == "" {
-		changeCause = fmt.Sprintf("Rolled back to revision %d via Kite", targetRevision)
-	}
-	patch, err := withChangeCauseAnnotation(target.Data.Raw, changeCause)
-	if err != nil {
+	if err := rollbackWorkload(cs, statefulSetGroupKind, &sts, targetRevision); err != nil {
 		errMsg = err.Error()
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
 
-	if err := cs.K8sClient.Patch(ctx, &sts, client.RawPatch(types.StrategicMergePatchType, patch)); err != nil {
+	// Re-fetch and annotate through the same typed clientset kubectl's
+	// Rollbacker just wrote through (rather than controller-runtime's
+	// client), so this read is guaranteed to see the rollback it just
+	// applied.
+	updated, err := cs.K8sClient.ClientSet.AppsV1().StatefulSets(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
 		errMsg = err.Error()
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
+	if updated.Annotations == nil {
+		updated.Annotations = make(map[string]string)
+	}
+	changeCause := strings.TrimSpace(req.ChangeCause)
+	if changeCause == "" {
+		changeCause = fmt.Sprintf("Rolled back to revision %d via Kite", targetRevision)
+	}
+	updated.Annotations[deploymentChangeCauseAnnotation] = changeCause
+	updated, err = cs.K8sClient.ClientSet.AppsV1().StatefulSets(namespace).Update(ctx, updated, metav1.UpdateOptions{})
+	if err != nil {
+		errMsg = err.Error()
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	sts = *updated
 
 	success = true
 	c.JSON(http.StatusOK, gin.H{"message": "statefulset rolled back", "revision": targetRevision})

--- a/pkg/resources/statefulset_handler.go
+++ b/pkg/resources/statefulset_handler.go
@@ -1,0 +1,200 @@
+package resources
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"sort"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/zxh326/kite/pkg/cluster"
+	"github.com/zxh326/kite/pkg/common"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type StatefulSetHandler struct {
+	*GenericResourceHandler[*appsv1.StatefulSet, *appsv1.StatefulSetList]
+}
+
+func NewStatefulSetHandler() *StatefulSetHandler {
+	return &StatefulSetHandler{
+		GenericResourceHandler: NewGenericResourceHandler[*appsv1.StatefulSet, *appsv1.StatefulSetList](common.StatefulSets),
+	}
+}
+
+func (h *StatefulSetHandler) registerCustomRoutes(group *gin.RouterGroup) {
+	group.GET("/:namespace/:name/revisions", h.Revisions)
+	group.PUT("/:namespace/:name/rollback", h.Rollback)
+}
+
+func (h *StatefulSetHandler) Revisions(c *gin.Context) {
+	namespace, name := c.Param("namespace"), c.Param("name")
+	cs := c.MustGet("cluster").(*cluster.ClientSet)
+	ctx := c.Request.Context()
+
+	var sts appsv1.StatefulSet
+	if err := cs.K8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, &sts); err != nil {
+		if client.IgnoreNotFound(err) == nil {
+			c.JSON(http.StatusNotFound, gin.H{"error": "not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	revisions, err := listControllerRevisions(ctx, cs, namespace, sts.Spec.Selector, &sts)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	currentIndex := statefulSetCurrentRevisionIndex(&sts, revisions)
+
+	items := make([]WorkloadRevisionItem, 0, len(revisions))
+	for i, rev := range revisions {
+		items = append(items, WorkloadRevisionItem{
+			Revision:       rev.Revision,
+			RevisionObject: rev.Name,
+			ChangeCause:    rev.Annotations[deploymentChangeCauseAnnotation],
+			Images:         controllerRevisionImages(rev.Data.Raw),
+			CreatedAt:      rev.CreationTimestamp,
+			Current:        i == currentIndex,
+		})
+	}
+	c.JSON(http.StatusOK, gin.H{"items": items})
+}
+
+func (h *StatefulSetHandler) Rollback(c *gin.Context) {
+	namespace, name := c.Param("namespace"), c.Param("name")
+	cs := c.MustGet("cluster").(*cluster.ClientSet)
+	ctx := c.Request.Context()
+
+	var req workloadRollbackRequest
+	if err := c.ShouldBindJSON(&req); err != nil && !errors.Is(err, io.EOF) {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	var sts appsv1.StatefulSet
+	if err := cs.K8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, &sts); err != nil {
+		if client.IgnoreNotFound(err) == nil {
+			c.JSON(http.StatusNotFound, gin.H{"error": "not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	oldSts := sts.DeepCopy()
+
+	revisions, err := listControllerRevisions(ctx, cs, namespace, sts.Spec.Selector, &sts)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	if len(revisions) == 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "no revision history found for this statefulset"})
+		return
+	}
+
+	targetRevision := req.Revision
+	if targetRevision == 0 {
+		currentIndex := statefulSetCurrentRevisionIndex(&sts, revisions)
+		if currentIndex < 0 || currentIndex+1 >= len(revisions) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "no previous revision found"})
+			return
+		}
+		targetRevision = revisions[currentIndex+1].Revision
+	}
+
+	var target *appsv1.ControllerRevision
+	for _, rev := range revisions {
+		if rev.Revision == targetRevision {
+			target = rev
+			break
+		}
+	}
+	if target == nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("revision %d not found", targetRevision)})
+		return
+	}
+
+	var success bool
+	var errMsg string
+	defer func() {
+		h.recordHistory(c, "rollback", oldSts, &sts, success, errMsg)
+	}()
+
+	changeCause := strings.TrimSpace(req.ChangeCause)
+	if changeCause == "" {
+		changeCause = fmt.Sprintf("Rolled back to revision %d via Kite", targetRevision)
+	}
+	patch, err := withChangeCauseAnnotation(target.Data.Raw, changeCause)
+	if err != nil {
+		errMsg = err.Error()
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	if err := cs.K8sClient.Patch(ctx, &sts, client.RawPatch(types.StrategicMergePatchType, patch)); err != nil {
+		errMsg = err.Error()
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	success = true
+	c.JSON(http.StatusOK, gin.H{"message": "statefulset rolled back", "revision": targetRevision})
+}
+
+// listControllerRevisions lists the ControllerRevisions in namespace matching
+// selector that are controlled by owner, sorted by descending revision. It's
+// shared by StatefulSet and DaemonSet, which both use ControllerRevision to
+// track rollout history (unlike Deployment, which uses ReplicaSet).
+func listControllerRevisions(ctx context.Context, cs *cluster.ClientSet, namespace string, selector *metav1.LabelSelector, owner metav1.Object) ([]*appsv1.ControllerRevision, error) {
+	labelSelector, err := metav1.LabelSelectorAsSelector(selector)
+	if err != nil {
+		return nil, err
+	}
+
+	var list appsv1.ControllerRevisionList
+	if err := cs.K8sClient.List(ctx, &list, client.InNamespace(namespace), client.MatchingLabelsSelector{Selector: labelSelector}); err != nil {
+		return nil, err
+	}
+
+	owned := make([]*appsv1.ControllerRevision, 0, len(list.Items))
+	for i := range list.Items {
+		rev := &list.Items[i]
+		if !metav1.IsControlledBy(rev, owner) {
+			continue
+		}
+		owned = append(owned, rev)
+	}
+	sort.Slice(owned, func(i, j int) bool {
+		return owned[i].Revision > owned[j].Revision
+	})
+	return owned, nil
+}
+
+// statefulSetCurrentRevisionIndex resolves which entry in revisions (sorted
+// by descending revision) is the StatefulSet's current revision, using the
+// authoritative status.currentRevision name. It falls back to the highest
+// revision (index 0) when status.currentRevision is empty or doesn't match
+// any ControllerRevision in the list.
+func statefulSetCurrentRevisionIndex(sts *appsv1.StatefulSet, revisions []*appsv1.ControllerRevision) int {
+	if sts.Status.CurrentRevision != "" {
+		for i, rev := range revisions {
+			if rev.Name == sts.Status.CurrentRevision {
+				return i
+			}
+		}
+	}
+	if len(revisions) > 0 {
+		return 0
+	}
+	return -1
+}

--- a/pkg/resources/statefulset_handler_test.go
+++ b/pkg/resources/statefulset_handler_test.go
@@ -85,7 +85,7 @@ func makeTestControllerRevision(t *testing.T, name string, revision int64, chang
 		Data:     controllerRevisionData(t, image),
 	}
 	if changeCause != "" {
-		cr.Annotations = map[string]string{deploymentChangeCauseAnnotation: changeCause}
+		cr.Annotations = map[string]string{changeCauseAnnotation: changeCause}
 	}
 	return cr
 }
@@ -108,18 +108,18 @@ func newStatefulSetHandlerTestRouter(t *testing.T, cs *cluster.ClientSet) *gin.E
 	return router
 }
 
-func TestStatefulSetHandlerRevisions_CurrentFollowsStatusCurrentRevision(t *testing.T) {
-	setupDeploymentHandlerTestDB(t)
+func TestStatefulSetHandlerRevisions_CurrentFollowsStatusUpdateRevision(t *testing.T) {
+	setupWorkloadHandlerTestDB(t)
 
-	// status.currentRevision names cr2 as current, even though cr3 (a higher
-	// revision number) also exists - mirrors a StatefulSet mid-rollout where
-	// the newest ControllerRevision hasn't been adopted as current yet.
+	// During a rollout, currentRevision still points to the old pods while
+	// updateRevision identifies the desired revision from the StatefulSet spec.
 	sts := makeTestStatefulSet("demo-sts-cr2")
+	sts.Status.UpdateRevision = "demo-sts-cr3"
 	cr1 := makeTestControllerRevision(t, "demo-sts-cr1", 1, "initial deploy", "nginx:1.25", statefulSetTestUID, "StatefulSet")
 	cr2 := makeTestControllerRevision(t, "demo-sts-cr2", 2, "bump to 1.26", "nginx:1.26", statefulSetTestUID, "StatefulSet")
 	cr3 := makeTestControllerRevision(t, "demo-sts-cr3", 3, "bump to 1.27", "nginx:1.27", statefulSetTestUID, "StatefulSet")
 
-	cs := newDeploymentHandlerTestClientSet(t, sts, cr1, cr2, cr3)
+	cs := newWorkloadHandlerTestClientSet(t, sts, cr1, cr2, cr3)
 	router := newStatefulSetHandlerTestRouter(t, cs)
 
 	rec := httptest.NewRecorder()
@@ -137,7 +137,7 @@ func TestStatefulSetHandlerRevisions_CurrentFollowsStatusCurrentRevision(t *test
 		t.Fatalf("unexpected revision order: %+v", items)
 	}
 	for _, item := range items {
-		wantCurrent := item.Revision == 2
+		wantCurrent := item.Revision == 3
 		if item.Current != wantCurrent {
 			t.Errorf("revision %d: current=%v, want %v", item.Revision, item.Current, wantCurrent)
 		}
@@ -151,13 +151,13 @@ func TestStatefulSetHandlerRevisions_CurrentFollowsStatusCurrentRevision(t *test
 }
 
 func TestStatefulSetHandlerRevisions_FallsBackToHighestWhenCurrentRevisionEmpty(t *testing.T) {
-	setupDeploymentHandlerTestDB(t)
+	setupWorkloadHandlerTestDB(t)
 
 	sts := makeTestStatefulSet("")
 	cr1 := makeTestControllerRevision(t, "demo-sts-cr1", 1, "", "nginx:1.25", statefulSetTestUID, "StatefulSet")
 	cr2 := makeTestControllerRevision(t, "demo-sts-cr2", 2, "", "nginx:1.26", statefulSetTestUID, "StatefulSet")
 
-	cs := newDeploymentHandlerTestClientSet(t, sts, cr1, cr2)
+	cs := newWorkloadHandlerTestClientSet(t, sts, cr1, cr2)
 	router := newStatefulSetHandlerTestRouter(t, cs)
 
 	rec := httptest.NewRecorder()
@@ -174,9 +174,9 @@ func TestStatefulSetHandlerRevisions_FallsBackToHighestWhenCurrentRevisionEmpty(
 }
 
 func TestStatefulSetHandlerRevisions_NotFound(t *testing.T) {
-	setupDeploymentHandlerTestDB(t)
+	setupWorkloadHandlerTestDB(t)
 
-	cs := newDeploymentHandlerTestClientSet(t)
+	cs := newWorkloadHandlerTestClientSet(t)
 	router := newStatefulSetHandlerTestRouter(t, cs)
 
 	rec := httptest.NewRecorder()
@@ -188,73 +188,63 @@ func TestStatefulSetHandlerRevisions_NotFound(t *testing.T) {
 	}
 }
 
-func TestStatefulSetHandlerRollback_DefaultUsesRevisionBeforeCurrent(t *testing.T) {
-	setupDeploymentHandlerTestDB(t)
-
-	sts := makeTestStatefulSet("demo-sts-cr2")
-	cr1 := makeTestControllerRevision(t, "demo-sts-cr1", 1, "initial deploy", "nginx:1.25", statefulSetTestUID, "StatefulSet")
-	cr2 := makeTestControllerRevision(t, "demo-sts-cr2", 2, "bump to 1.26", "nginx:1.26", statefulSetTestUID, "StatefulSet")
-	cr3 := makeTestControllerRevision(t, "demo-sts-cr3", 3, "bump to 1.27", "nginx:1.27", statefulSetTestUID, "StatefulSet")
-
-	cs := newDeploymentHandlerTestClientSet(t, sts, cr1, cr2, cr3)
-	router := newStatefulSetHandlerTestRouter(t, cs)
-
-	rec := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPut, "/statefulsets/default/demo-sts/rollback", strings.NewReader("{}"))
-	req.Header.Set("Content-Type", "application/json")
-	router.ServeHTTP(rec, req)
-
-	if rec.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+func TestStatefulSetHandlerRollback_Revision(t *testing.T) {
+	tests := []struct {
+		name            string
+		currentRevision string
+		body            string
+		wantImage       string
+	}{
+		{
+			name:            "defaults to the previous revision",
+			currentRevision: "demo-sts-cr2",
+			body:            "{}",
+			wantImage:       "nginx:1.26",
+		},
+		{
+			name:            "uses the explicit revision",
+			currentRevision: "demo-sts-cr3",
+			body:            `{"revision":1}`,
+			wantImage:       "nginx:1.25",
+		},
 	}
 
-	updated, err := cs.K8sClient.ClientSet.AppsV1().StatefulSets("default").Get(t.Context(), "demo-sts", metav1.GetOptions{})
-	if err != nil {
-		t.Fatalf("get updated statefulset: %v", err)
-	}
-	// Current is revision 2, so the default rollback target must be
-	// revision 1 (immediately before current), not revision 2 itself.
-	if got := updated.Spec.Template.Spec.Containers[0].Image; got != "nginx:1.25" {
-		t.Fatalf("expected rollback to revision 1's image nginx:1.25, got %s", got)
-	}
-	if got := updated.Annotations[deploymentChangeCauseAnnotation]; got != "Rolled back to revision 1 via Kite" {
-		t.Fatalf("unexpected change-cause annotation: %s", got)
-	}
-}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setupWorkloadHandlerTestDB(t)
 
-func TestStatefulSetHandlerRollback_ExplicitRevision(t *testing.T) {
-	setupDeploymentHandlerTestDB(t)
+			sts := makeTestStatefulSet(tt.currentRevision)
+			cr1 := makeTestControllerRevision(t, "demo-sts-cr1", 1, "initial deploy", "nginx:1.25", statefulSetTestUID, "StatefulSet")
+			cr2 := makeTestControllerRevision(t, "demo-sts-cr2", 2, "bump to 1.26", "nginx:1.26", statefulSetTestUID, "StatefulSet")
+			cr3 := makeTestControllerRevision(t, "demo-sts-cr3", 3, "bump to 1.27", "nginx:1.27", statefulSetTestUID, "StatefulSet")
 
-	sts := makeTestStatefulSet("demo-sts-cr3")
-	cr1 := makeTestControllerRevision(t, "demo-sts-cr1", 1, "initial deploy", "nginx:1.25", statefulSetTestUID, "StatefulSet")
-	cr2 := makeTestControllerRevision(t, "demo-sts-cr2", 2, "bump to 1.26", "nginx:1.26", statefulSetTestUID, "StatefulSet")
-	cr3 := makeTestControllerRevision(t, "demo-sts-cr3", 3, "bump to 1.27", "nginx:1.27", statefulSetTestUID, "StatefulSet")
+			cs := newWorkloadHandlerTestClientSet(t, sts, cr1, cr2, cr3)
+			router := newStatefulSetHandlerTestRouter(t, cs)
 
-	cs := newDeploymentHandlerTestClientSet(t, sts, cr1, cr2, cr3)
-	router := newStatefulSetHandlerTestRouter(t, cs)
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodPut, "/statefulsets/default/demo-sts/rollback", strings.NewReader(tt.body))
+			req.Header.Set("Content-Type", "application/json")
+			router.ServeHTTP(rec, req)
 
-	rec := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPut, "/statefulsets/default/demo-sts/rollback", strings.NewReader(`{"revision":1}`))
-	req.Header.Set("Content-Type", "application/json")
-	router.ServeHTTP(rec, req)
+			if rec.Code != http.StatusOK {
+				t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+			}
 
-	if rec.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
-	}
-
-	updated, err := cs.K8sClient.ClientSet.AppsV1().StatefulSets("default").Get(t.Context(), "demo-sts", metav1.GetOptions{})
-	if err != nil {
-		t.Fatalf("get updated statefulset: %v", err)
-	}
-	if got := updated.Spec.Template.Spec.Containers[0].Image; got != "nginx:1.25" {
-		t.Fatalf("expected rollback to revision 1's image nginx:1.25, got %s", got)
+			updated, err := cs.K8sClient.ClientSet.AppsV1().StatefulSets("default").Get(t.Context(), "demo-sts", metav1.GetOptions{})
+			if err != nil {
+				t.Fatalf("get updated statefulset: %v", err)
+			}
+			if got := updated.Spec.Template.Spec.Containers[0].Image; got != tt.wantImage {
+				t.Fatalf("expected rollback image %s, got %s", tt.wantImage, got)
+			}
+		})
 	}
 }
 
 func TestStatefulSetHandlerRollback_NotFound(t *testing.T) {
-	setupDeploymentHandlerTestDB(t)
+	setupWorkloadHandlerTestDB(t)
 
-	cs := newDeploymentHandlerTestClientSet(t)
+	cs := newWorkloadHandlerTestClientSet(t)
 	router := newStatefulSetHandlerTestRouter(t, cs)
 
 	rec := httptest.NewRecorder()
@@ -268,13 +258,13 @@ func TestStatefulSetHandlerRollback_NotFound(t *testing.T) {
 }
 
 func TestStatefulSetHandlerRollback_RevisionNotFound(t *testing.T) {
-	setupDeploymentHandlerTestDB(t)
+	setupWorkloadHandlerTestDB(t)
 
 	sts := makeTestStatefulSet("demo-sts-cr2")
 	cr1 := makeTestControllerRevision(t, "demo-sts-cr1", 1, "", "nginx:1.25", statefulSetTestUID, "StatefulSet")
 	cr2 := makeTestControllerRevision(t, "demo-sts-cr2", 2, "", "nginx:1.26", statefulSetTestUID, "StatefulSet")
 
-	cs := newDeploymentHandlerTestClientSet(t, sts, cr1, cr2)
+	cs := newWorkloadHandlerTestClientSet(t, sts, cr1, cr2)
 	router := newStatefulSetHandlerTestRouter(t, cs)
 
 	rec := httptest.NewRecorder()
@@ -288,10 +278,10 @@ func TestStatefulSetHandlerRollback_RevisionNotFound(t *testing.T) {
 }
 
 func TestStatefulSetHandlerRollback_NoHistory(t *testing.T) {
-	setupDeploymentHandlerTestDB(t)
+	setupWorkloadHandlerTestDB(t)
 
 	sts := makeTestStatefulSet("")
-	cs := newDeploymentHandlerTestClientSet(t, sts)
+	cs := newWorkloadHandlerTestClientSet(t, sts)
 	router := newStatefulSetHandlerTestRouter(t, cs)
 
 	rec := httptest.NewRecorder()

--- a/pkg/resources/statefulset_handler_test.go
+++ b/pkg/resources/statefulset_handler_test.go
@@ -208,8 +208,8 @@ func TestStatefulSetHandlerRollback_DefaultUsesRevisionBeforeCurrent(t *testing.
 		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
 	}
 
-	var updated appsv1.StatefulSet
-	if err := cs.K8sClient.Get(t.Context(), types.NamespacedName{Namespace: "default", Name: "demo-sts"}, &updated); err != nil {
+	updated, err := cs.K8sClient.ClientSet.AppsV1().StatefulSets("default").Get(t.Context(), "demo-sts", metav1.GetOptions{})
+	if err != nil {
 		t.Fatalf("get updated statefulset: %v", err)
 	}
 	// Current is revision 2, so the default rollback target must be
@@ -242,8 +242,8 @@ func TestStatefulSetHandlerRollback_ExplicitRevision(t *testing.T) {
 		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
 	}
 
-	var updated appsv1.StatefulSet
-	if err := cs.K8sClient.Get(t.Context(), types.NamespacedName{Namespace: "default", Name: "demo-sts"}, &updated); err != nil {
+	updated, err := cs.K8sClient.ClientSet.AppsV1().StatefulSets("default").Get(t.Context(), "demo-sts", metav1.GetOptions{})
+	if err != nil {
 		t.Fatalf("get updated statefulset: %v", err)
 	}
 	if got := updated.Spec.Template.Spec.Containers[0].Image; got != "nginx:1.25" {

--- a/pkg/resources/statefulset_handler_test.go
+++ b/pkg/resources/statefulset_handler_test.go
@@ -1,0 +1,305 @@
+package resources
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/zxh326/kite/pkg/cluster"
+	"github.com/zxh326/kite/pkg/model"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+const statefulSetTestUID = types.UID("demo-statefulset-uid")
+
+func makeTestStatefulSet(currentRevisionName string) *appsv1.StatefulSet {
+	return &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo-sts",
+			Namespace: "default",
+			UID:       statefulSetTestUID,
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "demo-sts"},
+			},
+		},
+		Status: appsv1.StatefulSetStatus{
+			CurrentRevision: currentRevisionName,
+		},
+	}
+}
+
+func controllerRevisionData(t *testing.T, image string) runtime.RawExtension {
+	t.Helper()
+	doc := map[string]interface{}{
+		"spec": map[string]interface{}{
+			"template": map[string]interface{}{
+				"$patch": "replace",
+				"spec": map[string]interface{}{
+					"containers": []map[string]interface{}{
+						{"name": "nginx", "image": image},
+					},
+				},
+			},
+		},
+	}
+	raw, err := json.Marshal(doc)
+	if err != nil {
+		t.Fatalf("marshal controller revision data: %v", err)
+	}
+	return runtime.RawExtension{Raw: raw}
+}
+
+func makeTestControllerRevision(t *testing.T, name string, revision int64, changeCause, image string, ownerUID types.UID, ownerKind string) *appsv1.ControllerRevision {
+	t.Helper()
+	ownerName := "demo-sts"
+	appLabel := "demo-sts"
+	if ownerKind == "DaemonSet" {
+		ownerName = "demo-ds"
+		appLabel = "demo-ds"
+	}
+	isController := true
+	cr := &appsv1.ControllerRevision{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+			Labels:    map[string]string{"app": appLabel},
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "apps/v1",
+					Kind:       ownerKind,
+					Name:       ownerName,
+					UID:        ownerUID,
+					Controller: &isController,
+				},
+			},
+		},
+		Revision: revision,
+		Data:     controllerRevisionData(t, image),
+	}
+	if changeCause != "" {
+		cr.Annotations = map[string]string{deploymentChangeCauseAnnotation: changeCause}
+	}
+	return cr
+}
+
+func newStatefulSetHandlerTestRouter(t *testing.T, cs *cluster.ClientSet) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	handler := NewStatefulSetHandler()
+	router := gin.New()
+	router.GET("/statefulsets/:namespace/:name/revisions", func(c *gin.Context) {
+		c.Set("cluster", cs)
+		c.Set("user", model.User{Username: "alice"})
+		handler.Revisions(c)
+	})
+	router.PUT("/statefulsets/:namespace/:name/rollback", func(c *gin.Context) {
+		c.Set("cluster", cs)
+		c.Set("user", model.User{Username: "alice"})
+		handler.Rollback(c)
+	})
+	return router
+}
+
+func TestStatefulSetHandlerRevisions_CurrentFollowsStatusCurrentRevision(t *testing.T) {
+	setupDeploymentHandlerTestDB(t)
+
+	// status.currentRevision names cr2 as current, even though cr3 (a higher
+	// revision number) also exists - mirrors a StatefulSet mid-rollout where
+	// the newest ControllerRevision hasn't been adopted as current yet.
+	sts := makeTestStatefulSet("demo-sts-cr2")
+	cr1 := makeTestControllerRevision(t, "demo-sts-cr1", 1, "initial deploy", "nginx:1.25", statefulSetTestUID, "StatefulSet")
+	cr2 := makeTestControllerRevision(t, "demo-sts-cr2", 2, "bump to 1.26", "nginx:1.26", statefulSetTestUID, "StatefulSet")
+	cr3 := makeTestControllerRevision(t, "demo-sts-cr3", 3, "bump to 1.27", "nginx:1.27", statefulSetTestUID, "StatefulSet")
+
+	cs := newDeploymentHandlerTestClientSet(t, sts, cr1, cr2, cr3)
+	router := newStatefulSetHandlerTestRouter(t, cs)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/statefulsets/default/demo-sts/revisions", nil)
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	items := decodeRevisionsResponse(t, rec)
+	if len(items) != 3 {
+		t.Fatalf("expected 3 items, got %d", len(items))
+	}
+	if items[0].Revision != 3 || items[1].Revision != 2 || items[2].Revision != 1 {
+		t.Fatalf("unexpected revision order: %+v", items)
+	}
+	for _, item := range items {
+		wantCurrent := item.Revision == 2
+		if item.Current != wantCurrent {
+			t.Errorf("revision %d: current=%v, want %v", item.Revision, item.Current, wantCurrent)
+		}
+		if item.Replicas != nil {
+			t.Errorf("revision %d: expected no replicas field for StatefulSet revisions, got %v", item.Revision, *item.Replicas)
+		}
+	}
+	if got := items[1].Images; len(got) != 1 || got[0] != "nginx:1.26" {
+		t.Fatalf("expected images [nginx:1.26], got %v", got)
+	}
+}
+
+func TestStatefulSetHandlerRevisions_FallsBackToHighestWhenCurrentRevisionEmpty(t *testing.T) {
+	setupDeploymentHandlerTestDB(t)
+
+	sts := makeTestStatefulSet("")
+	cr1 := makeTestControllerRevision(t, "demo-sts-cr1", 1, "", "nginx:1.25", statefulSetTestUID, "StatefulSet")
+	cr2 := makeTestControllerRevision(t, "demo-sts-cr2", 2, "", "nginx:1.26", statefulSetTestUID, "StatefulSet")
+
+	cs := newDeploymentHandlerTestClientSet(t, sts, cr1, cr2)
+	router := newStatefulSetHandlerTestRouter(t, cs)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/statefulsets/default/demo-sts/revisions", nil)
+	router.ServeHTTP(rec, req)
+
+	items := decodeRevisionsResponse(t, rec)
+	if len(items) != 2 {
+		t.Fatalf("expected 2 items, got %d", len(items))
+	}
+	if !items[0].Current || items[0].Revision != 2 {
+		t.Fatalf("expected highest revision (2) to be marked current, got %+v", items[0])
+	}
+}
+
+func TestStatefulSetHandlerRevisions_NotFound(t *testing.T) {
+	setupDeploymentHandlerTestDB(t)
+
+	cs := newDeploymentHandlerTestClientSet(t)
+	router := newStatefulSetHandlerTestRouter(t, cs)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/statefulsets/default/missing/revisions", nil)
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestStatefulSetHandlerRollback_DefaultUsesRevisionBeforeCurrent(t *testing.T) {
+	setupDeploymentHandlerTestDB(t)
+
+	sts := makeTestStatefulSet("demo-sts-cr2")
+	cr1 := makeTestControllerRevision(t, "demo-sts-cr1", 1, "initial deploy", "nginx:1.25", statefulSetTestUID, "StatefulSet")
+	cr2 := makeTestControllerRevision(t, "demo-sts-cr2", 2, "bump to 1.26", "nginx:1.26", statefulSetTestUID, "StatefulSet")
+	cr3 := makeTestControllerRevision(t, "demo-sts-cr3", 3, "bump to 1.27", "nginx:1.27", statefulSetTestUID, "StatefulSet")
+
+	cs := newDeploymentHandlerTestClientSet(t, sts, cr1, cr2, cr3)
+	router := newStatefulSetHandlerTestRouter(t, cs)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPut, "/statefulsets/default/demo-sts/rollback", strings.NewReader("{}"))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var updated appsv1.StatefulSet
+	if err := cs.K8sClient.Get(t.Context(), types.NamespacedName{Namespace: "default", Name: "demo-sts"}, &updated); err != nil {
+		t.Fatalf("get updated statefulset: %v", err)
+	}
+	// Current is revision 2, so the default rollback target must be
+	// revision 1 (immediately before current), not revision 2 itself.
+	if got := updated.Spec.Template.Spec.Containers[0].Image; got != "nginx:1.25" {
+		t.Fatalf("expected rollback to revision 1's image nginx:1.25, got %s", got)
+	}
+	if got := updated.Annotations[deploymentChangeCauseAnnotation]; got != "Rolled back to revision 1 via Kite" {
+		t.Fatalf("unexpected change-cause annotation: %s", got)
+	}
+}
+
+func TestStatefulSetHandlerRollback_ExplicitRevision(t *testing.T) {
+	setupDeploymentHandlerTestDB(t)
+
+	sts := makeTestStatefulSet("demo-sts-cr3")
+	cr1 := makeTestControllerRevision(t, "demo-sts-cr1", 1, "initial deploy", "nginx:1.25", statefulSetTestUID, "StatefulSet")
+	cr2 := makeTestControllerRevision(t, "demo-sts-cr2", 2, "bump to 1.26", "nginx:1.26", statefulSetTestUID, "StatefulSet")
+	cr3 := makeTestControllerRevision(t, "demo-sts-cr3", 3, "bump to 1.27", "nginx:1.27", statefulSetTestUID, "StatefulSet")
+
+	cs := newDeploymentHandlerTestClientSet(t, sts, cr1, cr2, cr3)
+	router := newStatefulSetHandlerTestRouter(t, cs)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPut, "/statefulsets/default/demo-sts/rollback", strings.NewReader(`{"revision":1}`))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var updated appsv1.StatefulSet
+	if err := cs.K8sClient.Get(t.Context(), types.NamespacedName{Namespace: "default", Name: "demo-sts"}, &updated); err != nil {
+		t.Fatalf("get updated statefulset: %v", err)
+	}
+	if got := updated.Spec.Template.Spec.Containers[0].Image; got != "nginx:1.25" {
+		t.Fatalf("expected rollback to revision 1's image nginx:1.25, got %s", got)
+	}
+}
+
+func TestStatefulSetHandlerRollback_NotFound(t *testing.T) {
+	setupDeploymentHandlerTestDB(t)
+
+	cs := newDeploymentHandlerTestClientSet(t)
+	router := newStatefulSetHandlerTestRouter(t, cs)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPut, "/statefulsets/default/missing/rollback", strings.NewReader("{}"))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestStatefulSetHandlerRollback_RevisionNotFound(t *testing.T) {
+	setupDeploymentHandlerTestDB(t)
+
+	sts := makeTestStatefulSet("demo-sts-cr2")
+	cr1 := makeTestControllerRevision(t, "demo-sts-cr1", 1, "", "nginx:1.25", statefulSetTestUID, "StatefulSet")
+	cr2 := makeTestControllerRevision(t, "demo-sts-cr2", 2, "", "nginx:1.26", statefulSetTestUID, "StatefulSet")
+
+	cs := newDeploymentHandlerTestClientSet(t, sts, cr1, cr2)
+	router := newStatefulSetHandlerTestRouter(t, cs)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPut, "/statefulsets/default/demo-sts/rollback", strings.NewReader(`{"revision":99}`))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestStatefulSetHandlerRollback_NoHistory(t *testing.T) {
+	setupDeploymentHandlerTestDB(t)
+
+	sts := makeTestStatefulSet("")
+	cs := newDeploymentHandlerTestClientSet(t, sts)
+	router := newStatefulSetHandlerTestRouter(t, cs)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPut, "/statefulsets/default/demo-sts/rollback", strings.NewReader("{}"))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+}

--- a/pkg/resources/workload_revisions.go
+++ b/pkg/resources/workload_revisions.go
@@ -1,33 +1,28 @@
 package resources
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
 
+	"github.com/gin-gonic/gin"
 	"github.com/zxh326/kite/pkg/cluster"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/klog/v2"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/polymorphichelpers"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// GroupKinds for the workload kinds that support kubectl-style rollout
-// history and rollback, used to look up the matching kubectl Rollbacker.
-var (
-	deploymentGroupKind  = schema.GroupKind{Group: "apps", Kind: "Deployment"}
-	statefulSetGroupKind = schema.GroupKind{Group: "apps", Kind: "StatefulSet"}
-	daemonSetGroupKind   = schema.GroupKind{Group: "apps", Kind: "DaemonSet"}
-)
+const changeCauseAnnotation = "kubernetes.io/change-cause"
 
-// WorkloadRevisionItem is the common shape returned by the revisions endpoint
-// for every workload kind that supports Kubernetes rollout history
-// (Deployments, StatefulSets, DaemonSets). RevisionObject holds the name of
-// the underlying object the revision is derived from (a ReplicaSet for
-// Deployments, a ControllerRevision for StatefulSets/DaemonSets). Replicas is
-// only meaningful for Deployments, where the owned ReplicaSet tracks its own
-// replica count; StatefulSet/DaemonSet revisions are point-in-time template
-// snapshots with no replica count of their own, so it's omitted for those.
 type WorkloadRevisionItem struct {
 	Revision       int64       `json:"revision"`
 	RevisionObject string      `json:"revisionObject"`
@@ -39,15 +34,9 @@ type WorkloadRevisionItem struct {
 }
 
 type workloadRollbackRequest struct {
-	Revision    int64  `json:"revision"`
-	ChangeCause string `json:"changeCause"`
+	Revision int64 `json:"revision"`
 }
 
-// controllerRevisionTemplatePatch mirrors the strategic-merge-patch shape
-// kubectl stores in a StatefulSet/DaemonSet ControllerRevision's Data field:
-// {"spec":{"template":{...pod template..., "$patch":"replace"}}}. Decoding
-// into this struct (rather than applying the patch to the live object) is
-// enough to read back the pod template that revision represents.
 type controllerRevisionTemplatePatch struct {
 	Spec struct {
 		Template corev1.PodTemplateSpec `json:"template"`
@@ -57,7 +46,7 @@ type controllerRevisionTemplatePatch struct {
 func controllerRevisionImages(data []byte) []string {
 	var patch controllerRevisionTemplatePatch
 	if err := json.Unmarshal(data, &patch); err != nil {
-		return nil
+		return []string{}
 	}
 	images := make([]string, 0, len(patch.Spec.Template.Spec.Containers))
 	for _, container := range patch.Spec.Template.Spec.Containers {
@@ -66,18 +55,90 @@ func controllerRevisionImages(data []byte) []string {
 	return images
 }
 
-// rollbackWorkload applies revision targetRevision to obj by delegating to
-// kubectl's own Rollbacker for groupKind - the same code path `kubectl
-// rollout undo` uses - instead of Kite reimplementing the per-kind template
-// swap (Deployment/ReplicaSet) or strategic-merge-patch application
-// (StatefulSet/DaemonSet ControllerRevision) itself. obj only needs its
-// Namespace/Name set; the Rollbacker re-fetches the live object by name via
-// the typed clientset.
-func rollbackWorkload(cs *cluster.ClientSet, groupKind schema.GroupKind, obj runtime.Object, targetRevision int64) error {
+func controllerRevisionItems(revisions []*appsv1.ControllerRevision, currentIndex int) []WorkloadRevisionItem {
+	items := make([]WorkloadRevisionItem, 0, len(revisions))
+	for i, revision := range revisions {
+		items = append(items, WorkloadRevisionItem{
+			Revision:       revision.Revision,
+			RevisionObject: revision.Name,
+			ChangeCause:    revision.Annotations[changeCauseAnnotation],
+			Images:         controllerRevisionImages(revision.Data.Raw),
+			CreatedAt:      revision.CreationTimestamp,
+			Current:        i == currentIndex,
+		})
+	}
+	return items
+}
+
+func (h *GenericResourceHandler[T, V]) Rollback(c *gin.Context) {
+	namespace, name := c.Param("namespace"), c.Param("name")
+	cs := c.MustGet("cluster").(*cluster.ClientSet)
+	ctx := c.Request.Context()
+
+	var req workloadRollbackRequest
+	if err := c.ShouldBindJSON(&req); err != nil && !errors.Is(err, io.EOF) {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	groupKind := h.getGroupKind()
+	resource, err := workloadFromClientSet(ctx, cs, groupKind, namespace, name)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	workload := resource.(T)
+	previous := workload.DeepCopyObject().(T)
+	current := workload
+	var success bool
+	var errMsg string
+	defer func() {
+		h.recordHistory(c, "rollback", previous, current, success, errMsg)
+	}()
+
 	rollbacker, err := polymorphichelpers.RollbackerFor(groupKind, cs.K8sClient.ClientSet)
 	if err != nil {
-		return err
+		errMsg = err.Error()
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
 	}
-	_, err = rollbacker.Rollback(obj, nil, targetRevision, cmdutil.DryRunNone)
-	return err
+
+	message, err := rollbacker.Rollback(workload, nil, req.Revision, cmdutil.DryRunNone)
+	if err != nil {
+		errMsg = err.Error()
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	success = true
+
+	updated, err := workloadFromClientSet(ctx, cs, groupKind, namespace, name)
+	if err == nil {
+		current = updated.(T)
+	} else {
+		klog.Warningf("failed to get %s %s/%s after rollback: %v", groupKind.Kind, namespace, name, err)
+	}
+
+	response := gin.H{"message": message}
+	if req.Revision > 0 {
+		response["revision"] = req.Revision
+	}
+	c.JSON(http.StatusOK, response)
+}
+
+func workloadFromClientSet(ctx context.Context, cs *cluster.ClientSet, groupKind schema.GroupKind, namespace, name string) (client.Object, error) {
+	switch groupKind.Kind {
+	case "Deployment":
+		return cs.K8sClient.ClientSet.AppsV1().Deployments(namespace).Get(ctx, name, metav1.GetOptions{})
+	case "StatefulSet":
+		return cs.K8sClient.ClientSet.AppsV1().StatefulSets(namespace).Get(ctx, name, metav1.GetOptions{})
+	case "DaemonSet":
+		return cs.K8sClient.ClientSet.AppsV1().DaemonSets(namespace).Get(ctx, name, metav1.GetOptions{})
+	default:
+		return nil, fmt.Errorf("rollback is not supported for %s", groupKind.String())
+	}
 }

--- a/pkg/resources/workload_revisions.go
+++ b/pkg/resources/workload_revisions.go
@@ -1,0 +1,77 @@
+package resources
+
+import (
+	"encoding/json"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// WorkloadRevisionItem is the common shape returned by the revisions endpoint
+// for every workload kind that supports Kubernetes rollout history
+// (Deployments, StatefulSets, DaemonSets). RevisionObject holds the name of
+// the underlying object the revision is derived from (a ReplicaSet for
+// Deployments, a ControllerRevision for StatefulSets/DaemonSets). Replicas is
+// only meaningful for Deployments, where the owned ReplicaSet tracks its own
+// replica count; StatefulSet/DaemonSet revisions are point-in-time template
+// snapshots with no replica count of their own, so it's omitted for those.
+type WorkloadRevisionItem struct {
+	Revision       int64       `json:"revision"`
+	RevisionObject string      `json:"revisionObject"`
+	ChangeCause    string      `json:"changeCause,omitempty"`
+	Images         []string    `json:"images"`
+	Replicas       *int32      `json:"replicas,omitempty"`
+	CreatedAt      metav1.Time `json:"createdAt"`
+	Current        bool        `json:"current"`
+}
+
+type workloadRollbackRequest struct {
+	Revision    int64  `json:"revision"`
+	ChangeCause string `json:"changeCause"`
+}
+
+// controllerRevisionTemplatePatch mirrors the strategic-merge-patch shape
+// kubectl stores in a StatefulSet/DaemonSet ControllerRevision's Data field:
+// {"spec":{"template":{...pod template..., "$patch":"replace"}}}. Decoding
+// into this struct (rather than applying the patch to the live object) is
+// enough to read back the pod template that revision represents.
+type controllerRevisionTemplatePatch struct {
+	Spec struct {
+		Template corev1.PodTemplateSpec `json:"template"`
+	} `json:"spec"`
+}
+
+func controllerRevisionImages(data []byte) []string {
+	var patch controllerRevisionTemplatePatch
+	if err := json.Unmarshal(data, &patch); err != nil {
+		return nil
+	}
+	images := make([]string, 0, len(patch.Spec.Template.Spec.Containers))
+	for _, container := range patch.Spec.Template.Spec.Containers {
+		images = append(images, container.Image)
+	}
+	return images
+}
+
+// withChangeCauseAnnotation merges a kubernetes.io/change-cause annotation
+// into a ControllerRevision's raw strategic-merge-patch document, so the
+// rollout's template change and its change-cause can be applied to the live
+// object in a single PATCH call instead of two separate writes.
+func withChangeCauseAnnotation(rawPatch []byte, changeCause string) ([]byte, error) {
+	var doc map[string]interface{}
+	if err := json.Unmarshal(rawPatch, &doc); err != nil {
+		return nil, err
+	}
+	metadata, _ := doc["metadata"].(map[string]interface{})
+	if metadata == nil {
+		metadata = map[string]interface{}{}
+	}
+	annotations, _ := metadata["annotations"].(map[string]interface{})
+	if annotations == nil {
+		annotations = map[string]interface{}{}
+	}
+	annotations[deploymentChangeCauseAnnotation] = changeCause
+	metadata["annotations"] = annotations
+	doc["metadata"] = metadata
+	return json.Marshal(doc)
+}

--- a/pkg/resources/workload_revisions.go
+++ b/pkg/resources/workload_revisions.go
@@ -3,8 +3,21 @@ package resources
 import (
 	"encoding/json"
 
+	"github.com/zxh326/kite/pkg/cluster"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"k8s.io/kubectl/pkg/polymorphichelpers"
+)
+
+// GroupKinds for the workload kinds that support kubectl-style rollout
+// history and rollback, used to look up the matching kubectl Rollbacker.
+var (
+	deploymentGroupKind  = schema.GroupKind{Group: "apps", Kind: "Deployment"}
+	statefulSetGroupKind = schema.GroupKind{Group: "apps", Kind: "StatefulSet"}
+	daemonSetGroupKind   = schema.GroupKind{Group: "apps", Kind: "DaemonSet"}
 )
 
 // WorkloadRevisionItem is the common shape returned by the revisions endpoint
@@ -53,25 +66,18 @@ func controllerRevisionImages(data []byte) []string {
 	return images
 }
 
-// withChangeCauseAnnotation merges a kubernetes.io/change-cause annotation
-// into a ControllerRevision's raw strategic-merge-patch document, so the
-// rollout's template change and its change-cause can be applied to the live
-// object in a single PATCH call instead of two separate writes.
-func withChangeCauseAnnotation(rawPatch []byte, changeCause string) ([]byte, error) {
-	var doc map[string]interface{}
-	if err := json.Unmarshal(rawPatch, &doc); err != nil {
-		return nil, err
+// rollbackWorkload applies revision targetRevision to obj by delegating to
+// kubectl's own Rollbacker for groupKind - the same code path `kubectl
+// rollout undo` uses - instead of Kite reimplementing the per-kind template
+// swap (Deployment/ReplicaSet) or strategic-merge-patch application
+// (StatefulSet/DaemonSet ControllerRevision) itself. obj only needs its
+// Namespace/Name set; the Rollbacker re-fetches the live object by name via
+// the typed clientset.
+func rollbackWorkload(cs *cluster.ClientSet, groupKind schema.GroupKind, obj runtime.Object, targetRevision int64) error {
+	rollbacker, err := polymorphichelpers.RollbackerFor(groupKind, cs.K8sClient.ClientSet)
+	if err != nil {
+		return err
 	}
-	metadata, _ := doc["metadata"].(map[string]interface{})
-	if metadata == nil {
-		metadata = map[string]interface{}{}
-	}
-	annotations, _ := metadata["annotations"].(map[string]interface{})
-	if annotations == nil {
-		annotations = map[string]interface{}{}
-	}
-	annotations[deploymentChangeCauseAnnotation] = changeCause
-	metadata["annotations"] = annotations
-	doc["metadata"] = metadata
-	return json.Marshal(doc)
+	_, err = rollbacker.Rollback(obj, nil, targetRevision, cmdutil.DryRunNone)
+	return err
 }

--- a/ui/src/components/deployment-revisions-table.tsx
+++ b/ui/src/components/deployment-revisions-table.tsx
@@ -40,7 +40,7 @@ function DeploymentRollbackButton({
       await onRollback(item.revision)
       setOpen(false)
     } catch (error) {
-      toast.error(translateError(error, t))
+      // onRollback is responsible for surfacing errors
     }
   }
 

--- a/ui/src/components/deployment-revisions-table.tsx
+++ b/ui/src/components/deployment-revisions-table.tsx
@@ -1,0 +1,236 @@
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { toast } from 'sonner'
+
+import { DeploymentRevisionItem } from '@/types/api'
+import { rollbackDeployment, useDeploymentRevisions } from '@/lib/api'
+import { formatDate, translateError } from '@/lib/utils'
+
+import { SimpleTable } from './simple-table'
+import { Button } from './ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from './ui/card'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from './ui/dialog'
+
+function DeploymentRollbackButton({
+  item,
+  namespace,
+  name,
+  disabled,
+  onRollback,
+}: {
+  item: DeploymentRevisionItem
+  namespace: string
+  name: string
+  disabled: boolean
+  onRollback: (revision: number) => Promise<void>
+}) {
+  const { t } = useTranslation()
+  const [open, setOpen] = useState(false)
+
+  const handleConfirm = async () => {
+    await onRollback(item.revision)
+    setOpen(false)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button
+          variant="outline"
+          size="sm"
+          className="w-24"
+          disabled={disabled}
+        >
+          {t('deployments.actions.rollback')}
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="!max-w-md sm:!max-w-md">
+        <DialogHeader>
+          <DialogTitle>
+            {t('deployments.messages.rollbackConfirmTitle')}
+          </DialogTitle>
+          <DialogDescription>
+            {t('deployments.messages.rollbackConfirmDescription', {
+              namespace,
+              name,
+              revision: item.revision,
+            })}
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => setOpen(false)}
+            disabled={disabled}
+          >
+            {t('common.actions.cancel')}
+          </Button>
+          <Button
+            type="button"
+            variant="destructive"
+            onClick={() => void handleConfirm()}
+            disabled={disabled}
+          >
+            {t('deployments.actions.rollback')}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+export function DeploymentRevisionsTable({
+  namespace,
+  name,
+  onRollbackComplete,
+}: {
+  namespace: string
+  name: string
+  onRollbackComplete: () => Promise<unknown>
+}) {
+  const { t } = useTranslation()
+  const [rollingBackRevision, setRollingBackRevision] = useState<number | null>(
+    null
+  )
+  const {
+    data,
+    isLoading,
+    isError,
+    error,
+    refetch: refetchRevisions,
+  } = useDeploymentRevisions(namespace, name)
+
+  const handleRollback = async (revision: number) => {
+    setRollingBackRevision(revision)
+    try {
+      await rollbackDeployment(namespace, name, revision)
+      toast.success(t('deployments.messages.rollbackStarted'))
+      await Promise.all([refetchRevisions(), onRollbackComplete()])
+    } catch (err) {
+      toast.error(translateError(err, t))
+    } finally {
+      setRollingBackRevision(null)
+    }
+  }
+
+  if (isLoading) {
+    return (
+      <Card>
+        <CardContent className="pt-6 text-sm text-muted-foreground">
+          {t('common.messages.loading')}
+        </CardContent>
+      </Card>
+    )
+  }
+
+  if (isError) {
+    return (
+      <Card>
+        <CardContent className="pt-6 text-sm text-destructive">
+          {translateError(error, t)}
+        </CardContent>
+      </Card>
+    )
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{t('common.tabs.revisions')}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <SimpleTable
+          data={data?.items || []}
+          emptyMessage={t('deployments.messages.noRevisions')}
+          columns={[
+            {
+              header: t('common.fields.revision'),
+              accessor: (item) => item.revision,
+              cell: (value) => (
+                <span className="font-medium tabular-nums">
+                  {value as number}
+                </span>
+              ),
+            },
+            {
+              header: t('deployments.fields.replicaSet'),
+              accessor: (item) => item.replicaSet,
+              cell: (value) => value as string,
+              align: 'left',
+            },
+            {
+              header: t('common.fields.updated'),
+              accessor: (item) => item.createdAt,
+              cell: (value) => (
+                <span className="text-sm text-muted-foreground">
+                  {value ? formatDate(value as string) : '-'}
+                </span>
+              ),
+              align: 'left',
+            },
+            {
+              header: t('common.tabs.containers'),
+              accessor: (item) => item.images,
+              cell: (value) => (
+                <div className="max-w-md whitespace-pre-wrap break-words text-xs text-muted-foreground">
+                  {((value as string[]) || []).join(', ') || '-'}
+                </div>
+              ),
+              align: 'left',
+            },
+            {
+              header: t('deployments.fields.changeCause'),
+              accessor: (item) => item.changeCause || '-',
+              cell: (value) => (
+                <span className="text-sm text-muted-foreground">
+                  {value as string}
+                </span>
+              ),
+              align: 'left',
+            },
+            {
+              header: t('common.fields.actions'),
+              accessor: (item) => item,
+              cell: (value) => {
+                const item = value as DeploymentRevisionItem
+                return (
+                  <div className="ml-auto w-max">
+                    {item.current ? (
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        className="w-24"
+                        disabled
+                      >
+                        {t('common.fields.current')}
+                      </Button>
+                    ) : (
+                      <DeploymentRollbackButton
+                        item={item}
+                        namespace={namespace}
+                        name={name}
+                        disabled={rollingBackRevision !== null}
+                        onRollback={handleRollback}
+                      />
+                    )}
+                  </div>
+                )
+              },
+              align: 'right',
+            },
+          ]}
+          pagination={{ enabled: true, pageSize: 10 }}
+        />
+      </CardContent>
+    </Card>
+  )
+}

--- a/ui/src/components/deployment-revisions-table.tsx
+++ b/ui/src/components/deployment-revisions-table.tsx
@@ -36,12 +36,8 @@ function DeploymentRollbackButton({
   const [open, setOpen] = useState(false)
 
   const handleConfirm = async () => {
-    try {
-      await onRollback(item.revision)
-      setOpen(false)
-    } catch (error) {
-      // onRollback is responsible for surfacing errors
-    }
+    await onRollback(item.revision)
+    setOpen(false)
   }
 
   return (

--- a/ui/src/components/deployment-revisions-table.tsx
+++ b/ui/src/components/deployment-revisions-table.tsx
@@ -36,8 +36,12 @@ function DeploymentRollbackButton({
   const [open, setOpen] = useState(false)
 
   const handleConfirm = async () => {
-    await onRollback(item.revision)
-    setOpen(false)
+    try {
+      await onRollback(item.revision)
+      setOpen(false)
+    } catch (error) {
+      toast.error(translateError(error, t))
+    }
   }
 
   return (

--- a/ui/src/components/deployment-revisions-table.tsx
+++ b/ui/src/components/deployment-revisions-table.tsx
@@ -168,7 +168,7 @@ export function DeploymentRevisionsTable({
               align: 'left',
             },
             {
-              header: t('common.fields.updated'),
+              header: t('common.fields.created'),
               accessor: (item) => item.createdAt,
               cell: (value) => (
                 <span className="text-sm text-muted-foreground">

--- a/ui/src/components/deployment-revisions-table.tsx
+++ b/ui/src/components/deployment-revisions-table.tsx
@@ -168,6 +168,14 @@ export function DeploymentRevisionsTable({
               align: 'left',
             },
             {
+              header: t('common.fields.replicas'),
+              accessor: (item) => item.replicas,
+              cell: (value) => (
+                <span className="tabular-nums">{value as number}</span>
+              ),
+              align: 'left',
+            },
+            {
               header: t('common.fields.created'),
               accessor: (item) => item.createdAt,
               cell: (value) => (

--- a/ui/src/components/workload-history-tabs.tsx
+++ b/ui/src/components/workload-history-tabs.tsx
@@ -1,8 +1,8 @@
 import { useTranslation } from 'react-i18next'
 
 import { ResourceTypeMap, WorkloadRevisionResourceType } from '@/types/api'
-import { ResourceHistoryTable } from '@/components/resource-history-table'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { ResourceHistoryTable } from '@/components/resource-history-table'
 import { WorkloadRevisionsTable } from '@/components/workload-revisions-table'
 
 export function WorkloadHistoryTabs<T extends WorkloadRevisionResourceType>({

--- a/ui/src/components/workload-history-tabs.tsx
+++ b/ui/src/components/workload-history-tabs.tsx
@@ -1,0 +1,53 @@
+import { useTranslation } from 'react-i18next'
+
+import { ResourceTypeMap, WorkloadRevisionResourceType } from '@/types/api'
+import { ResourceHistoryTable } from '@/components/resource-history-table'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { WorkloadRevisionsTable } from '@/components/workload-revisions-table'
+
+export function WorkloadHistoryTabs<T extends WorkloadRevisionResourceType>({
+  resourceType,
+  namespace,
+  name,
+  resource,
+  onRollbackComplete,
+}: {
+  resourceType: T
+  namespace: string
+  name: string
+  resource: ResourceTypeMap[T]
+  onRollbackComplete: () => Promise<unknown>
+}) {
+  const { t } = useTranslation()
+
+  return (
+    <Tabs defaultValue="revisions" className="gap-3">
+      <TabsList className="gap-1">
+        <TabsTrigger value="revisions">
+          {t('workloads.tabs.rolloutRevisions')}
+        </TabsTrigger>
+        <TabsTrigger value="kiteAudit">
+          {t('workloads.tabs.kiteAudit')}
+        </TabsTrigger>
+      </TabsList>
+
+      <TabsContent value="revisions">
+        <WorkloadRevisionsTable
+          resourceType={resourceType}
+          namespace={namespace}
+          name={name}
+          onRollbackComplete={onRollbackComplete}
+        />
+      </TabsContent>
+
+      <TabsContent value="kiteAudit">
+        <ResourceHistoryTable
+          resourceType={resourceType}
+          name={name}
+          namespace={namespace}
+          currentResource={resource}
+        />
+      </TabsContent>
+    </Tabs>
+  )
+}

--- a/ui/src/components/workload-revisions-table.tsx
+++ b/ui/src/components/workload-revisions-table.tsx
@@ -2,13 +2,13 @@ import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
 
-import { DeploymentRevisionItem } from '@/types/api'
-import { rollbackDeployment, useDeploymentRevisions } from '@/lib/api'
+import { WorkloadRevisionItem, WorkloadRevisionResourceType } from '@/types/api'
+import { rollbackWorkload, useWorkloadRevisions } from '@/lib/api'
 import { formatDate, translateError } from '@/lib/utils'
 
 import { SimpleTable } from './simple-table'
 import { Button } from './ui/button'
-import { Card, CardContent, CardHeader, CardTitle } from './ui/card'
+import { Card, CardContent } from './ui/card'
 import {
   Dialog,
   DialogContent,
@@ -19,14 +19,20 @@ import {
   DialogTrigger,
 } from './ui/dialog'
 
-function DeploymentRollbackButton({
+const revisionObjectLabelKey: Record<WorkloadRevisionResourceType, string> = {
+  deployments: 'workloads.fields.replicaSet',
+  statefulsets: 'workloads.fields.controllerRevision',
+  daemonsets: 'workloads.fields.controllerRevision',
+}
+
+function WorkloadRollbackButton({
   item,
   namespace,
   name,
   disabled,
   onRollback,
 }: {
-  item: DeploymentRevisionItem
+  item: WorkloadRevisionItem
   namespace: string
   name: string
   disabled: boolean
@@ -49,16 +55,16 @@ function DeploymentRollbackButton({
           className="w-24"
           disabled={disabled}
         >
-          {t('deployments.actions.rollback')}
+          {t('workloads.actions.rollback')}
         </Button>
       </DialogTrigger>
       <DialogContent className="!max-w-md sm:!max-w-md">
         <DialogHeader>
           <DialogTitle>
-            {t('deployments.messages.rollbackConfirmTitle')}
+            {t('workloads.messages.rollbackConfirmTitle')}
           </DialogTitle>
           <DialogDescription>
-            {t('deployments.messages.rollbackConfirmDescription', {
+            {t('workloads.messages.rollbackConfirmDescription', {
               namespace,
               name,
               revision: item.revision,
@@ -80,7 +86,7 @@ function DeploymentRollbackButton({
             onClick={() => void handleConfirm()}
             disabled={disabled}
           >
-            {t('deployments.actions.rollback')}
+            {t('workloads.actions.rollback')}
           </Button>
         </DialogFooter>
       </DialogContent>
@@ -88,32 +94,34 @@ function DeploymentRollbackButton({
   )
 }
 
-export function DeploymentRevisionsTable({
+export function WorkloadRevisionsTable({
+  resourceType,
   namespace,
   name,
   onRollbackComplete,
 }: {
+  resourceType: WorkloadRevisionResourceType
   namespace: string
   name: string
   onRollbackComplete: () => Promise<unknown>
 }) {
   const { t } = useTranslation()
-  const [rollingBackRevision, setRollingBackRevision] = useState<number | null>(
-    null
-  )
+  const [rollingBackRevision, setRollingBackRevision] = useState<
+    number | null
+  >(null)
   const {
     data,
     isLoading,
     isError,
     error,
     refetch: refetchRevisions,
-  } = useDeploymentRevisions(namespace, name)
+  } = useWorkloadRevisions(resourceType, namespace, name)
 
   const handleRollback = async (revision: number) => {
     setRollingBackRevision(revision)
     try {
-      await rollbackDeployment(namespace, name, revision)
-      toast.success(t('deployments.messages.rollbackStarted'))
+      await rollbackWorkload(resourceType, namespace, name, revision)
+      toast.success(t('workloads.messages.rollbackStarted'))
       await Promise.all([refetchRevisions(), onRollbackComplete()])
     } catch (err) {
       toast.error(translateError(err, t))
@@ -144,13 +152,10 @@ export function DeploymentRevisionsTable({
 
   return (
     <Card>
-      <CardHeader>
-        <CardTitle>{t('common.tabs.revisions')}</CardTitle>
-      </CardHeader>
       <CardContent>
         <SimpleTable
           data={data?.items || []}
-          emptyMessage={t('deployments.messages.noRevisions')}
+          emptyMessage={t('workloads.messages.noRevisions')}
           columns={[
             {
               header: t('common.fields.revision'),
@@ -162,8 +167,8 @@ export function DeploymentRevisionsTable({
               ),
             },
             {
-              header: t('deployments.fields.replicaSet'),
-              accessor: (item) => item.replicaSet,
+              header: t(revisionObjectLabelKey[resourceType]),
+              accessor: (item) => item.revisionObject,
               cell: (value) => value as string,
               align: 'left',
             },
@@ -171,7 +176,9 @@ export function DeploymentRevisionsTable({
               header: t('common.fields.replicas'),
               accessor: (item) => item.replicas,
               cell: (value) => (
-                <span className="tabular-nums">{value as number}</span>
+                <span className="tabular-nums">
+                  {value === undefined ? '-' : (value as number)}
+                </span>
               ),
               align: 'left',
             },
@@ -196,7 +203,7 @@ export function DeploymentRevisionsTable({
               align: 'left',
             },
             {
-              header: t('deployments.fields.changeCause'),
+              header: t('workloads.fields.changeCause'),
               accessor: (item) => item.changeCause || '-',
               cell: (value) => (
                 <span className="text-sm text-muted-foreground">
@@ -209,7 +216,7 @@ export function DeploymentRevisionsTable({
               header: t('common.fields.actions'),
               accessor: (item) => item,
               cell: (value) => {
-                const item = value as DeploymentRevisionItem
+                const item = value as WorkloadRevisionItem
                 return (
                   <div className="ml-auto w-max">
                     {item.current ? (
@@ -222,7 +229,7 @@ export function DeploymentRevisionsTable({
                         {t('common.fields.current')}
                       </Button>
                     ) : (
-                      <DeploymentRollbackButton
+                      <WorkloadRollbackButton
                         item={item}
                         namespace={namespace}
                         name={name}

--- a/ui/src/components/workload-revisions-table.tsx
+++ b/ui/src/components/workload-revisions-table.tsx
@@ -6,7 +6,7 @@ import { WorkloadRevisionItem, WorkloadRevisionResourceType } from '@/types/api'
 import { rollbackWorkload, useWorkloadRevisions } from '@/lib/api'
 import { formatDate, translateError } from '@/lib/utils'
 
-import { SimpleTable } from './simple-table'
+import { Column, SimpleTable } from './simple-table'
 import { Button } from './ui/button'
 import { Card, CardContent } from './ui/card'
 import {
@@ -36,14 +36,15 @@ function WorkloadRollbackButton({
   namespace: string
   name: string
   disabled: boolean
-  onRollback: (revision: number) => Promise<void>
+  onRollback: (revision: number) => Promise<boolean>
 }) {
   const { t } = useTranslation()
   const [open, setOpen] = useState(false)
 
   const handleConfirm = async () => {
-    await onRollback(item.revision)
-    setOpen(false)
+    if (await onRollback(item.revision)) {
+      setOpen(false)
+    }
   }
 
   return (
@@ -106,9 +107,9 @@ export function WorkloadRevisionsTable({
   onRollbackComplete: () => Promise<unknown>
 }) {
   const { t } = useTranslation()
-  const [rollingBackRevision, setRollingBackRevision] = useState<
-    number | null
-  >(null)
+  const [rollingBackRevision, setRollingBackRevision] = useState<number | null>(
+    null
+  )
   const {
     data,
     isLoading,
@@ -121,13 +122,16 @@ export function WorkloadRevisionsTable({
     setRollingBackRevision(revision)
     try {
       await rollbackWorkload(resourceType, namespace, name, revision)
-      toast.success(t('workloads.messages.rollbackStarted'))
-      await Promise.all([refetchRevisions(), onRollbackComplete()])
     } catch (err) {
       toast.error(translateError(err, t))
-    } finally {
       setRollingBackRevision(null)
+      return false
     }
+
+    toast.success(t('workloads.messages.rollbackStarted'))
+    await Promise.allSettled([refetchRevisions(), onRollbackComplete()])
+    setRollingBackRevision(null)
+    return true
   }
 
   if (isLoading) {
@@ -150,99 +154,94 @@ export function WorkloadRevisionsTable({
     )
   }
 
+  const columns: Column<WorkloadRevisionItem>[] = [
+    {
+      header: t('common.fields.revision'),
+      accessor: (item) => item.revision,
+      cell: (value) => (
+        <span className="font-medium tabular-nums">{value as number}</span>
+      ),
+    },
+    {
+      header: t(revisionObjectLabelKey[resourceType]),
+      accessor: (item) => item.revisionObject,
+      cell: (value) => value as string,
+      align: 'left',
+    },
+    ...(resourceType === 'deployments'
+      ? [
+          {
+            header: t('common.fields.replicas'),
+            accessor: (item: WorkloadRevisionItem) => item.replicas,
+            cell: (value: unknown) => (
+              <span className="tabular-nums">{value as number}</span>
+            ),
+            align: 'left' as const,
+          },
+        ]
+      : []),
+    {
+      header: t('common.fields.created'),
+      accessor: (item) => item.createdAt,
+      cell: (value) => (
+        <span className="text-sm text-muted-foreground">
+          {value ? formatDate(value as string) : '-'}
+        </span>
+      ),
+      align: 'left',
+    },
+    {
+      header: t('common.tabs.containers'),
+      accessor: (item) => item.images,
+      cell: (value) => (
+        <div className="max-w-md whitespace-pre-wrap break-words text-xs text-muted-foreground">
+          {((value as string[]) || []).join(', ') || '-'}
+        </div>
+      ),
+      align: 'left',
+    },
+    {
+      header: t('workloads.fields.changeCause'),
+      accessor: (item) => item.changeCause || '-',
+      cell: (value) => (
+        <span className="text-sm text-muted-foreground">{value as string}</span>
+      ),
+      align: 'left',
+    },
+    {
+      header: t('common.fields.actions'),
+      accessor: (item) => item,
+      cell: (value) => {
+        const item = value as WorkloadRevisionItem
+        return (
+          <div className="ml-auto w-max">
+            {item.current ? (
+              <Button variant="outline" size="sm" className="w-24" disabled>
+                {t('common.fields.current')}
+              </Button>
+            ) : (
+              <WorkloadRollbackButton
+                item={item}
+                namespace={namespace}
+                name={name}
+                disabled={rollingBackRevision !== null}
+                onRollback={handleRollback}
+              />
+            )}
+          </div>
+        )
+      },
+      align: 'right',
+    },
+  ]
+
   return (
     <Card>
       <CardContent>
         <SimpleTable
-          data={data?.items || []}
+          data={data?.items ?? []}
           emptyMessage={t('workloads.messages.noRevisions')}
-          columns={[
-            {
-              header: t('common.fields.revision'),
-              accessor: (item) => item.revision,
-              cell: (value) => (
-                <span className="font-medium tabular-nums">
-                  {value as number}
-                </span>
-              ),
-            },
-            {
-              header: t(revisionObjectLabelKey[resourceType]),
-              accessor: (item) => item.revisionObject,
-              cell: (value) => value as string,
-              align: 'left',
-            },
-            {
-              header: t('common.fields.replicas'),
-              accessor: (item) => item.replicas,
-              cell: (value) => (
-                <span className="tabular-nums">
-                  {value === undefined ? '-' : (value as number)}
-                </span>
-              ),
-              align: 'left',
-            },
-            {
-              header: t('common.fields.created'),
-              accessor: (item) => item.createdAt,
-              cell: (value) => (
-                <span className="text-sm text-muted-foreground">
-                  {value ? formatDate(value as string) : '-'}
-                </span>
-              ),
-              align: 'left',
-            },
-            {
-              header: t('common.tabs.containers'),
-              accessor: (item) => item.images,
-              cell: (value) => (
-                <div className="max-w-md whitespace-pre-wrap break-words text-xs text-muted-foreground">
-                  {((value as string[]) || []).join(', ') || '-'}
-                </div>
-              ),
-              align: 'left',
-            },
-            {
-              header: t('workloads.fields.changeCause'),
-              accessor: (item) => item.changeCause || '-',
-              cell: (value) => (
-                <span className="text-sm text-muted-foreground">
-                  {value as string}
-                </span>
-              ),
-              align: 'left',
-            },
-            {
-              header: t('common.fields.actions'),
-              accessor: (item) => item,
-              cell: (value) => {
-                const item = value as WorkloadRevisionItem
-                return (
-                  <div className="ml-auto w-max">
-                    {item.current ? (
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        className="w-24"
-                        disabled
-                      >
-                        {t('common.fields.current')}
-                      </Button>
-                    ) : (
-                      <WorkloadRollbackButton
-                        item={item}
-                        namespace={namespace}
-                        name={name}
-                        disabled={rollingBackRevision !== null}
-                        onRollback={handleRollback}
-                      />
-                    )}
-                  </div>
-                )
-              },
-              align: 'right',
-            },
-          ]}
+          columns={columns}
           pagination={{ enabled: true, pageSize: 10 }}
         />
       </CardContent>

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -292,7 +292,6 @@
       "overview": "Overview",
       "pods": "Pods",
       "related": "Related",
-      "revisions": "Revisions",
       "terminal": "Terminal",
       "volumes": "Volumes",
       "yaml": "YAML"
@@ -501,19 +500,26 @@
     "servicePort": "Service Port",
     "targetPort": "Target Port",
     "exposeInvalidPort": "Port must be between 1 and 65535",
-    "exposeNoSelector": "No Deployment selector labels found to expose",
+    "exposeNoSelector": "No Deployment selector labels found to expose"
+  },
+  "workloads": {
     "actions": {
       "rollback": "Rollback"
     },
     "fields": {
       "replicaSet": "ReplicaSet",
+      "controllerRevision": "ControllerRevision",
       "changeCause": "Change Cause"
     },
     "messages": {
       "noRevisions": "No revision history found",
       "rollbackStarted": "Rollback requested",
-      "rollbackConfirmTitle": "Rollback deployment?",
+      "rollbackConfirmTitle": "Rollback?",
       "rollbackConfirmDescription": "Rollback {{namespace}}/{{name}} to revision {{revision}}."
+    },
+    "tabs": {
+      "rolloutRevisions": "Rollout Revisions",
+      "kiteAudit": "Kite Audit"
     }
   },
   "daemonsets": {

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -292,6 +292,7 @@
       "overview": "Overview",
       "pods": "Pods",
       "related": "Related",
+      "revisions": "Revisions",
       "terminal": "Terminal",
       "volumes": "Volumes",
       "yaml": "YAML"
@@ -500,7 +501,20 @@
     "servicePort": "Service Port",
     "targetPort": "Target Port",
     "exposeInvalidPort": "Port must be between 1 and 65535",
-    "exposeNoSelector": "No Deployment selector labels found to expose"
+    "exposeNoSelector": "No Deployment selector labels found to expose",
+    "actions": {
+      "rollback": "Rollback"
+    },
+    "fields": {
+      "replicaSet": "ReplicaSet",
+      "changeCause": "Change Cause"
+    },
+    "messages": {
+      "noRevisions": "No revision history found",
+      "rollbackStarted": "Rollback requested",
+      "rollbackConfirmTitle": "Rollback deployment?",
+      "rollbackConfirmDescription": "Rollback {{namespace}}/{{name}} to revision {{revision}}."
+    }
   },
   "daemonsets": {
     "title": "DaemonSets"

--- a/ui/src/i18n/locales/zh.json
+++ b/ui/src/i18n/locales/zh.json
@@ -292,6 +292,7 @@
       "overview": "概览",
       "pods": "Pods",
       "related": "相关资源",
+      "revisions": "版本历史",
       "terminal": "终端",
       "volumes": "卷",
       "yaml": "YAML"
@@ -505,7 +506,20 @@
     "servicePort": "Service 端口",
     "targetPort": "目标端口",
     "exposeInvalidPort": "端口必须在 1 到 65535 之间",
-    "exposeNoSelector": "Deployment 没有可用于暴露的 selector 标签"
+    "exposeNoSelector": "Deployment 没有可用于暴露的 selector 标签",
+    "actions": {
+      "rollback": "回滚"
+    },
+    "fields": {
+      "replicaSet": "ReplicaSet",
+      "changeCause": "变更原因"
+    },
+    "messages": {
+      "noRevisions": "未找到版本历史",
+      "rollbackStarted": "已发起回滚",
+      "rollbackConfirmTitle": "回滚 Deployment？",
+      "rollbackConfirmDescription": "将 {{namespace}}/{{name}} 回滚到版本 {{revision}}。"
+    }
   },
   "daemonsets": {
     "title": "DaemonSets"

--- a/ui/src/i18n/locales/zh.json
+++ b/ui/src/i18n/locales/zh.json
@@ -292,7 +292,6 @@
       "overview": "概览",
       "pods": "Pods",
       "related": "相关资源",
-      "revisions": "版本历史",
       "terminal": "终端",
       "volumes": "卷",
       "yaml": "YAML"
@@ -506,19 +505,26 @@
     "servicePort": "Service 端口",
     "targetPort": "目标端口",
     "exposeInvalidPort": "端口必须在 1 到 65535 之间",
-    "exposeNoSelector": "Deployment 没有可用于暴露的 selector 标签",
+    "exposeNoSelector": "Deployment 没有可用于暴露的 selector 标签"
+  },
+  "workloads": {
     "actions": {
       "rollback": "回滚"
     },
     "fields": {
       "replicaSet": "ReplicaSet",
+      "controllerRevision": "ControllerRevision",
       "changeCause": "变更原因"
     },
     "messages": {
       "noRevisions": "未找到版本历史",
       "rollbackStarted": "已发起回滚",
-      "rollbackConfirmTitle": "回滚 Deployment？",
+      "rollbackConfirmTitle": "回滚？",
       "rollbackConfirmDescription": "将 {{namespace}}/{{name}} 回滚到版本 {{revision}}。"
+    },
+    "tabs": {
+      "rolloutRevisions": "发布版本历史",
+      "kiteAudit": "Kite 审计记录"
     }
   },
   "daemonsets": {

--- a/ui/src/lib/api/core.ts
+++ b/ui/src/lib/api/core.ts
@@ -1072,7 +1072,7 @@ export const useDeploymentRevisions = (
     queryKey: ['deployment-revisions', namespace, name],
     queryFn: () => fetchDeploymentRevisions(namespace, name),
     enabled: options?.enabled ?? true,
-    staleTime: options?.staleTime || 30000,
+    staleTime: options?.staleTime ?? 30000,
   })
 }
 
@@ -1083,7 +1083,7 @@ export const rollbackDeployment = async (
 ): Promise<{ message?: string }> => {
   return apiClient.put<{ message?: string }>(
     `/deployments/${encodeURIComponent(namespace)}/${encodeURIComponent(name)}/rollback`,
-    revision ? { revision } : {}
+    revision !== undefined ? { revision } : {}
   )
 }
 

--- a/ui/src/lib/api/core.ts
+++ b/ui/src/lib/api/core.ts
@@ -1083,11 +1083,11 @@ export const rollbackWorkload = async (
   resourceType: WorkloadRevisionResourceType,
   namespace: string,
   name: string,
-  revision?: number
+  revision: number
 ): Promise<{ message?: string; revision?: number }> => {
   return apiClient.put<{ message?: string; revision?: number }>(
     `/${resourceType}/${encodeURIComponent(namespace)}/${encodeURIComponent(name)}/rollback`,
-    revision !== undefined ? { revision } : {}
+    { revision }
   )
 }
 

--- a/ui/src/lib/api/core.ts
+++ b/ui/src/lib/api/core.ts
@@ -1080,8 +1080,8 @@ export const rollbackDeployment = async (
   namespace: string,
   name: string,
   revision?: number
-): Promise<{ message?: string }> => {
-  return apiClient.put<{ message?: string }>(
+): Promise<{ message?: string; revision?: number }> => {
+  return apiClient.put<{ message?: string; revision?: number }>(
     `/deployments/${encodeURIComponent(namespace)}/${encodeURIComponent(name)}/rollback`,
     revision !== undefined ? { revision } : {}
   )

--- a/ui/src/lib/api/core.ts
+++ b/ui/src/lib/api/core.ts
@@ -3,7 +3,6 @@ import { useQuery } from '@tanstack/react-query'
 import { Pod } from 'kubernetes-types/core/v1'
 
 import {
-  DeploymentRevisionsResponse,
   HelmChartContent,
   HelmChartContentType,
   HelmChartDetail,
@@ -23,6 +22,8 @@ import {
   ResourceTemplate,
   ResourceType,
   ResourceTypeMap,
+  WorkloadRevisionResourceType,
+  WorkloadRevisionsResponse,
 } from '@/types/api'
 import { getResourceQueryKey } from '@/lib/resource-metadata'
 import { useCluster } from '@/hooks/use-cluster'
@@ -1054,35 +1055,38 @@ export const fetchResourceHistory = (
   return fetchAPI<ResourceHistoryResponse>(endpoint)
 }
 
-export const fetchDeploymentRevisions = (
+export const fetchWorkloadRevisions = (
+  resourceType: WorkloadRevisionResourceType,
   namespace: string,
   name: string
-): Promise<DeploymentRevisionsResponse> => {
-  return fetchAPI<DeploymentRevisionsResponse>(
-    `/deployments/${encodeURIComponent(namespace)}/${encodeURIComponent(name)}/revisions`
+): Promise<WorkloadRevisionsResponse> => {
+  return fetchAPI<WorkloadRevisionsResponse>(
+    `/${resourceType}/${encodeURIComponent(namespace)}/${encodeURIComponent(name)}/revisions`
   )
 }
 
-export const useDeploymentRevisions = (
+export const useWorkloadRevisions = (
+  resourceType: WorkloadRevisionResourceType,
   namespace: string,
   name: string,
   options?: { enabled?: boolean; staleTime?: number }
 ) => {
   return useQuery({
-    queryKey: ['deployment-revisions', namespace, name],
-    queryFn: () => fetchDeploymentRevisions(namespace, name),
+    queryKey: ['workload-revisions', resourceType, namespace, name],
+    queryFn: () => fetchWorkloadRevisions(resourceType, namespace, name),
     enabled: options?.enabled ?? true,
     staleTime: options?.staleTime ?? 30000,
   })
 }
 
-export const rollbackDeployment = async (
+export const rollbackWorkload = async (
+  resourceType: WorkloadRevisionResourceType,
   namespace: string,
   name: string,
   revision?: number
 ): Promise<{ message?: string; revision?: number }> => {
   return apiClient.put<{ message?: string; revision?: number }>(
-    `/deployments/${encodeURIComponent(namespace)}/${encodeURIComponent(name)}/rollback`,
+    `/${resourceType}/${encodeURIComponent(namespace)}/${encodeURIComponent(name)}/rollback`,
     revision !== undefined ? { revision } : {}
   )
 }

--- a/ui/src/lib/api/core.ts
+++ b/ui/src/lib/api/core.ts
@@ -3,6 +3,7 @@ import { useQuery } from '@tanstack/react-query'
 import { Pod } from 'kubernetes-types/core/v1'
 
 import {
+  DeploymentRevisionsResponse,
   HelmChartContent,
   HelmChartContentType,
   HelmChartDetail,
@@ -1051,6 +1052,39 @@ export const fetchResourceHistory = (
 ): Promise<ResourceHistoryResponse> => {
   const endpoint = `/${resourceType}/${namespace}/${name}/history?page=${page}&pageSize=${pageSize}`
   return fetchAPI<ResourceHistoryResponse>(endpoint)
+}
+
+export const fetchDeploymentRevisions = (
+  namespace: string,
+  name: string
+): Promise<DeploymentRevisionsResponse> => {
+  return fetchAPI<DeploymentRevisionsResponse>(
+    `/deployments/${encodeURIComponent(namespace)}/${encodeURIComponent(name)}/revisions`
+  )
+}
+
+export const useDeploymentRevisions = (
+  namespace: string,
+  name: string,
+  options?: { enabled?: boolean; staleTime?: number }
+) => {
+  return useQuery({
+    queryKey: ['deployment-revisions', namespace, name],
+    queryFn: () => fetchDeploymentRevisions(namespace, name),
+    enabled: options?.enabled ?? true,
+    staleTime: options?.staleTime || 30000,
+  })
+}
+
+export const rollbackDeployment = async (
+  namespace: string,
+  name: string,
+  revision?: number
+): Promise<{ message?: string }> => {
+  return apiClient.put<{ message?: string }>(
+    `/deployments/${encodeURIComponent(namespace)}/${encodeURIComponent(name)}/rollback`,
+    revision ? { revision } : {}
+  )
 }
 
 export const useResourceHistory = (

--- a/ui/src/pages/daemonset-detail.tsx
+++ b/ui/src/pages/daemonset-detail.tsx
@@ -26,9 +26,9 @@ import { LogViewer } from '@/components/log-viewer'
 import { PodMonitoring } from '@/components/pod-monitoring'
 import { PodTable } from '@/components/pod-table'
 import { RelatedResourcesTable } from '@/components/related-resource-table'
-import { ResourceHistoryTable } from '@/components/resource-history-table'
 import { Terminal } from '@/components/terminal'
 import { VolumeTable } from '@/components/volume-table'
+import { WorkloadHistoryTabs } from '@/components/workload-history-tabs'
 
 import {
   ResourceDetailShell,
@@ -267,11 +267,12 @@ export function DaemonSetDetail(props: { namespace: string; name: string }) {
         value: 'history',
         label: t('common.tabs.history', { defaultValue: 'History' }),
         content: daemonset ? (
-          <ResourceHistoryTable
+          <WorkloadHistoryTabs
             resourceType="daemonsets"
-            name={name}
             namespace={namespace}
-            currentResource={daemonset}
+            name={name}
+            resource={daemonset}
+            onRollbackComplete={refetch}
           />
         ) : null,
       },
@@ -307,6 +308,7 @@ export function DaemonSetDetail(props: { namespace: string; name: string }) {
     labelSelector,
     name,
     namespace,
+    refetch,
     relatedPods,
     t,
   ])

--- a/ui/src/pages/deployment-detail.tsx
+++ b/ui/src/pages/deployment-detail.tsx
@@ -42,6 +42,7 @@ import {
 } from '@/components/ui/select'
 import { ContainerInfoCard } from '@/components/container-info-card'
 import { DeploymentOverview } from '@/components/deployment-overview'
+import { DeploymentRevisionsTable } from '@/components/deployment-revisions-table'
 import { EventTable } from '@/components/event-table'
 import { LogViewer } from '@/components/log-viewer'
 import { PodMonitoring } from '@/components/pod-monitoring'
@@ -386,6 +387,17 @@ export function DeploymentDetail(props: { namespace: string; name: string }) {
         ),
       },
       {
+        value: 'revisions',
+        label: t('common.tabs.revisions'),
+        content: (
+          <DeploymentRevisionsTable
+            namespace={namespace}
+            name={name}
+            onRollbackComplete={refetch}
+          />
+        ),
+      },
+      {
         value: 'history',
         label: t('common.tabs.history'),
         content: deployment ? (
@@ -460,6 +472,7 @@ export function DeploymentDetail(props: { namespace: string; name: string }) {
     handleContainerUpdate,
     name,
     namespace,
+    refetch,
     relatedPods,
     t,
   ])

--- a/ui/src/pages/deployment-detail.tsx
+++ b/ui/src/pages/deployment-detail.tsx
@@ -42,15 +42,14 @@ import {
 } from '@/components/ui/select'
 import { ContainerInfoCard } from '@/components/container-info-card'
 import { DeploymentOverview } from '@/components/deployment-overview'
-import { DeploymentRevisionsTable } from '@/components/deployment-revisions-table'
 import { EventTable } from '@/components/event-table'
 import { LogViewer } from '@/components/log-viewer'
 import { PodMonitoring } from '@/components/pod-monitoring'
 import { PodTable } from '@/components/pod-table'
 import { RelatedResourcesTable } from '@/components/related-resource-table'
-import { ResourceHistoryTable } from '@/components/resource-history-table'
 import { Terminal } from '@/components/terminal'
 import { VolumeTable } from '@/components/volume-table'
+import { WorkloadHistoryTabs } from '@/components/workload-history-tabs'
 
 import {
   ResourceDetailShell,
@@ -387,25 +386,15 @@ export function DeploymentDetail(props: { namespace: string; name: string }) {
         ),
       },
       {
-        value: 'revisions',
-        label: t('common.tabs.revisions'),
-        content: (
-          <DeploymentRevisionsTable
-            namespace={namespace}
-            name={name}
-            onRollbackComplete={refetch}
-          />
-        ),
-      },
-      {
         value: 'history',
         label: t('common.tabs.history'),
         content: deployment ? (
-          <ResourceHistoryTable
+          <WorkloadHistoryTabs
             resourceType="deployments"
-            name={name}
             namespace={namespace}
-            currentResource={deployment}
+            name={name}
+            resource={deployment}
+            onRollbackComplete={refetch}
           />
         ) : null,
       }

--- a/ui/src/pages/statefulset-detail.tsx
+++ b/ui/src/pages/statefulset-detail.tsx
@@ -27,10 +27,10 @@ import { LogViewer } from '@/components/log-viewer'
 import { PodMonitoring } from '@/components/pod-monitoring'
 import { PodTable } from '@/components/pod-table'
 import { RelatedResourcesTable } from '@/components/related-resource-table'
-import { ResourceHistoryTable } from '@/components/resource-history-table'
 import { StatefulSetOverview } from '@/components/statefulset-overview'
 import { Terminal } from '@/components/terminal'
 import { VolumeTable } from '@/components/volume-table'
+import { WorkloadHistoryTabs } from '@/components/workload-history-tabs'
 
 import {
   ResourceDetailShell,
@@ -308,11 +308,12 @@ export function StatefulSetDetail(props: { namespace: string; name: string }) {
         value: 'history',
         label: t('common.tabs.history', { defaultValue: 'History' }),
         content: statefulset ? (
-          <ResourceHistoryTable
+          <WorkloadHistoryTabs
             resourceType="statefulsets"
-            name={name}
             namespace={namespace}
-            currentResource={statefulset}
+            name={name}
+            resource={statefulset}
+            onRollbackComplete={refetch}
           />
         ) : null,
       },
@@ -349,6 +350,7 @@ export function StatefulSetDetail(props: { namespace: string; name: string }) {
     labelSelector,
     name,
     namespace,
+    refetch,
     relatedPods,
     statefulset,
     t,

--- a/ui/src/types/api.ts
+++ b/ui/src/types/api.ts
@@ -745,6 +745,20 @@ export interface ResourceHistoryResponse {
   }
 }
 
+export interface DeploymentRevisionItem {
+  revision: number
+  replicaSet: string
+  changeCause?: string
+  images: string[]
+  replicas: number
+  createdAt: string
+  current: boolean
+}
+
+export interface DeploymentRevisionsResponse {
+  items: DeploymentRevisionItem[]
+}
+
 export interface AuditLogResponse {
   data: ResourceHistory[]
   total: number

--- a/ui/src/types/api.ts
+++ b/ui/src/types/api.ts
@@ -746,18 +746,13 @@ export interface ResourceHistoryResponse {
 }
 
 export type WorkloadRevisionResourceType =
-  | 'deployments'
-  | 'statefulsets'
-  | 'daemonsets'
+  'deployments' | 'statefulsets' | 'daemonsets'
 
 export interface WorkloadRevisionItem {
   revision: number
   revisionObject: string
   changeCause?: string
   images: string[]
-  // Only present for Deployments, where the owned ReplicaSet tracks its own
-  // replica count. StatefulSet/DaemonSet revisions are point-in-time
-  // template snapshots (ControllerRevisions) with no replica count.
   replicas?: number
   createdAt: string
   current: boolean

--- a/ui/src/types/api.ts
+++ b/ui/src/types/api.ts
@@ -745,18 +745,26 @@ export interface ResourceHistoryResponse {
   }
 }
 
-export interface DeploymentRevisionItem {
+export type WorkloadRevisionResourceType =
+  | 'deployments'
+  | 'statefulsets'
+  | 'daemonsets'
+
+export interface WorkloadRevisionItem {
   revision: number
-  replicaSet: string
+  revisionObject: string
   changeCause?: string
   images: string[]
-  replicas: number
+  // Only present for Deployments, where the owned ReplicaSet tracks its own
+  // replica count. StatefulSet/DaemonSet revisions are point-in-time
+  // template snapshots (ControllerRevisions) with no replica count.
+  replicas?: number
   createdAt: string
   current: boolean
 }
 
-export interface DeploymentRevisionsResponse {
-  items: DeploymentRevisionItem[]
+export interface WorkloadRevisionsResponse {
+  items: WorkloadRevisionItem[]
 }
 
 export interface AuditLogResponse {


### PR DESCRIPTION
## Summary

Adds a **Revisions** tab to the Deployment detail page showing real Kubernetes rollout history (`kubectl rollout history`-equivalent), with a **Rollback** action to revert to any previous revision (`kubectl rollout undo`-equivalent).

- Backend: `GET /deployments/:namespace/:name/revisions` lists the ReplicaSets owned by a Deployment, sorted by the `deployment.kubernetes.io/revision` annotation, with images, replica count, and the `kubernetes.io/change-cause` annotation. `PUT /deployments/:namespace/:name/rollback` reverts the Deployment's pod template to a target revision (or the previous one by default), mirroring `kubectl rollout undo`. Rollbacks are recorded in Kite's existing audit history.
- Frontend: new `DeploymentRevisionsTable` component wired into the Deployment detail page's "Revisions" tab, with a confirmation dialog before rolling back, following the same pattern as the existing HelmRelease rollback UI.

## Why

Kite's existing "History" tab only shows Kite's own internal audit log of changes made through Kite itself. It doesn't surface revisions created by external tools (e.g. a Jenkins pipeline deploying directly to the cluster), so there was no way to see or roll back to a prior deployment state without re-running the external pipeline.

## Related issue

Closes #535

## Validation

- `go build ./...`, `go vet ./pkg/resources/...`, `go test ./pkg/resources/...` all pass.
- Frontend `pnpm run type-check`, `pnpm run lint`, `pnpm run test`, `pnpm run build` all pass.
- Manually verified end-to-end against a local k3d cluster: created a Deployment with 3 revisions (distinct images + `change-cause` annotations, simulating external/Jenkins deploys), confirmed `GET .../revisions` returns them in the correct order with `current` flagged correctly, and confirmed `PUT .../rollback` correctly reverts the Deployment's image and that Kubernetes reuses/bumps the matching old ReplicaSet's revision, matching `kubectl rollout undo` semantics.

## Checklist

- [x] I reviewed this PR myself before requesting review.
- [x] I understand the changes, including AI-generated parts (if any).
- [x] For new features, a feature request issue is linked.
- [ ] I cleaned up AI noise (unnecessary comments, dead code, and unrelated changes).
- [x] This PR is reasonably scoped (or split into smaller PRs).
