### PR TITLE
fix(ui): isolate namespace selection across browser tabs

### DIFF
--- a/ui/src/hooks/use-resource-table-state.ts
+++ b/ui/src/hooks/use-resource-table-state.ts
@@ -82,10 +82,18 @@ export function useResourceTableState({
   const [selectedNamespace, setSelectedNamespace] = useState<
     string | undefined
   >(() => {
-    const storedNamespace = localStorage.getItem(
+    // Prefer tab-scoped sessionStorage to isolate namespace selection across tabs
+    const tabNamespace = sessionStorage.getItem(
       getClusterScopedStorageKey('selectedNamespace')
     )
-    return clusterScope ? undefined : storedNamespace || 'default'
+    if (tabNamespace) {
+      return clusterScope ? undefined : tabNamespace
+    }
+    // Fall back to localStorage for global preference (new tabs inherit last choice)
+    const globalNamespace = localStorage.getItem(
+      getClusterScopedStorageKey('selectedNamespace')
+    )
+    return clusterScope ? undefined : globalNamespace || 'default'
   })
   const [useSSE, setUseSSE] = useState(false)
 
@@ -100,9 +108,12 @@ export function useResourceTableState({
       return
     }
 
-    const storedNamespace = localStorage.getItem(
+    const tabNamespace = sessionStorage.getItem(
       getClusterScopedStorageKey('selectedNamespace')
     )
+    const storedNamespace =
+      tabNamespace ||
+      localStorage.getItem(getClusterScopedStorageKey('selectedNamespace'))
     setSelectedNamespace(storedNamespace || 'default')
   }, [clusterScope, selectedNamespace])
 
@@ -159,6 +170,12 @@ export function useResourceTableState({
   }, [columnFilters, searchQuery])
 
   const handleNamespaceChange = useCallback((value: string) => {
+    // Persist to sessionStorage for tab-level isolation
+    sessionStorage.setItem(
+      getClusterScopedStorageKey('selectedNamespace'),
+      value
+    )
+    // Also update localStorage as global preference for new tabs
     localStorage.setItem(getClusterScopedStorageKey('selectedNamespace'), value)
     setSelectedNamespace(value)
     setPagination((prev) => ({ ...prev, pageIndex: 0 }))


### PR DESCRIPTION
## Summary

Use `sessionStorage` as the primary per-tab store for namespace selection, with `localStorage` kept as a global preference fallback for newly opened tabs. This isolates namespace state across browser tabs so that switching namespace in one tab no longer affects another.

## Why

Previously, the selected namespace was stored only in `localStorage`, which is shared across all tabs of the same origin. When a user opened two tabs and selected different namespaces in each, refreshing either tab would always reset to the namespace that was last written to `localStorage` by the other tab.

The fix introduces a dual-write strategy:
- **Read priority**: `sessionStorage` (tab-scoped) → `localStorage` (global fallback) → `default`
- **Write**: both `sessionStorage` (current tab isolation) and `localStorage` (new-tab default)

This is consistent with how other tab-scoped state (e.g., `searchQuery`, `columnFilters`) already uses `sessionStorage` in the same file.

## Related issue

<!-- No existing issue -->

## Validation

- Verified that opening two tabs and selecting different namespaces in each keeps them independent after refresh
  - Tab A stays on its own namespace after refresh, regardless of Tab B's selection
- Verified that opening a brand-new tab still inherits the most recent namespace preference from `localStorage`
- Verified that closing all tabs and reopening the dashboard restores the last-used namespace
- No regression in other resource table state (pagination, column visibility, search query)

## Checklist

- [x] I reviewed this PR myself before requesting review.
- [x] I understand the changes, including AI-generated parts (if any).
- [ ] For new features, a feature request issue is linked.
- [x] I cleaned up AI noise (unnecessary comments, dead code, and unrelated changes).
- [x] This PR is reasonably scoped (or split into smaller PRs).