### PR TITLE
feat(ui): add aggregated Policies page

### DIFF
--- a/ui/src/components/settings/rbac-dialog.tsx
+++ b/ui/src/components/settings/rbac-dialog.tsx
@@ -55,6 +55,7 @@ const RESOURCE_SUGGESTIONS = [
   '*',
   ...resourceCatalog
     .filter((resource) => resource.type !== 'crs')
+    .filter((resource) => !('synthetic' in resource && resource.synthetic))
     .map((resource) => resource.type),
 ]
 

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -120,6 +120,7 @@
       "kernelVersion": "Kernel Version",
       "key": "Key",
       "keys": "Keys",
+      "kind": "Kind",
       "kubeProxyVersion": "Kube Proxy Version",
       "kubeletVersion": "Kubelet Version",
       "labels": "Labels",
@@ -380,6 +381,12 @@
     "unsetGlobalError": "Failed to disable global sidebar",
     "updateAvailable": "A newer Kite version is available"
   },
+  "policies": {
+    "searchPlaceholder": "Search policies...",
+    "allKinds": "All kinds",
+    "empty": "No policies found",
+    "partialError": "Some policy types failed to load; the list may be incomplete."
+  },
   "nav": {
     "overview": "Overview",
     "pods": "Pods",
@@ -440,6 +447,7 @@
     "podgroups": "PodGroups",
     "flowschemas": "FlowSchemas",
     "prioritylevelconfigurations": "PriorityLevelConfigurations",
+    "policies": "Policies",
     "validatingadmissionpolicies": "ValidatingAdmissionPolicies",
     "validatingadmissionpolicybindings": "ValidatingAdmissionPolicyBindings",
     "validatingwebhookconfigurations": "ValidatingWebhookConfigurations",

--- a/ui/src/i18n/locales/zh.json
+++ b/ui/src/i18n/locales/zh.json
@@ -118,6 +118,7 @@
       "kernelVersion": "内核版本",
       "key": "键",
       "keys": "键",
+      "kind": "类型",
       "kubeProxyVersion": "Kube-Proxy 版本",
       "kubeletVersion": "Kubelet 版本",
       "labels": "标签",
@@ -384,6 +385,12 @@
     "collapse": "收起",
     "updateAvailable": "有新的 Kite 版本可用"
   },
+  "policies": {
+    "searchPlaceholder": "搜索策略...",
+    "allKinds": "所有类型",
+    "empty": "未找到策略",
+    "partialError": "部分策略类型加载失败，列表可能不完整。"
+  },
   "nav": {
     "overview": "概览",
     "workloads": "工作负载",
@@ -445,6 +452,7 @@
     "podgroups": "PodGroups",
     "flowschemas": "FlowSchemas",
     "prioritylevelconfigurations": "PriorityLevelConfigurations",
+    "policies": "策略",
     "validatingadmissionpolicies": "ValidatingAdmissionPolicies",
     "validatingadmissionpolicybindings": "ValidatingAdmissionPolicyBindings",
     "validatingwebhookconfigurations": "ValidatingWebhookConfigurations",

--- a/ui/src/lib/resource-catalog.ts
+++ b/ui/src/lib/resource-catalog.ts
@@ -72,6 +72,7 @@ interface ResourceCatalogEntryBase {
   pluralLabel: string
   shortLabel?: string
   clusterScope: boolean
+  synthetic?: boolean
   titleKey?: string
   icon?: ResourceIconName
   sidebar?: {
@@ -245,7 +246,7 @@ export const resourceCatalog = [
     clusterScope: true,
     titleKey: 'nav.crds',
     icon: 'IconCode',
-    sidebar: { groupKey: 'sidebar.groups.other', order: 3 },
+    sidebar: { groupKey: 'sidebar.groups.other', order: 4 },
   },
   {
     type: 'crs',
@@ -637,6 +638,17 @@ export const resourceCatalog = [
     },
   },
   {
+    type: 'policies',
+    singular: 'policy',
+    singularLabel: 'Policy',
+    pluralLabel: 'Policies',
+    clusterScope: true,
+    synthetic: true,
+    titleKey: 'nav.policies',
+    icon: 'IconShieldCheck',
+    sidebar: { groupKey: 'sidebar.groups.other', order: 3 },
+  },
+  {
     type: 'validatingadmissionpolicies',
     singular: 'validatingadmissionpolicy',
     singularLabel: 'ValidatingAdmissionPolicy',
@@ -644,11 +656,6 @@ export const resourceCatalog = [
     clusterScope: true,
     titleKey: 'nav.validatingadmissionpolicies',
     icon: 'IconShieldCheck',
-    sidebar: {
-      groupKey: 'sidebar.groups.other',
-      order: 37,
-      defaultHidden: true,
-    },
   },
   {
     type: 'validatingadmissionpolicybindings',
@@ -658,11 +665,6 @@ export const resourceCatalog = [
     clusterScope: true,
     titleKey: 'nav.validatingadmissionpolicybindings',
     icon: 'IconShieldCheck',
-    sidebar: {
-      groupKey: 'sidebar.groups.other',
-      order: 38,
-      defaultHidden: true,
-    },
   },
   {
     type: 'validatingwebhookconfigurations',
@@ -672,11 +674,6 @@ export const resourceCatalog = [
     clusterScope: true,
     titleKey: 'nav.validatingwebhookconfigurations',
     icon: 'IconShieldCheck',
-    sidebar: {
-      groupKey: 'sidebar.groups.other',
-      order: 39,
-      defaultHidden: true,
-    },
   },
   {
     type: 'mutatingwebhookconfigurations',
@@ -686,11 +683,6 @@ export const resourceCatalog = [
     clusterScope: true,
     titleKey: 'nav.mutatingwebhookconfigurations',
     icon: 'IconShield',
-    sidebar: {
-      groupKey: 'sidebar.groups.other',
-      order: 40,
-      defaultHidden: true,
-    },
   },
   {
     type: 'mutatingadmissionpolicies',
@@ -700,11 +692,6 @@ export const resourceCatalog = [
     clusterScope: true,
     titleKey: 'nav.mutatingadmissionpolicies',
     icon: 'IconShield',
-    sidebar: {
-      groupKey: 'sidebar.groups.other',
-      order: 41,
-      defaultHidden: true,
-    },
   },
   {
     type: 'mutatingadmissionpolicybindings',
@@ -714,11 +701,6 @@ export const resourceCatalog = [
     clusterScope: true,
     titleKey: 'nav.mutatingadmissionpolicybindings',
     icon: 'IconShield',
-    sidebar: {
-      groupKey: 'sidebar.groups.other',
-      order: 42,
-      defaultHidden: true,
-    },
   },
   {
     type: 'resourceslices',
@@ -1007,8 +989,9 @@ export type ResourceMetadata = Omit<ResourceCatalogEntryBase, 'type'> & {
   type: ResourceType
 }
 
-export const resourceMetadataList: readonly ResourceMetadata[] =
-  resourceCatalog.map((item) => ({
+export const resourceMetadataList: readonly ResourceMetadata[] = resourceCatalog
+  .filter((item) => !('synthetic' in item && item.synthetic))
+  .map((item) => ({
     type: item.type,
     singular: item.singular,
     singularLabel: item.singularLabel,

--- a/ui/src/pages/policies-list-page.tsx
+++ b/ui/src/pages/policies-list-page.tsx
@@ -1,0 +1,284 @@
+import { useMemo } from 'react'
+import {
+  createColumnHelper,
+  getCoreRowModel,
+  getFilteredRowModel,
+  getPaginationRowModel,
+  getSortedRowModel,
+  useReactTable,
+} from '@tanstack/react-table'
+import { useTranslation } from 'react-i18next'
+import { Link } from 'react-router-dom'
+
+import { KubernetesResource, ResourceType } from '@/types/api'
+import { useResources } from '@/lib/api'
+import { createSearchFilter } from '@/lib/k8s'
+import { formatDate } from '@/lib/utils'
+import { useResourceTableState } from '@/hooks/use-resource-table-state'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import { Badge } from '@/components/ui/badge'
+import { Input } from '@/components/ui/input'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { ErrorMessage } from '@/components/error-message'
+import { ResourceTableView } from '@/components/resource-table-view'
+
+const POLICY_SOURCES: { resourceType: ResourceType; kind: string }[] = [
+  {
+    resourceType: 'validatingwebhookconfigurations',
+    kind: 'ValidatingWebhookConfiguration',
+  },
+  {
+    resourceType: 'mutatingwebhookconfigurations',
+    kind: 'MutatingWebhookConfiguration',
+  },
+  {
+    resourceType: 'validatingadmissionpolicies',
+    kind: 'ValidatingAdmissionPolicy',
+  },
+  {
+    resourceType: 'validatingadmissionpolicybindings',
+    kind: 'ValidatingAdmissionPolicyBinding',
+  },
+  {
+    resourceType: 'mutatingadmissionpolicies',
+    kind: 'MutatingAdmissionPolicy',
+  },
+  {
+    resourceType: 'mutatingadmissionpolicybindings',
+    kind: 'MutatingAdmissionPolicyBinding',
+  },
+]
+
+type PolicyRow = KubernetesResource & {
+  _kind: string
+  _resourceType: ResourceType
+}
+
+const columnHelper = createColumnHelper<PolicyRow>()
+
+const policySearchFilter = createSearchFilter<PolicyRow>(
+  (policy) => policy.metadata?.name,
+  (policy) => policy._kind
+)
+
+export function PoliciesListPage() {
+  const { t } = useTranslation()
+
+  const validatingWebhooks = useResources(
+    'validatingwebhookconfigurations',
+    undefined,
+    { reduce: true }
+  )
+  const mutatingWebhooks = useResources(
+    'mutatingwebhookconfigurations',
+    undefined,
+    { reduce: true }
+  )
+  const validatingPolicies = useResources(
+    'validatingadmissionpolicies',
+    undefined,
+    { reduce: true }
+  )
+  const validatingPolicyBindings = useResources(
+    'validatingadmissionpolicybindings',
+    undefined,
+    { reduce: true }
+  )
+  const mutatingPolicies = useResources(
+    'mutatingadmissionpolicies',
+    undefined,
+    { reduce: true }
+  )
+  const mutatingPolicyBindings = useResources(
+    'mutatingadmissionpolicybindings',
+    undefined,
+    { reduce: true }
+  )
+
+  const queries = [
+    validatingWebhooks,
+    mutatingWebhooks,
+    validatingPolicies,
+    validatingPolicyBindings,
+    mutatingPolicies,
+    mutatingPolicyBindings,
+  ]
+
+  const isLoading = queries.some((query) => query.isLoading)
+  const firstError = queries.find((query) => query.isError)?.error
+
+  const rows = useMemo(() => {
+    const dataByType: Partial<
+      Record<ResourceType, KubernetesResource[] | undefined>
+    > = {
+      validatingwebhookconfigurations: validatingWebhooks.data,
+      mutatingwebhookconfigurations: mutatingWebhooks.data,
+      validatingadmissionpolicies: validatingPolicies.data,
+      validatingadmissionpolicybindings: validatingPolicyBindings.data,
+      mutatingadmissionpolicies: mutatingPolicies.data,
+      mutatingadmissionpolicybindings: mutatingPolicyBindings.data,
+    }
+    return POLICY_SOURCES.flatMap((source) =>
+      (dataByType[source.resourceType] || []).map((item) => ({
+        ...item,
+        _kind: source.kind,
+        _resourceType: source.resourceType,
+      }))
+    )
+  }, [
+    validatingWebhooks.data,
+    mutatingWebhooks.data,
+    validatingPolicies.data,
+    validatingPolicyBindings.data,
+    mutatingPolicies.data,
+    mutatingPolicyBindings.data,
+  ])
+
+  const columns = useMemo(
+    () => [
+      columnHelper.accessor('metadata.name', {
+        header: t('common.fields.name'),
+        cell: ({ row }) => (
+          <div className="font-medium app-link">
+            <Link
+              to={`/${row.original._resourceType}/${row.original.metadata?.name}`}
+            >
+              {row.original.metadata?.name}
+            </Link>
+          </div>
+        ),
+      }),
+      columnHelper.accessor('_kind', {
+        id: 'kind',
+        header: t('common.fields.kind'),
+        filterFn: 'equalsString',
+        cell: ({ getValue }) => (
+          <Badge variant="outline" className="text-xs">
+            {getValue()}
+          </Badge>
+        ),
+      }),
+      columnHelper.accessor('metadata.creationTimestamp', {
+        id: 'created',
+        header: t('common.fields.created'),
+        cell: ({ getValue }) => (
+          <span className="text-muted-foreground text-sm">
+            {getValue() ? formatDate(getValue() as string) : '-'}
+          </span>
+        ),
+      }),
+    ],
+    [t]
+  )
+
+  const {
+    sorting,
+    setSorting,
+    columnFilters,
+    setColumnFilters,
+    searchQuery,
+    setSearchQuery,
+    debouncedSearchQuery,
+    pagination,
+    setPagination,
+  } = useResourceTableState({
+    resourceName: 'policies',
+    clusterScope: true,
+    defaultHiddenColumns: [],
+  })
+
+  const table = useReactTable<PolicyRow>({
+    data: rows,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
+    onSortingChange: setSorting,
+    onColumnFiltersChange: setColumnFilters,
+    onPaginationChange: setPagination,
+    getRowId: (row) => `${row._resourceType}/${row.metadata?.name}`,
+    globalFilterFn: (row, _columnId, value) =>
+      policySearchFilter(row.original, String(value)),
+    state: {
+      sorting,
+      columnFilters,
+      globalFilter: debouncedSearchQuery,
+      pagination,
+    },
+  })
+
+  const emptyState =
+    firstError && rows.length === 0 ? (
+      <ErrorMessage
+        resourceName={t('nav.policies')}
+        error={firstError as Error}
+        refetch={() => queries.forEach((query) => query.refetch())}
+      />
+    ) : !isLoading && rows.length === 0 ? (
+      <div className="h-72 flex flex-col items-center justify-center">
+        <h3 className="text-lg font-medium mb-1">{t('policies.empty')}</h3>
+      </div>
+    ) : null
+
+  return (
+    <div className="flex flex-col gap-3">
+      {firstError && rows.length > 0 ? (
+        <Alert variant="destructive">
+          <AlertDescription>{t('policies.partialError')}</AlertDescription>
+        </Alert>
+      ) : null}
+      <div className="flex items-center gap-2">
+        <Input
+          placeholder={t('policies.searchPlaceholder')}
+          value={searchQuery}
+          onChange={(event) => setSearchQuery(event.target.value)}
+          className="max-w-sm"
+        />
+        <Select
+          value={(table.getColumn('kind')?.getFilterValue() as string) || 'all'}
+          onValueChange={(value) =>
+            table
+              .getColumn('kind')
+              ?.setFilterValue(value === 'all' ? undefined : value)
+          }
+        >
+          <SelectTrigger className="w-64">
+            <SelectValue placeholder={t('policies.allKinds')} />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">{t('policies.allKinds')}</SelectItem>
+            {POLICY_SOURCES.map((source) => (
+              <SelectItem key={source.resourceType} value={source.kind}>
+                {source.kind}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <ResourceTableView
+        table={table}
+        columnCount={columns.length}
+        isLoading={isLoading}
+        data={rows}
+        fitViewportHeight={true}
+        emptyState={emptyState}
+        hasActiveFilters={
+          Boolean(debouncedSearchQuery) || columnFilters.length > 0
+        }
+        filteredRowCount={table.getFilteredRowModel().rows.length}
+        totalRowCount={rows.length}
+        searchQuery={debouncedSearchQuery}
+        pagination={pagination}
+        setPagination={setPagination}
+      />
+    </div>
+  )
+}

--- a/ui/src/pages/resource-definitions.tsx
+++ b/ui/src/pages/resource-definitions.tsx
@@ -33,6 +33,7 @@ import { NodeDetail } from './node-detail'
 import { NodeListPage } from './node-list-page'
 import { PodDetail } from './pod-detail'
 import { PodListPage } from './pod-list-page'
+import { PoliciesListPage } from './policies-list-page'
 import { PVListPage } from './pv-list-page'
 import { PVCListPage } from './pvc-list-page'
 import { SecretDetail } from './secret-detail'
@@ -133,6 +134,10 @@ function getResourceViews(resourceType: ResourceType): ResourceViewDefinition {
     case 'crds':
       return {
         listPage: () => <CRDListPage />,
+      }
+    case 'policies':
+      return {
+        listPage: () => <PoliciesListPage />,
       }
     case 'nodes':
       return {

--- a/ui/src/pages/resource-detail.tsx
+++ b/ui/src/pages/resource-detail.tsx
@@ -1,4 +1,4 @@
-import { useParams } from 'react-router-dom'
+import { Navigate, useParams } from 'react-router-dom'
 
 import { ResourceType } from '@/types/api'
 import { usePageTitle } from '@/hooks/use-page-title'
@@ -33,6 +33,10 @@ export function ResourceDetail() {
 
   if (resourceDefinition?.detailPage) {
     return resourceDefinition.detailPage({ name, namespace })
+  }
+
+  if (resourceDefinition?.synthetic) {
+    return <Navigate to={`/${resource}`} replace />
   }
 
   return (

--- a/ui/src/types/api.ts
+++ b/ui/src/types/api.ts
@@ -408,6 +408,7 @@ export interface ResourcesTypeMap {
   mutatingwebhookconfigurations: KubernetesResourceList
   mutatingadmissionpolicies: KubernetesResourceList
   mutatingadmissionpolicybindings: KubernetesResourceList
+  policies: KubernetesResourceList
   resourceslices: KubernetesResourceList
   resourceclaims: KubernetesResourceList
   deviceclasses: KubernetesResourceList
@@ -521,6 +522,7 @@ export interface ResourceTypeMap {
   mutatingwebhookconfigurations: KubernetesResource
   mutatingadmissionpolicies: KubernetesResource
   mutatingadmissionpolicybindings: KubernetesResource
+  policies: KubernetesResource
   resourceslices: KubernetesResource
   resourceclaims: KubernetesResource
   deviceclasses: KubernetesResource


### PR DESCRIPTION
## Summary

Add a cluster-scoped aggregated **Policies** page:

- Aggregates all six admission-policy types (validating/mutating admission policies, their bindings, webhook configurations) into one list with a kind filter, search, and a partial-error notice when some types fail to load (e.g. the API group is not enabled on the cluster).
- The catalog entry is marked `synthetic`: it is a frontend aggregation, not a real API resource. The individual policy types lose their sidebar entries in favor of the aggregated page but keep their routes and detail pages.
- `rbac-dialog` excludes synthetic entries from resource suggestions since they cannot be RBAC targets.

Frontend-only; no backend changes.

## Why

The admission-policy resources each had their own hidden-by-default sidebar entry, so getting an overview of what admission control is active in a cluster meant visiting six separate lists.

## Related issue

Closes #669

## Validation

- `pnpm run type-check && pnpm run lint && pnpm run test`
- Verified against a cluster with and without the `ValidatingAdmissionPolicy` API group enabled (partial-error path)

## Checklist

- [x] I reviewed this PR myself before requesting review.
- [x] I understand the changes, including AI-generated parts (if any).
- [x] For new features, a feature request issue is linked.
- [x] I cleaned up AI noise (unnecessary comments, dead code, and unrelated changes).
- [x] This PR is reasonably scoped (or split into smaller PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)