### PR TITLE
fix DeepSeek reasoning passthrough

### DIFF
--- a/pkg/ai/openai.go
+++ b/pkg/ai/openai.go
@@ -104,9 +104,8 @@ func (a *Agent) runOpenAIConversation(
 			return
 		}
 
+		messages = append(messages, streamedToolCallsToAssistantMessage(streamedToolCalls, messageContent, thinkingContent))
 		for _, tc := range streamedToolCalls {
-			messages = append(messages, streamedToolCallsToAssistantMessage([]streamedToolCall{tc}))
-
 			toolName := tc.Name
 			args, err := parseToolCallArguments(tc.Arguments)
 			if err != nil {
@@ -325,7 +324,7 @@ func extractThinkingFromRaw(raw string) string {
 	return raw
 }
 
-func streamedToolCallsToAssistantMessage(toolCalls []streamedToolCall) openai.ChatCompletionMessageParamUnion {
+func streamedToolCallsToAssistantMessage(toolCalls []streamedToolCall, content, reasoningContent string) openai.ChatCompletionMessageParamUnion {
 	params := make([]openai.ChatCompletionMessageToolCallParam, 0, len(toolCalls))
 	for _, tc := range toolCalls {
 		params = append(params, openai.ChatCompletionMessageToolCallParam{
@@ -337,8 +336,11 @@ func streamedToolCallsToAssistantMessage(toolCalls []streamedToolCall) openai.Ch
 		})
 	}
 
-	assistant := openai.ChatCompletionAssistantMessageParam{
-		ToolCalls: params,
+	message := openai.AssistantMessage(content)
+	assistant := message.OfAssistant
+	assistant.ToolCalls = params
+	if reasoningContent != "" {
+		assistant.SetExtraFields(map[string]any{"reasoning_content": reasoningContent})
 	}
-	return openai.ChatCompletionMessageParamUnion{OfAssistant: &assistant}
+	return message
 }

--- a/pkg/ai/pending_session.go
+++ b/pkg/ai/pending_session.go
@@ -3,11 +3,13 @@ package ai
 import (
 	"crypto/rand"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"time"
 
 	anthropic "github.com/anthropics/anthropic-sdk-go"
 	"github.com/openai/openai-go"
+	"github.com/openai/openai-go/packages/param"
 	"github.com/zxh326/kite/pkg/model"
 	"k8s.io/klog/v2"
 )
@@ -113,8 +115,13 @@ func pendingSessionFromModel(dbSession *model.PendingSession) (pendingSession, e
 	var err error
 
 	// Unmarshal messages and args directly in the AI package
-	if err = dbSession.OpenAIMessages.Unmarshal(&session.OpenAIMessages); err != nil {
+	var rawOpenAIMessages []json.RawMessage
+	if err = dbSession.OpenAIMessages.Unmarshal(&rawOpenAIMessages); err != nil {
 		return pendingSession{}, fmt.Errorf("failed to unmarshal OpenAI messages: %w", err)
+	}
+	session.OpenAIMessages = make([]openai.ChatCompletionMessageParamUnion, 0, len(rawOpenAIMessages))
+	for _, rawMessage := range rawOpenAIMessages {
+		session.OpenAIMessages = append(session.OpenAIMessages, param.Override[openai.ChatCompletionMessageParamUnion](rawMessage))
 	}
 	if err = dbSession.AnthropicMessages.Unmarshal(&session.AnthropicMessages); err != nil {
 		return pendingSession{}, fmt.Errorf("failed to unmarshal Anthropic messages: %w", err)


### PR DESCRIPTION
## What changed

- Replay an OpenAI-compatible tool-call response as one assistant message containing its content, full tool-call set, and `reasoning_content`.
- Preserve raw OpenAI-compatible messages across pending-session persistence so provider-specific fields survive confirmation and input pauses.

## Why

DeepSeek thinking mode requires `reasoning_content` from an assistant tool-call response to be passed back in subsequent requests. Kite collected and displayed that field but rebuilt the assistant history with only `tool_calls`, causing the next completion request to fail with HTTP 400.

## Impact

DeepSeek thinking-mode conversations can continue after read tools and after pending action/input resumes without losing the required reasoning context. Anthropic behavior is unchanged.

## Validation

- `make pre-commit`
- `go test ./pkg/ai`