### PR TITLE
increase prometheus_url length to 512

### DIFF
--- a/pkg/model/cluster.go
+++ b/pkg/model/cluster.go
@@ -5,7 +5,7 @@ type Cluster struct {
 	Name          string       `json:"name" gorm:"type:varchar(100);uniqueIndex;not null"`
 	Description   string       `json:"description" gorm:"type:text"`
 	Config        SecretString `json:"config" gorm:"type:text"`
-	PrometheusURL string       `json:"prometheus_url,omitempty" gorm:"type:varchar(255)"`
+	PrometheusURL string       `json:"prometheus_url,omitempty" gorm:"type:varchar(512)"`
 	InCluster     bool         `json:"in_cluster" gorm:"type:boolean;default:false"`
 	IsDefault     bool         `json:"is_default" gorm:"type:boolean;default:false"`
 	Enable        bool         `json:"enable" gorm:"type:boolean;default:true"`


### PR DESCRIPTION
## Summary

<!-- What does this PR change? Keep it short. -->
change prometheus_url length to 512

## Why

<!-- Why is this change needed? -->
https://help.aliyun.com/zh/sls/collection-of-alibaba-cloud-service-logs/ 

阿里云这个名字太长 http://ak:sk@workspace-default-cms-1xxxxxxxx0-cn-hangzhou.cn-hangzhou-intranet.log.aliyuncs.com/prometheus/workspace-default-cms-1xxxxxxxx0-cn-hangzhou/aliyun-prom-ixxxxxxxxd

## Related issue

<!-- For new features, please open and link a feature request issue first. -->

#486 方式支持的长度太短了

Closes #

## Validation

<!-- How did you test this change? -->

## Checklist

- [ ] I reviewed this PR myself before requesting review.
- [ ] I understand the changes, including AI-generated parts (if any).
- [ ] For new features, a feature request issue is linked.
- [ ] I cleaned up AI noise (unnecessary comments, dead code, and unrelated changes).
- [ ] This PR is reasonably scoped (or split into smaller PRs).
