### PR TITLE
fix(ui): isolate namespace selection across browser tabs

### DIFF
--- a/ui/src/hooks/use-resource-table-state.ts
+++ b/ui/src/hooks/use-resource-table-state.ts
@@ -82,10 +82,18 @@ export function useResourceTableState({
   const [selectedNamespace, setSelectedNamespace] = useState<
     string | undefined
   >(() => {
-    const storedNamespace = localStorage.getItem(
+    // Prefer tab-scoped sessionStorage to isolate namespace selection across tabs
+    const tabNamespace = sessionStorage.getItem(
       getClusterScopedStorageKey('selectedNamespace')
     )
-    return clusterScope ? undefined : storedNamespace || 'default'
+    if (tabNamespace) {
+      return clusterScope ? undefined : tabNamespace
+    }
+    // Fall back to localStorage for global preference (new tabs inherit last choice)
+    const globalNamespace = localStorage.getItem(
+      getClusterScopedStorageKey('selectedNamespace')
+    )
+    return clusterScope ? undefined : globalNamespace || 'default'
   })
   const [useSSE, setUseSSE] = useState(false)
 
@@ -100,9 +108,12 @@ export function useResourceTableState({
       return
     }
 
-    const storedNamespace = localStorage.getItem(
+    const tabNamespace = sessionStorage.getItem(
       getClusterScopedStorageKey('selectedNamespace')
     )
+    const storedNamespace =
+      tabNamespace ||
+      localStorage.getItem(getClusterScopedStorageKey('selectedNamespace'))
     setSelectedNamespace(storedNamespace || 'default')
   }, [clusterScope, selectedNamespace])
 
@@ -159,6 +170,12 @@ export function useResourceTableState({
   }, [columnFilters, searchQuery])
 
   const handleNamespaceChange = useCallback((value: string) => {
+    // Persist to sessionStorage for tab-level isolation
+    sessionStorage.setItem(
+      getClusterScopedStorageKey('selectedNamespace'),
+      value
+    )
+    // Also update localStorage as global preference for new tabs
     localStorage.setItem(getClusterScopedStorageKey('selectedNamespace'), value)
     setSelectedNamespace(value)
     setPagination((prev) => ({ ...prev, pageIndex: 0 }))


### PR DESCRIPTION
Previously, the selected namespace was stored only in localStorage, which is shared across all tabs of the same origin. When a user opened two tabs and selected different namespaces in each, refreshing either tab would always show the namespace that was last written to localStorage by the other tab.

This commit introduces sessionStorage as the primary per-tab store for the selected namespace, while keeping localStorage as a global preference fallback for newly opened tabs. On initialization, the hook now reads from sessionStorage first (tab-scoped); if absent, it falls back to localStorage (global preference) or 'default'. When the user changes the namespace, the value is written to both sessionStorage (current tab isolation) and localStorage (new-tab default).

This ensures that each tab maintains its own independent namespace selection while still providing a sensible default for new tabs.

## Summary

<!-- What does this PR change? Keep it short. -->

## Why

<!-- Why is this change needed? -->

## Related issue

<!-- For new features, please open and link a feature request issue first. -->

Closes #

## Validation

<!-- How did you test this change? -->

## Checklist

- [ ] I reviewed this PR myself before requesting review.
- [ ] I understand the changes, including AI-generated parts (if any).
- [ ] For new features, a feature request issue is linked.
- [ ] I cleaned up AI noise (unnecessary comments, dead code, and unrelated changes).
- [ ] This PR is reasonably scoped (or split into smaller PRs).
