### PR TITLE
feat(connector): add connector manifest generation endpoint and UI

### DIFF
--- a/.github/workflows/build-preview-docker-image.yml
+++ b/.github/workflows/build-preview-docker-image.yml
@@ -73,7 +73,8 @@ jobs:
       - name: Generate tags
         id: tags
         run: |
-          echo "tags=ghcr.io/${{ github.repository_owner }}/kite:main" >> $GITHUB_OUTPUT
+          OWNER_LC=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+          echo "tags=ghcr.io/${OWNER_LC}/kite:main" >> $GITHUB_OUTPUT
           echo "image_tag=main" >> $GITHUB_OUTPUT
 
       - name: Build

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -108,6 +108,7 @@ export default defineConfig({
             { text: "Helm Management", link: "/guide/helm-management" },
             { text: "AI Assistant", link: "/guide/ai-assistant" },
             { text: "Web Terminal", link: "/guide/web-terminal" },
+            { text: "Kite Connector", link: "/guide/kite-connector" },
             { text: "Resource History", link: "/guide/resource-history" },
             { text: "Custom Sidebar", link: "/guide/custom-sidebar" },
             { text: "Kube Proxy", link: "/guide/kube-proxy" },

--- a/docs/config/env.md
+++ b/docs/config/env.md
@@ -15,7 +15,11 @@ Kite supports several environment variables by default to change the default val
 
 - **TRUSTED_PROXIES**: Comma-separated list of reverse proxy, ingress, or load balancer IPs/CIDRs that Kite should trust when reading `X-Forwarded-For` / `X-Real-IP` to determine the client IP. By default, Kite trusts local/private network ranges (`127.0.0.0/8`, `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `::1`, `fc00::/7`) so common ingress deployments can report real client IPs. Set a narrower value such as `TRUSTED_PROXIES=10.42.0.0/16,192.168.1.10` for production, or `TRUSTED_PROXIES=none` to ignore all client-supplied forwarding headers.
 
+- **KUBECTL_TERMINAL_IMAGE**: Docker image used for the kubectl terminal.
+
 - **NODE_TERMINAL_IMAGE**: Docker image used for generating Node Terminal Agent.
+
+- **CONNECTOR_IMAGE**: Docker image used when generating the Kite Connector manifest for connector-type clusters.
 
 - **ENABLE_ANALYTICS**: Enable data analytics functionality, default value is `false`. When enabled, Kite will collect limited data to help improve the product.
 

--- a/docs/guide/kite-connector.md
+++ b/docs/guide/kite-connector.md
@@ -1,0 +1,152 @@
+---
+outline: deep
+---
+
+# Kite Connector
+
+Kite Connector is used to onboard Kubernetes clusters that Kite Server cannot reach directly. The Connector runs inside the target cluster, initiates the connection to Kite, and forwards Kubernetes API requests issued by Kite over that connection.
+
+## Background
+
+In private networks, edge environments, or firewall-restricted scenarios, the target cluster may be able to reach Kite while Kite Server cannot connect to the cluster's kube-apiserver. The traditional kubeconfig onboarding method requires Kite Server to connect to kube-apiserver, so it cannot cover this one-way network topology.
+
+Kite Connector reverses the connection direction:
+
+- The Connector dials Kite Server from the cluster side; Kite does not need to enter the cluster network.
+- Kubernetes credentials stay in the Connector's runtime environment and are never uploaded to Kite Server.
+- Kite still uses its existing Kubernetes Client to access the cluster, so resource management, logs, and terminals do not need a separate protocol.
+
+## How It Works
+
+The connection chain looks like this:
+
+```text
+Kite Kubernetes Client
+        │
+        ▼
+Kite Server local loopback port
+        │
+        ▼
+WebSocket tunnel (established by the Connector)
+        │
+        ▼
+Connector local Kubernetes API reverse proxy
+        │
+        ▼
+Target cluster kube-apiserver
+```
+
+The detailed process:
+
+1. When you create a Connector cluster in the Kite UI, Kite generates a random connection token, stores only its SHA-256 hash, and shows the raw token once after creation.
+2. The Connector connects to Kite Server's `/api/v1/connector/connect` WebSocket endpoint using the token. Kite validates the token and binds the connection to the corresponding cluster.
+3. Kite Server creates a random port listening only on `127.0.0.1` for that cluster. The existing Kubernetes Client connects to this port, and requests are tunneled to the Connector.
+4. The Connector also creates a Kubernetes API reverse proxy listening only on `127.0.0.1` and uses its local ServiceAccount or kubeconfig to reach kube-apiserver.
+5. The Connector strips any `Authorization` and `Impersonate-*` headers coming from Kite, then its local Kubernetes Transport injects the Connector's own cluster credentials.
+
+A single Connector WebSocket can carry multiple Kubernetes API connections. Streaming requests such as logs, watches, and terminals also travel over the same tunnel.
+
+## Usage
+
+### 1. Create a Connector Cluster
+
+Go to **Settings → Cluster Management** in Kite, select **Add Cluster**, and then:
+
+1. Fill in the cluster name and description.
+2. Set the cluster type to **Kite Connector**.
+3. Create the cluster.
+
+After creation, Kite shows the connection info only once, and you can choose the command-line or Kubernetes YAML option.
+
+Command-line option:
+
+```bash
+kite connector --server='https://kite.example.com' --token='<connector-token>'
+```
+
+`--server` may include Kite's Base Path. For example:
+
+```bash
+kite connector --server='https://kite.example.com/kite' --token='<connector-token>'
+```
+
+The Connector automatically appends `/api/v1/connector/connect` to this address; do not add this API path to `--server` manually.
+
+The Kubernetes YAML option creates the following resources:
+
+- A `kite-connector-token` Secret in the `kube-system` namespace to hold the Connector Token.
+- A `kite-connector` ServiceAccount in the `kube-system` namespace.
+- A ClusterRoleBinding that binds this ServiceAccount to `cluster-admin`.
+- A single-replica `kite-connector` Deployment in the `kube-system` namespace.
+
+You can deploy in either of the following ways:
+
+**Option 1: Deploy directly via URL**
+
+After creation, Kite generates a manifest download URL that you can apply directly with `kubectl apply`:
+
+```bash
+kubectl apply -f 'https://kite.example.com/api/v1/connector/manifest?token=<connector-token>'
+```
+
+This URL is authenticated by the Connector Token and requires no additional credentials. The token is embedded in the returned YAML, so the URL has the same security level as the token itself and is shown only once when the cluster is created.
+
+**Option 2: Copy the YAML and deploy manually**
+
+Copy the YAML from the connection info dialog, save it to a file, and then deploy:
+
+```bash
+kubectl apply -f kite-connector.yaml
+```
+
+The image used by the Deployment is configured via **Connector Image** in the platform settings, defaulting to `ghcr.io/kite-org/kite:latest`. The token is injected into the Connector process via a Secret.
+
+### 2. Start It in the Target Cluster
+
+When starting manually via the command line, run the generated command inside a Pod that can reach kube-apiserver. When `--kubeconfig` is not specified, the Connector uses `rest.InClusterConfig()` to read the Pod's ServiceAccount credentials.
+
+Once the Connector connects successfully, the cluster management page shows it as "Connected". If the connection drops, the Connector retries every 5 seconds.
+
+### 3. Test with a Local kubeconfig
+
+For local development and testing, you can specify a kubeconfig explicitly:
+
+```bash
+kite connector \
+  --server='http://localhost:8080' \
+  --token='<connector-token>' \
+  --kubeconfig='/path/to/kubeconfig'
+```
+
+The Connector then uses the API server and credentials from the kubeconfig's current context. `http://` is recommended only for local testing; production should use `https://`.
+
+## Things to Note
+
+### Token Security
+
+- The Connector Token currently has no expiry. As long as the corresponding cluster exists and is enabled, it can be used to reconnect. Disabling a cluster stops Kite from using it and rejects subsequent new or reconnecting Connector handshakes, but does not actively close already-established Connector sessions; re-enabling the cluster keeps the original token valid.
+- The Kite database stores only the token hash. The raw token is shown only once after cluster creation, so save it somewhere safe immediately.
+- There is no dedicated token rotation endpoint yet. If a token leaks, delete and recreate the Connector cluster to generate a new token.
+- `--token` appears in process arguments and shell history. Restrict login and process-viewing permissions on the Connector host, and never paste the real token into logs, tickets, or chats.
+
+### Server Identity Verification
+
+- Production must use `https://` with a Kite Server certificate issued by a CA trusted by the Connector's runtime environment. The Connector validates the certificate domain and trust chain by standard TLS rules, preventing connections to a forged Kite Server.
+- With `http://` there is no server identity verification, and neither the token nor the tunnel data is protected by TLS. Use it only for controlled local testing.
+- The connection currently uses a Bearer Token; mTLS, client certificate issuance, and certificate rotation are not yet implemented.
+
+### Kubernetes Permissions and Auditing
+
+- The permissions of the Connector's ServiceAccount or kubeconfig determine what Kite can do in the cluster. If you need features like logs or terminals, grant the corresponding Kubernetes RBAC permissions as well.
+- The generated YAML binds the Connector ServiceAccount to `cluster-admin`, granting administrative privileges over the entire cluster. Confirm this meets your security requirements before deploying.
+- Kite users are still governed by Kite's own RBAC, but the identity kube-apiserver sees is the ServiceAccount or kubeconfig user used by the Connector, not the actual logged-in Kite user.
+- The Connector does not accept Kubernetes `Authorization` or `Impersonate-*` headers passed in from Kite.
+
+### Network and Availability
+
+- The Connector only needs outbound access to Kite Server and the target cluster's kube-apiserver; it does not expose any new listening port to the outside.
+- Both Kite Server and the Connector process create random ports bound only to `127.0.0.1`, which is normal behavior of the internal forwarding chain.
+- The Ingress or reverse proxy in front of Kite must support WebSocket Upgrade and long-lived connections.
+- Connector session routing across multiple Kite Server replicas is not yet implemented. When using Connector clusters, run a single Kite Server replica first.
+- A tunnel disconnect aborts any running logs, watch, or terminal connections. After the Connector reconnects, clients must re-initiate these streaming requests.
+- Terminals and command execution prefer WebSocket and fall back to SPDY on upgrade failure; the API server and intermediate proxies must support the corresponding connection upgrade.

--- a/docs/guide/kite-connector.md
+++ b/docs/guide/kite-connector.md
@@ -86,10 +86,10 @@ You can deploy in either of the following ways:
 After creation, Kite generates a manifest download URL that you can apply directly with `kubectl apply`:
 
 ```bash
-kubectl apply -f 'https://kite.example.com/api/v1/connector/manifest?token=<connector-token>'
+kubectl apply -f 'https://kite.example.com/api/v1/connector/manifest?grant=<manifest-grant>'
 ```
 
-This URL is authenticated by the Connector Token and requires no additional credentials. The token is embedded in the returned YAML, so the URL has the same security level as the token itself and is shown only once when the cluster is created.
+The URL contains an encrypted manifest grant that is separate from the Connector Token. The grant expires after 10 minutes and remains valid across Kite restarts while the JWT secret is unchanged. It can be reused until it expires, so apply it promptly or use the YAML shown in the dialog. The returned YAML contains the Connector Token and must still be handled as a secret.
 
 **Option 2: Copy the YAML and deploy manually**
 

--- a/docs/zh/config/env.md
+++ b/docs/zh/config/env.md
@@ -15,7 +15,11 @@ Kite 默认支持一些环境变量，来改变一些配置项的默认值。
 
 - **TRUSTED_PROXIES**：以逗号分隔的反向代理、Ingress 或负载均衡器 IP/CIDR 列表；只有这些直连 Kite 的上一跳才会被信任，Kite 才会读取其转发的 `X-Forwarded-For` / `X-Real-IP` 来判断客户端 IP。默认信任本地和常见私网网段（`127.0.0.0/8`、`10.0.0.0/8`、`172.16.0.0/12`、`192.168.0.0/16`、`::1`、`fc00::/7`），方便常见 Ingress 部署拿到真实用户 IP。生产环境建议配置为更窄的范围，例如 `TRUSTED_PROXIES=10.42.0.0/16,192.168.1.10`；如需忽略所有客户端转发头，可设置 `TRUSTED_PROXIES=none`。
 
+- **KUBECTL_TERMINAL_IMAGE**: 用于 kubectl 终端的 Docker 镜像。
+
 - **NODE_TERMINAL_IMAGE**: 用于生成 Node Terminal Agent 的 Docker 镜像。
+
+- **CONNECTOR_IMAGE**: 为 Connector 类型集群生成 Kite Connector 部署清单时使用的 Docker 镜像。
 
 - **ENABLE_ANALYTICS**：启用数据分析功能，默认值为 `false`。当启用后，Kite 将收集有限数据以帮助改进产品。
 

--- a/docs/zh/guide/kite-connector.md
+++ b/docs/zh/guide/kite-connector.md
@@ -79,13 +79,27 @@ Kubernetes YAML 方式会创建以下资源：
 - 将该 ServiceAccount 绑定到 `cluster-admin` 的 ClusterRoleBinding。
 - `kube-system` 命名空间中的单副本 `kite-connector` Deployment。
 
-复制 YAML 并保存为文件后，可以直接部署：
+可以通过以下两种方式部署：
+
+**方式一：通过 URL 直接部署**
+
+创建成功后，Kite 会生成一个 Manifest 下载 URL，可以直接用 `kubectl apply` 部署：
+
+```bash
+kubectl apply -f 'https://kite.example.com/api/v1/connector/manifest?token=<connector-token>'
+```
+
+该 URL 通过 Connector Token 鉴权，无需额外认证。Token 已嵌入返回的 YAML 中，因此 URL 的安全级别与 Token 本身一致，仅在创建集群时展示一次。
+
+**方式二：复制 YAML 手动部署**
+
+在连接信息对话框中复制 YAML 并保存为文件后，可以直接部署：
 
 ```bash
 kubectl apply -f kite-connector.yaml
 ```
 
-Deployment 使用 `ghcr.io/kite-org/kite:latest` 镜像，通过 Secret 将 Token 注入 Connector 进程。
+Deployment 使用的镜像由平台设置中的 **Connector Image** 配置，默认为 `ghcr.io/kite-org/kite:latest`。通过 Secret 将 Token 注入 Connector 进程。
 
 ### 2. 在目标集群中启动
 

--- a/docs/zh/guide/kite-connector.md
+++ b/docs/zh/guide/kite-connector.md
@@ -86,10 +86,10 @@ Kubernetes YAML 方式会创建以下资源：
 创建成功后，Kite 会生成一个 Manifest 下载 URL，可以直接用 `kubectl apply` 部署：
 
 ```bash
-kubectl apply -f 'https://kite.example.com/api/v1/connector/manifest?token=<connector-token>'
+kubectl apply -f 'https://kite.example.com/api/v1/connector/manifest?grant=<manifest-grant>'
 ```
 
-该 URL 通过 Connector Token 鉴权，无需额外认证。Token 已嵌入返回的 YAML 中，因此 URL 的安全级别与 Token 本身一致，仅在创建集群时展示一次。
+该 URL 包含一个与 Connector Token 分离的加密 Manifest Grant。Grant 会在 10 分钟后过期，只要 JWT Secret 不变，Kite 重启后仍然有效。Grant 在过期前可以重复使用，因此请尽快执行该命令，或改用对话框中展示的 YAML。返回的 YAML 仍包含 Connector Token，必须按敏感凭据处理。
 
 **方式二：复制 YAML 手动部署**
 

--- a/pkg/cluster/cluster_handler.go
+++ b/pkg/cluster/cluster_handler.go
@@ -148,9 +148,15 @@ func (cm *ClusterManager) CreateCluster(c *gin.Context) {
 
 	var connectorToken string
 	var connectorTokenHash string
+	var connectorManifestGrant string
 	if req.Connector {
 		var err error
 		connectorToken, connectorTokenHash, err = connector.NewToken()
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		connectorManifestGrant, err = cm.connectorManager.CreateManifestGrant(connectorToken)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 			return
@@ -184,15 +190,7 @@ func (cm *ClusterManager) CreateCluster(c *gin.Context) {
 		serverURL := connectorServerURL(c)
 		result["connectorServer"] = serverURL
 		result["connectorToken"] = connectorToken
-		image := model.DefaultGeneralConnectorImageValue()
-		if setting, err := model.GetGeneralSetting(); err == nil && setting != nil && setting.ConnectorImage != "" {
-			image = setting.ConnectorImage
-		}
-		// Build the manifest download URL so the user can kubectl apply -f <url>.
-		result["connectorManifestURL"] = fmt.Sprintf("%s/api/v1/connector/manifest?token=%s", strings.TrimRight(serverURL, "/"), connectorToken)
-		// Include the pre-generated manifest so the frontend does not need to
-		// duplicate the template logic.
-		result["connectorYaml"] = connector.GenerateManifest(serverURL, connectorToken, image)
+		result["connectorManifestURL"] = fmt.Sprintf("%s/api/v1/connector/manifest?grant=%s", strings.TrimRight(serverURL, "/"), connectorManifestGrant)
 	}
 	c.JSON(http.StatusCreated, result)
 }
@@ -318,19 +316,19 @@ func (cm *ClusterManager) ConnectConnector(c *gin.Context) {
 	cm.connectorManager.ServeHTTP(c.Writer, c.Request)
 }
 
-// GetConnectorManifest returns a Kubernetes YAML manifest that deploys the
-// Connector inside a target cluster. Authentication is done via the connector
-// token in the query string, so no JWT is required (similar to ConnectConnector).
 func (cm *ClusterManager) GetConnectorManifest(c *gin.Context) {
-	token := strings.TrimSpace(c.Query("token"))
-	if token == "" || !connector.ValidToken(token) {
-		c.JSON(http.StatusUnauthorized, gin.H{"error": "invalid token"})
+	grant := strings.TrimSpace(c.Query("grant"))
+	token, err := cm.connectorManager.ResolveManifestGrant(grant)
+	if errors.Is(err, connector.ErrInvalidManifestGrant) {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "invalid or expired manifest grant"})
 		return
 	}
-	hash := connector.TokenHash(token)
-	cluster, err := model.GetClusterByConnectorTokenHash(hash)
-	if err != nil || cluster == nil || !cluster.Connector || !cluster.Enable {
-		c.JSON(http.StatusUnauthorized, gin.H{"error": "invalid token"})
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to validate manifest grant"})
+		return
+	}
+	if token == "" {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "invalid or expired manifest grant"})
 		return
 	}
 	serverURL := connectorServerURL(c)
@@ -339,6 +337,7 @@ func (cm *ClusterManager) GetConnectorManifest(c *gin.Context) {
 		image = setting.ConnectorImage
 	}
 	manifest := connector.GenerateManifest(serverURL, token, image)
+	c.Header("Cache-Control", "no-store")
 	c.Header("Content-Disposition", `attachment; filename="kite-connector.yaml"`)
 	c.Data(http.StatusOK, "text/yaml; charset=utf-8", []byte(manifest))
 }

--- a/pkg/cluster/cluster_handler.go
+++ b/pkg/cluster/cluster_handler.go
@@ -18,6 +18,26 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
+// connectorServerURL derives the Kite server URL from the request context,
+// using common.Host / X-Forwarded-Host / request host and common.Base.
+func connectorServerURL(c *gin.Context) string {
+	scheme := "http"
+	if c.Request.TLS != nil || strings.EqualFold(c.GetHeader("X-Forwarded-Proto"), "https") {
+		scheme = "https"
+	}
+	host := strings.TrimSpace(common.Host)
+	if host == "" {
+		host = strings.TrimSpace(c.GetHeader("X-Forwarded-Host"))
+		if host == "" {
+			host = c.Request.Host
+		}
+	}
+	if !strings.HasPrefix(host, "http://") && !strings.HasPrefix(host, "https://") {
+		host = scheme + "://" + host
+	}
+	return fmt.Sprintf("%s%s", strings.TrimRight(host, "/"), common.Base)
+}
+
 func (cm *ClusterManager) GetClusters(c *gin.Context) {
 	clusters, errors, defaultContext := cm.snapshotState()
 	result := make([]common.ClusterInfo, 0, len(clusters))
@@ -161,22 +181,18 @@ func (cm *ClusterManager) CreateCluster(c *gin.Context) {
 		"message": "cluster created successfully",
 	}
 	if req.Connector {
-		scheme := "http"
-		if c.Request.TLS != nil || strings.EqualFold(c.GetHeader("X-Forwarded-Proto"), "https") {
-			scheme = "https"
-		}
-		host := strings.TrimSpace(common.Host)
-		if host == "" {
-			host = strings.TrimSpace(c.GetHeader("X-Forwarded-Host"))
-			if host == "" {
-				host = c.Request.Host
-			}
-		}
-		if !strings.HasPrefix(host, "http://") && !strings.HasPrefix(host, "https://") {
-			host = scheme + "://" + host
-		}
-		result["connectorServer"] = fmt.Sprintf("%s%s", strings.TrimRight(host, "/"), common.Base)
+		serverURL := connectorServerURL(c)
+		result["connectorServer"] = serverURL
 		result["connectorToken"] = connectorToken
+		image := model.DefaultGeneralConnectorImageValue()
+		if setting, err := model.GetGeneralSetting(); err == nil && setting != nil && setting.ConnectorImage != "" {
+			image = setting.ConnectorImage
+		}
+		// Build the manifest download URL so the user can kubectl apply -f <url>.
+		result["connectorManifestURL"] = fmt.Sprintf("%s/api/v1/connector/manifest?token=%s", strings.TrimRight(serverURL, "/"), connectorToken)
+		// Include the pre-generated manifest so the frontend does not need to
+		// duplicate the template logic.
+		result["connectorYaml"] = connector.GenerateManifest(serverURL, connectorToken, image)
 	}
 	c.JSON(http.StatusCreated, result)
 }
@@ -300,6 +316,31 @@ func (cm *ClusterManager) DeleteCluster(c *gin.Context) {
 
 func (cm *ClusterManager) ConnectConnector(c *gin.Context) {
 	cm.connectorManager.ServeHTTP(c.Writer, c.Request)
+}
+
+// GetConnectorManifest returns a Kubernetes YAML manifest that deploys the
+// Connector inside a target cluster. Authentication is done via the connector
+// token in the query string, so no JWT is required (similar to ConnectConnector).
+func (cm *ClusterManager) GetConnectorManifest(c *gin.Context) {
+	token := strings.TrimSpace(c.Query("token"))
+	if token == "" || !connector.ValidToken(token) {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "invalid token"})
+		return
+	}
+	hash := connector.TokenHash(token)
+	cluster, err := model.GetClusterByConnectorTokenHash(hash)
+	if err != nil || cluster == nil || !cluster.Connector || !cluster.Enable {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "invalid token"})
+		return
+	}
+	serverURL := connectorServerURL(c)
+	image := model.DefaultGeneralConnectorImageValue()
+	if setting, err := model.GetGeneralSetting(); err == nil && setting != nil && setting.ConnectorImage != "" {
+		image = setting.ConnectorImage
+	}
+	manifest := connector.GenerateManifest(serverURL, token, image)
+	c.Header("Content-Disposition", `attachment; filename="kite-connector.yaml"`)
+	c.Data(http.StatusOK, "text/yaml; charset=utf-8", []byte(manifest))
 }
 
 func (cm *ClusterManager) ImportClustersFromKubeconfig(c *gin.Context) {

--- a/pkg/cluster/cluster_handler_test.go
+++ b/pkg/cluster/cluster_handler_test.go
@@ -155,7 +155,7 @@ func setupClusterHandlerTestDB(t *testing.T) {
 	if err != nil {
 		t.Fatalf("opening test database: %v", err)
 	}
-	if err := db.AutoMigrate(&model.Cluster{}); err != nil {
+	if err := db.AutoMigrate(&model.Cluster{}, &model.GeneralSetting{}); err != nil {
 		t.Fatalf("migrating test database: %v", err)
 	}
 	model.DB = db

--- a/pkg/cluster/connector_manifest_test.go
+++ b/pkg/cluster/connector_manifest_test.go
@@ -1,0 +1,248 @@
+package cluster
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/zxh326/kite/pkg/connector"
+	"github.com/zxh326/kite/pkg/model"
+)
+
+func TestGetConnectorManifest(t *testing.T) {
+	setupClusterHandlerTestDB(t)
+
+	token, hash, err := connector.NewToken()
+	if err != nil {
+		t.Fatalf("generating token: %v", err)
+	}
+	cluster := &model.Cluster{
+		Name:               "conn-cluster",
+		Connector:          true,
+		Enable:             true,
+		ConnectorTokenHash: hash,
+	}
+	if err := model.AddCluster(cluster); err != nil {
+		t.Fatalf("adding cluster: %v", err)
+	}
+
+	manager := &ClusterManager{clusters: map[string]*ClientSet{}, errors: map[string]string{}}
+	router := newConnectorManifestRouter(manager)
+
+	rec := performClusterRequest(router, http.MethodGet, "/manifest?token="+token, "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	if ct := rec.Header().Get("Content-Type"); !strings.HasPrefix(ct, "text/yaml") {
+		t.Fatalf("content-type = %q", ct)
+	}
+	body := rec.Body.String()
+	for _, want := range []string{
+		"kind: Secret",
+		"kind: ServiceAccount",
+		"kind: ClusterRoleBinding",
+		"kind: Deployment",
+		"kite-connector",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("manifest missing %q:\n%s", want, body)
+		}
+	}
+}
+
+func TestGetConnectorManifestInvalidToken(t *testing.T) {
+	setupClusterHandlerTestDB(t)
+	manager := &ClusterManager{clusters: map[string]*ClientSet{}, errors: map[string]string{}}
+	router := newConnectorManifestRouter(manager)
+
+	// Missing token.
+	rec := performClusterRequest(router, http.MethodGet, "/manifest", "")
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("missing token: status = %d, want %d", rec.Code, http.StatusUnauthorized)
+	}
+
+	// Malformed token.
+	rec = performClusterRequest(router, http.MethodGet, "/manifest?token=garbage", "")
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("malformed token: status = %d, want %d", rec.Code, http.StatusUnauthorized)
+	}
+}
+
+func TestGetConnectorManifestTokenNotAssociated(t *testing.T) {
+	setupClusterHandlerTestDB(t)
+
+	token, _, err := connector.NewToken()
+	if err != nil {
+		t.Fatalf("generating token: %v", err)
+	}
+
+	manager := &ClusterManager{clusters: map[string]*ClientSet{}, errors: map[string]string{}}
+	router := newConnectorManifestRouter(manager)
+
+	rec := performClusterRequest(router, http.MethodGet, "/manifest?token="+token, "")
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("unassociated token: status = %d, want %d", rec.Code, http.StatusUnauthorized)
+	}
+}
+
+func TestGetConnectorManifestDisabledCluster(t *testing.T) {
+	setupClusterHandlerTestDB(t)
+
+	token, hash, err := connector.NewToken()
+	if err != nil {
+		t.Fatalf("generating token: %v", err)
+	}
+	cluster := &model.Cluster{
+		Name:               "disabled-conn",
+		Connector:          true,
+		Enable:             true,
+		ConnectorTokenHash: hash,
+	}
+	if err := model.AddCluster(cluster); err != nil {
+		t.Fatalf("adding cluster: %v", err)
+	}
+	if err := model.UpdateCluster(cluster, map[string]interface{}{"enable": false}); err != nil {
+		t.Fatalf("disabling cluster: %v", err)
+	}
+
+	manager := &ClusterManager{clusters: map[string]*ClientSet{}, errors: map[string]string{}}
+	router := newConnectorManifestRouter(manager)
+
+	rec := performClusterRequest(router, http.MethodGet, "/manifest?token="+token, "")
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("disabled cluster: status = %d, want %d", rec.Code, http.StatusUnauthorized)
+	}
+}
+
+func TestCreateConnectorClusterReturnsConnectionInfo(t *testing.T) {
+	setupClusterHandlerTestDB(t)
+
+	manager := &ClusterManager{clusters: map[string]*ClientSet{}, errors: map[string]string{}}
+	router := gin.New()
+	router.POST("/clusters", manager.CreateCluster)
+
+	rec := performClusterRequest(router, http.MethodPost, "/clusters",
+		`{"name":"conn-test","connector":true}`)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusCreated, rec.Body.String())
+	}
+
+	var result map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &result); err != nil {
+		t.Fatalf("decoding response: %v", err)
+	}
+
+	serverURL, _ := result["connectorServer"].(string)
+	token, _ := result["connectorToken"].(string)
+	manifestURL, _ := result["connectorManifestURL"].(string)
+	yaml, _ := result["connectorYaml"].(string)
+
+	if serverURL == "" {
+		t.Fatal("connectorServer is empty")
+	}
+	if token == "" {
+		t.Fatal("connectorToken is empty")
+	}
+	if manifestURL == "" {
+		t.Fatal("connectorManifestURL is empty")
+	}
+	if !strings.HasPrefix(manifestURL, serverURL) {
+		t.Errorf("manifestURL %q should start with serverURL %q", manifestURL, serverURL)
+	}
+	if !strings.Contains(manifestURL, token) {
+		t.Errorf("manifestURL %q should contain the token", manifestURL)
+	}
+	if yaml == "" {
+		t.Fatal("connectorYaml is empty")
+	}
+	for _, want := range []string{
+		"kind: Secret",
+		"kind: Deployment",
+		"kite-connector",
+	} {
+		if !strings.Contains(yaml, want) {
+			t.Errorf("connectorYaml missing %q", want)
+		}
+	}
+
+	// Verify the cluster was persisted correctly.
+	cluster, err := model.GetClusterByName("conn-test")
+	if err != nil {
+		t.Fatalf("loading cluster: %v", err)
+	}
+	if !cluster.Connector {
+		t.Error("cluster.Connector should be true")
+	}
+	if cluster.ConnectorTokenHash == "" {
+		t.Error("ConnectorTokenHash should not be empty")
+	}
+	if string(cluster.Config) != "" {
+		t.Errorf("connector cluster should have empty config, got %q", cluster.Config)
+	}
+}
+
+func TestCreateConnectorClusterIgnoresKubeconfig(t *testing.T) {
+	setupClusterHandlerTestDB(t)
+
+	manager := &ClusterManager{clusters: map[string]*ClientSet{}, errors: map[string]string{}}
+	router := gin.New()
+	router.POST("/clusters", manager.CreateCluster)
+
+	rec := performClusterRequest(router, http.MethodPost, "/clusters",
+		`{"name":"conn-ignore","connector":true,"config":"should-be-ignored","inCluster":true,"prometheusURL":"https://prom.example.com"}`)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusCreated, rec.Body.String())
+	}
+
+	cluster, err := model.GetClusterByName("conn-ignore")
+	if err != nil {
+		t.Fatalf("loading cluster: %v", err)
+	}
+	if string(cluster.Config) != "" {
+		t.Errorf("connector cluster config should be empty, got %q", cluster.Config)
+	}
+	if cluster.InCluster {
+		t.Error("connector cluster InCluster should be false")
+	}
+	if cluster.PrometheusURL != "" {
+		t.Errorf("connector cluster PrometheusURL should be empty, got %q", cluster.PrometheusURL)
+	}
+}
+
+func TestCreateConnectorClusterServerURLDerivation(t *testing.T) {
+	setupClusterHandlerTestDB(t)
+
+	manager := &ClusterManager{clusters: map[string]*ClientSet{}, errors: map[string]string{}}
+	router := gin.New()
+	router.POST("/clusters", manager.CreateCluster)
+
+	// Verify that X-Forwarded-Host and X-Forwarded-Proto are respected.
+	rec := httptest.NewRecorder()
+	body := strings.NewReader(`{"name":"conn-fwd","connector":true}`)
+	req := httptest.NewRequest(http.MethodPost, "/clusters", body)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Forwarded-Host", "kite.example.com")
+	req.Header.Set("X-Forwarded-Proto", "https")
+	router.ServeHTTP(rec, req)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusCreated, rec.Body.String())
+	}
+
+	var result map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &result); err != nil {
+		t.Fatalf("decoding response: %v", err)
+	}
+	serverURL, _ := result["connectorServer"].(string)
+	if !strings.HasPrefix(serverURL, "https://kite.example.com") {
+		t.Errorf("serverURL = %q, want https://kite.example.com prefix", serverURL)
+	}
+}
+
+func newConnectorManifestRouter(manager *ClusterManager) *gin.Engine {
+	router := gin.New()
+	router.GET("/manifest", manager.GetConnectorManifest)
+	return router
+}

--- a/pkg/cluster/connector_manifest_test.go
+++ b/pkg/cluster/connector_manifest_test.go
@@ -29,10 +29,14 @@ func TestGetConnectorManifest(t *testing.T) {
 		t.Fatalf("adding cluster: %v", err)
 	}
 
-	manager := &ClusterManager{clusters: map[string]*ClientSet{}, errors: map[string]string{}}
+	manager := &ClusterManager{clusters: map[string]*ClientSet{}, errors: map[string]string{}, connectorManager: connector.NewManager(func() {})}
+	grant, err := manager.connectorManager.CreateManifestGrant(token)
+	if err != nil {
+		t.Fatalf("generating manifest grant: %v", err)
+	}
 	router := newConnectorManifestRouter(manager)
 
-	rec := performClusterRequest(router, http.MethodGet, "/manifest?token="+token, "")
+	rec := performClusterRequest(router, http.MethodGet, "/manifest?grant="+grant, "")
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusOK, rec.Body.String())
 	}
@@ -53,21 +57,21 @@ func TestGetConnectorManifest(t *testing.T) {
 	}
 }
 
-func TestGetConnectorManifestInvalidToken(t *testing.T) {
+func TestGetConnectorManifestInvalidGrant(t *testing.T) {
 	setupClusterHandlerTestDB(t)
-	manager := &ClusterManager{clusters: map[string]*ClientSet{}, errors: map[string]string{}}
+	manager := &ClusterManager{clusters: map[string]*ClientSet{}, errors: map[string]string{}, connectorManager: connector.NewManager(func() {})}
 	router := newConnectorManifestRouter(manager)
 
-	// Missing token.
+	// Missing grant.
 	rec := performClusterRequest(router, http.MethodGet, "/manifest", "")
 	if rec.Code != http.StatusUnauthorized {
-		t.Fatalf("missing token: status = %d, want %d", rec.Code, http.StatusUnauthorized)
+		t.Fatalf("missing grant: status = %d, want %d", rec.Code, http.StatusUnauthorized)
 	}
 
-	// Malformed token.
-	rec = performClusterRequest(router, http.MethodGet, "/manifest?token=garbage", "")
+	// Malformed grant.
+	rec = performClusterRequest(router, http.MethodGet, "/manifest?grant=garbage", "")
 	if rec.Code != http.StatusUnauthorized {
-		t.Fatalf("malformed token: status = %d, want %d", rec.Code, http.StatusUnauthorized)
+		t.Fatalf("malformed grant: status = %d, want %d", rec.Code, http.StatusUnauthorized)
 	}
 }
 
@@ -79,10 +83,14 @@ func TestGetConnectorManifestTokenNotAssociated(t *testing.T) {
 		t.Fatalf("generating token: %v", err)
 	}
 
-	manager := &ClusterManager{clusters: map[string]*ClientSet{}, errors: map[string]string{}}
+	manager := &ClusterManager{clusters: map[string]*ClientSet{}, errors: map[string]string{}, connectorManager: connector.NewManager(func() {})}
+	grant, err := manager.connectorManager.CreateManifestGrant(token)
+	if err != nil {
+		t.Fatalf("generating manifest grant: %v", err)
+	}
 	router := newConnectorManifestRouter(manager)
 
-	rec := performClusterRequest(router, http.MethodGet, "/manifest?token="+token, "")
+	rec := performClusterRequest(router, http.MethodGet, "/manifest?grant="+grant, "")
 	if rec.Code != http.StatusUnauthorized {
 		t.Fatalf("unassociated token: status = %d, want %d", rec.Code, http.StatusUnauthorized)
 	}
@@ -108,10 +116,14 @@ func TestGetConnectorManifestDisabledCluster(t *testing.T) {
 		t.Fatalf("disabling cluster: %v", err)
 	}
 
-	manager := &ClusterManager{clusters: map[string]*ClientSet{}, errors: map[string]string{}}
+	manager := &ClusterManager{clusters: map[string]*ClientSet{}, errors: map[string]string{}, connectorManager: connector.NewManager(func() {})}
+	grant, err := manager.connectorManager.CreateManifestGrant(token)
+	if err != nil {
+		t.Fatalf("generating manifest grant: %v", err)
+	}
 	router := newConnectorManifestRouter(manager)
 
-	rec := performClusterRequest(router, http.MethodGet, "/manifest?token="+token, "")
+	rec := performClusterRequest(router, http.MethodGet, "/manifest?grant="+grant, "")
 	if rec.Code != http.StatusUnauthorized {
 		t.Fatalf("disabled cluster: status = %d, want %d", rec.Code, http.StatusUnauthorized)
 	}
@@ -120,7 +132,7 @@ func TestGetConnectorManifestDisabledCluster(t *testing.T) {
 func TestCreateConnectorClusterReturnsConnectionInfo(t *testing.T) {
 	setupClusterHandlerTestDB(t)
 
-	manager := &ClusterManager{clusters: map[string]*ClientSet{}, errors: map[string]string{}}
+	manager := &ClusterManager{clusters: map[string]*ClientSet{}, errors: map[string]string{}, connectorManager: connector.NewManager(func() {})}
 	router := gin.New()
 	router.POST("/clusters", manager.CreateCluster)
 
@@ -138,7 +150,6 @@ func TestCreateConnectorClusterReturnsConnectionInfo(t *testing.T) {
 	serverURL, _ := result["connectorServer"].(string)
 	token, _ := result["connectorToken"].(string)
 	manifestURL, _ := result["connectorManifestURL"].(string)
-	yaml, _ := result["connectorYaml"].(string)
 
 	if serverURL == "" {
 		t.Fatal("connectorServer is empty")
@@ -152,22 +163,12 @@ func TestCreateConnectorClusterReturnsConnectionInfo(t *testing.T) {
 	if !strings.HasPrefix(manifestURL, serverURL) {
 		t.Errorf("manifestURL %q should start with serverURL %q", manifestURL, serverURL)
 	}
-	if !strings.Contains(manifestURL, token) {
-		t.Errorf("manifestURL %q should contain the token", manifestURL)
+	if strings.Contains(manifestURL, token) {
+		t.Errorf("manifestURL %q should not contain the connector token", manifestURL)
 	}
-	if yaml == "" {
-		t.Fatal("connectorYaml is empty")
+	if !strings.Contains(manifestURL, "?grant=") {
+		t.Errorf("manifestURL %q should contain a manifest grant", manifestURL)
 	}
-	for _, want := range []string{
-		"kind: Secret",
-		"kind: Deployment",
-		"kite-connector",
-	} {
-		if !strings.Contains(yaml, want) {
-			t.Errorf("connectorYaml missing %q", want)
-		}
-	}
-
 	// Verify the cluster was persisted correctly.
 	cluster, err := model.GetClusterByName("conn-test")
 	if err != nil {
@@ -187,7 +188,7 @@ func TestCreateConnectorClusterReturnsConnectionInfo(t *testing.T) {
 func TestCreateConnectorClusterIgnoresKubeconfig(t *testing.T) {
 	setupClusterHandlerTestDB(t)
 
-	manager := &ClusterManager{clusters: map[string]*ClientSet{}, errors: map[string]string{}}
+	manager := &ClusterManager{clusters: map[string]*ClientSet{}, errors: map[string]string{}, connectorManager: connector.NewManager(func() {})}
 	router := gin.New()
 	router.POST("/clusters", manager.CreateCluster)
 
@@ -215,7 +216,7 @@ func TestCreateConnectorClusterIgnoresKubeconfig(t *testing.T) {
 func TestCreateConnectorClusterServerURLDerivation(t *testing.T) {
 	setupClusterHandlerTestDB(t)
 
-	manager := &ClusterManager{clusters: map[string]*ClientSet{}, errors: map[string]string{}}
+	manager := &ClusterManager{clusters: map[string]*ClientSet{}, errors: map[string]string{}, connectorManager: connector.NewManager(func() {})}
 	router := gin.New()
 	router.POST("/clusters", manager.CreateCluster)
 

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -33,6 +33,7 @@ var (
 
 	NodeTerminalImage    = "busybox:latest"
 	KubectlTerminalImage = "zzde/kubectl:latest"
+	ConnectorImage       = "ghcr.io/kite-org/kite:latest"
 	DBType               = "sqlite"
 	DBDSN                = "dev.db"
 
@@ -119,6 +120,10 @@ func LoadEnvs() {
 
 	if kubectlTerminalImage := os.Getenv("KUBECTL_TERMINAL_IMAGE"); kubectlTerminalImage != "" {
 		KubectlTerminalImage = kubectlTerminalImage
+	}
+
+	if connectorImage := os.Getenv("CONNECTOR_IMAGE"); connectorImage != "" {
+		ConnectorImage = connectorImage
 	}
 
 	if dbDSN := os.Getenv("DB_DSN"); dbDSN != "" {

--- a/pkg/common/common_test.go
+++ b/pkg/common/common_test.go
@@ -69,6 +69,7 @@ func TestLoadEnvs(t *testing.T) {
 	t.Setenv("NAMESPACE", "test-namespace")
 	t.Setenv("NODE_TERMINAL_IMAGE", "test-node-image")
 	t.Setenv("KUBECTL_TERMINAL_IMAGE", "test-kubectl-image")
+	t.Setenv("CONNECTOR_IMAGE", "test-connector-image")
 	t.Setenv("DB_DSN", "test.db")
 	t.Setenv("DB_TYPE", "mysql")
 	t.Setenv("KITE_ENCRYPT_KEY", "test-encrypt-key")

--- a/pkg/connector/manager.go
+++ b/pkg/connector/manager.go
@@ -56,9 +56,20 @@ func NewToken() (string, string, error) {
 	return token, hex.EncodeToString(hash[:]), nil
 }
 
+// TokenHash returns the SHA-256 hex hash for a plaintext connector token.
+func TokenHash(token string) string {
+	hash := sha256.Sum256([]byte(token))
+	return hex.EncodeToString(hash[:])
+}
+
 func validToken(token string) bool {
 	decoded, err := base64.RawURLEncoding.Strict().DecodeString(token)
 	return err == nil && len(decoded) == connectorTokenSize
+}
+
+// ValidToken checks whether the token string has a valid format.
+func ValidToken(token string) bool {
+	return validToken(token)
 }
 
 func (m *Manager) authorize(req *http.Request) (string, bool, error) {

--- a/pkg/connector/manager.go
+++ b/pkg/connector/manager.go
@@ -2,10 +2,14 @@ package connector
 
 import (
 	"context"
+	"crypto/aes"
+	"crypto/cipher"
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
+	"encoding/json"
+	"errors"
 	"io"
 	"net"
 	"net/http"
@@ -15,14 +19,21 @@ import (
 	"time"
 
 	"github.com/rancher/remotedialer"
+	"github.com/zxh326/kite/pkg/common"
 	"github.com/zxh326/kite/pkg/model"
+	"golang.org/x/crypto/hkdf"
+	"gorm.io/gorm"
 	"k8s.io/klog/v2"
 )
 
 const (
-	kubernetesAPITarget = "kubernetes-api"
-	connectorTokenSize  = 32
+	kubernetesAPITarget  = "kubernetes-api"
+	connectorTokenSize   = 32
+	manifestGrantTimeout = 10 * time.Minute
+	manifestGrantAAD     = "kite:connector-manifest-grant:v1"
 )
+
+var ErrInvalidManifestGrant = errors.New("invalid manifest grant")
 
 type requestStateKey struct{}
 
@@ -30,9 +41,15 @@ type requestState struct {
 	authenticated bool
 }
 
+type manifestGrant struct {
+	ConnectorToken string `json:"token"`
+	ExpiresAt      int64  `json:"exp"`
+}
+
 type Manager struct {
 	server    *remotedialer.Server
 	onChange  func()
+	jwtSecret string
 	mu        sync.Mutex
 	listeners map[string]net.Listener
 }
@@ -40,6 +57,7 @@ type Manager struct {
 func NewManager(onChange func()) *Manager {
 	m := &Manager{
 		onChange:  onChange,
+		jwtSecret: common.JwtSecret,
 		listeners: make(map[string]net.Listener),
 	}
 	m.server = remotedialer.New(m.authorize, remotedialer.DefaultErrorWriter)
@@ -52,12 +70,10 @@ func NewToken() (string, string, error) {
 		return "", "", err
 	}
 	token := base64.RawURLEncoding.EncodeToString(value)
-	hash := sha256.Sum256([]byte(token))
-	return token, hex.EncodeToString(hash[:]), nil
+	return token, tokenHash(token), nil
 }
 
-// TokenHash returns the SHA-256 hex hash for a plaintext connector token.
-func TokenHash(token string) string {
+func tokenHash(token string) string {
 	hash := sha256.Sum256([]byte(token))
 	return hex.EncodeToString(hash[:])
 }
@@ -67,9 +83,90 @@ func validToken(token string) bool {
 	return err == nil && len(decoded) == connectorTokenSize
 }
 
-// ValidToken checks whether the token string has a valid format.
-func ValidToken(token string) bool {
-	return validToken(token)
+func resolveToken(token string) (*model.Cluster, error) {
+	if !validToken(token) {
+		return nil, nil
+	}
+	cluster, err := model.GetClusterByConnectorTokenHash(tokenHash(token))
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	if !cluster.Connector || !cluster.Enable {
+		return nil, nil
+	}
+	return cluster, nil
+}
+
+func manifestGrantCipher(jwtSecret string) (cipher.AEAD, error) {
+	key := make([]byte, 32)
+	if _, err := io.ReadFull(hkdf.New(sha256.New, []byte(jwtSecret), nil, []byte(manifestGrantAAD)), key); err != nil {
+		return nil, err
+	}
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+	return cipher.NewGCM(block)
+}
+
+func (m *Manager) CreateManifestGrant(connectorToken string) (string, error) {
+	payload, err := json.Marshal(manifestGrant{
+		ConnectorToken: connectorToken,
+		ExpiresAt:      time.Now().Add(manifestGrantTimeout).Unix(),
+	})
+	if err != nil {
+		return "", err
+	}
+	aead, err := manifestGrantCipher(m.jwtSecret)
+	if err != nil {
+		return "", err
+	}
+	nonce := make([]byte, aead.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return "", err
+	}
+	ciphertext := aead.Seal(nil, nonce, payload, []byte(manifestGrantAAD))
+	encrypted := make([]byte, len(nonce)+len(ciphertext))
+	copy(encrypted, nonce)
+	copy(encrypted[len(nonce):], ciphertext)
+	return base64.RawURLEncoding.EncodeToString(encrypted), nil
+}
+
+func (m *Manager) ResolveManifestGrant(grant string) (string, error) {
+	encrypted, err := base64.RawURLEncoding.Strict().DecodeString(grant)
+	if err != nil {
+		return "", ErrInvalidManifestGrant
+	}
+	aead, err := manifestGrantCipher(m.jwtSecret)
+	if err != nil {
+		return "", err
+	}
+	if len(encrypted) < aead.NonceSize() {
+		return "", nil
+	}
+	nonce, ciphertext := encrypted[:aead.NonceSize()], encrypted[aead.NonceSize():]
+	payload, err := aead.Open(nil, nonce, ciphertext, []byte(manifestGrantAAD))
+	if err != nil {
+		return "", ErrInvalidManifestGrant
+	}
+	var stored manifestGrant
+	if err := json.Unmarshal(payload, &stored); err != nil {
+		return "", ErrInvalidManifestGrant
+	}
+	if time.Now().Unix() >= stored.ExpiresAt {
+		return "", ErrInvalidManifestGrant
+	}
+	cluster, err := resolveToken(stored.ConnectorToken)
+	if err != nil {
+		return "", err
+	}
+	if cluster == nil {
+		return "", nil
+	}
+	return stored.ConnectorToken, nil
 }
 
 func (m *Manager) authorize(req *http.Request) (string, bool, error) {
@@ -78,12 +175,12 @@ func (m *Manager) authorize(req *http.Request) (string, bool, error) {
 	if !found || token == "" {
 		return "", false, nil
 	}
-	if !validToken(token) {
-		return "", false, nil
+	cluster, err := resolveToken(token)
+	if err != nil {
+		klog.Errorf("Failed to validate connector token: %v", err)
+		return "", false, errors.New("failed to validate connector token")
 	}
-	hash := sha256.Sum256([]byte(token))
-	cluster, _ := model.GetClusterByConnectorTokenHash(hex.EncodeToString(hash[:]))
-	if cluster == nil || !cluster.Connector || !cluster.Enable {
+	if cluster == nil {
 		return "", false, nil
 	}
 	if state, ok := req.Context().Value(requestStateKey{}).(*requestState); ok {

--- a/pkg/connector/manifest.go
+++ b/pkg/connector/manifest.go
@@ -1,0 +1,82 @@
+package connector
+
+import (
+	"fmt"
+	"strings"
+)
+
+// GenerateManifest builds the Kubernetes manifest (Secret, ServiceAccount,
+// ClusterRoleBinding, Deployment) used to deploy the Connector inside a
+// target cluster. The image and server URL are injected so the manifest is
+// always consistent with the platform configuration.
+func GenerateManifest(serverURL, token, image string) string {
+	serverURL = strings.TrimSpace(serverURL)
+	token = strings.TrimSpace(token)
+	image = strings.TrimSpace(image)
+	// JSON-encode the string values so the YAML is always valid regardless
+	// of special characters.
+	tokenJSON := fmt.Sprintf("%q", token)
+	serverJSON := fmt.Sprintf("%q", serverURL)
+	return fmt.Sprintf(`apiVersion: v1
+kind: Secret
+metadata:
+  name: kite-connector-token
+  namespace: kube-system
+type: Opaque
+stringData:
+  token: %s
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kite-connector
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kite-connector
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: kite-connector
+    namespace: kube-system
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kite-connector
+  namespace: kube-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kite-connector
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: kite-connector
+    spec:
+      serviceAccountName: kite-connector
+      containers:
+        - name: connector
+          image: %s
+          command:
+            - /app/kite
+          args:
+            - connector
+            - --server=$(KITE_SERVER)
+            - --token=$(CONNECTOR_TOKEN)
+          env:
+            - name: KITE_SERVER
+              value: %s
+            - name: CONNECTOR_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: kite-connector-token
+                  key: token
+`, tokenJSON, image, serverJSON)
+}

--- a/pkg/connector/manifest.go
+++ b/pkg/connector/manifest.go
@@ -17,6 +17,8 @@ func GenerateManifest(serverURL, token, image string) string {
 	// of special characters.
 	tokenJSON := fmt.Sprintf("%q", token)
 	serverJSON := fmt.Sprintf("%q", serverURL)
+	imageJSON := fmt.Sprintf("%q", image)
+	tokenHashJSON := fmt.Sprintf("%q", tokenHash(token))
 	return fmt.Sprintf(`apiVersion: v1
 kind: Secret
 metadata:
@@ -57,6 +59,8 @@ spec:
       app.kubernetes.io/name: kite-connector
   template:
     metadata:
+      annotations:
+        kite.kubernetes.io/connector-token-hash: %s
       labels:
         app.kubernetes.io/name: kite-connector
     spec:
@@ -78,5 +82,5 @@ spec:
                 secretKeyRef:
                   name: kite-connector-token
                   key: token
-`, tokenJSON, image, serverJSON)
+`, tokenJSON, tokenHashJSON, imageJSON, serverJSON)
 }

--- a/pkg/connector/manifest_test.go
+++ b/pkg/connector/manifest_test.go
@@ -18,7 +18,7 @@ func TestGenerateManifest(t *testing.T) {
 		"apiVersion: rbac.authorization.k8s.io/v1\nkind: ClusterRoleBinding",
 		"name: cluster-admin",
 		"apiVersion: apps/v1\nkind: Deployment",
-		"image: ghcr.io/kite-org/kite:v1.0",
+		`image: "ghcr.io/kite-org/kite:v1.0"`,
 		"--server=$(KITE_SERVER)",
 		"--token=$(CONNECTOR_TOKEN)",
 		"value: \"https://kite.example.com\"",
@@ -43,7 +43,7 @@ func TestGenerateManifestWhitespaceTrimmed(t *testing.T) {
 	if !strings.Contains(manifest, `"tok"`) {
 		t.Errorf("token not trimmed:\n%s", manifest)
 	}
-	if !strings.Contains(manifest, "image: img:tag") {
+	if !strings.Contains(manifest, `image: "img:tag"`) {
 		t.Errorf("image not trimmed:\n%s", manifest)
 	}
 }

--- a/pkg/connector/manifest_test.go
+++ b/pkg/connector/manifest_test.go
@@ -1,0 +1,57 @@
+package connector
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGenerateManifest(t *testing.T) {
+	manifest := GenerateManifest("https://kite.example.com", "my-token", "ghcr.io/kite-org/kite:v1.0")
+
+	checks := []string{
+		"apiVersion: v1\nkind: Secret",
+		"name: kite-connector-token",
+		"namespace: kube-system",
+		"token: \"my-token\"",
+		"apiVersion: v1\nkind: ServiceAccount",
+		"name: kite-connector",
+		"apiVersion: rbac.authorization.k8s.io/v1\nkind: ClusterRoleBinding",
+		"name: cluster-admin",
+		"apiVersion: apps/v1\nkind: Deployment",
+		"image: ghcr.io/kite-org/kite:v1.0",
+		"--server=$(KITE_SERVER)",
+		"--token=$(CONNECTOR_TOKEN)",
+		"value: \"https://kite.example.com\"",
+	}
+	for _, want := range checks {
+		if !strings.Contains(manifest, want) {
+			t.Errorf("manifest missing %q\n--- manifest ---\n%s", want, manifest)
+		}
+	}
+
+	// Should contain exactly 4 documents separated by ---
+	if strings.Count(manifest, "---") != 3 {
+		t.Errorf("expected 3 document separators, got %d", strings.Count(manifest, "---"))
+	}
+}
+
+func TestGenerateManifestWhitespaceTrimmed(t *testing.T) {
+	manifest := GenerateManifest("  https://kite.example.com  ", "  tok  ", "  img:tag  ")
+	if !strings.Contains(manifest, `"https://kite.example.com"`) {
+		t.Errorf("serverURL not trimmed:\n%s", manifest)
+	}
+	if !strings.Contains(manifest, `"tok"`) {
+		t.Errorf("token not trimmed:\n%s", manifest)
+	}
+	if !strings.Contains(manifest, "image: img:tag") {
+		t.Errorf("image not trimmed:\n%s", manifest)
+	}
+}
+
+func TestGenerateManifestSpecialCharacters(t *testing.T) {
+	// Token with special characters that would break YAML if not quoted.
+	manifest := GenerateManifest("https://kite.example.com", "tok:en\"'", "img")
+	if !strings.Contains(manifest, `"tok:en\"'"`) {
+		t.Errorf("special characters in token not properly escaped:\n%s", manifest)
+	}
+}

--- a/pkg/model/general_setting.go
+++ b/pkg/model/general_setting.go
@@ -15,6 +15,7 @@ const DefaultGeneralAIModel = "gpt-4o-mini"
 const DefaultGeneralAnthropicModel = "claude-sonnet-4-5"
 const DefaultGeneralKubectlImage = "zzde/kubectl:latest"
 const DefaultGeneralNodeTerminalImage = "busybox:latest"
+const DefaultGeneralConnectorImage = "ghcr.io/kite-org/kite:latest"
 
 const GeneralAIProviderOpenAI = "openai"
 const GeneralAIProviderAnthropic = "anthropic"
@@ -24,6 +25,22 @@ func DefaultGeneralNodeTerminalImageValue() string {
 	image := strings.TrimSpace(common.NodeTerminalImage)
 	if image == "" {
 		return DefaultGeneralNodeTerminalImage
+	}
+	return image
+}
+
+func DefaultGeneralKubectlImageValue() string {
+	image := strings.TrimSpace(common.KubectlTerminalImage)
+	if image == "" {
+		return DefaultGeneralKubectlImage
+	}
+	return image
+}
+
+func DefaultGeneralConnectorImageValue() string {
+	image := strings.TrimSpace(common.ConnectorImage)
+	if image == "" {
+		return DefaultGeneralConnectorImage
 	}
 	return image
 }
@@ -39,6 +56,7 @@ type GeneralSetting struct {
 	KubectlEnabled          bool         `json:"kubectlEnabled" gorm:"column:kubectl_enabled;type:boolean;not null;default:true"`
 	KubectlImage            string       `json:"kubectlImage" gorm:"column:kubectl_image;type:varchar(255);not null;default:'zzde/kubectl:latest'"`
 	NodeTerminalImage       string       `json:"nodeTerminalImage" gorm:"column:node_terminal_image;type:varchar(255);not null;default:'busybox:latest'"`
+	ConnectorImage          string       `json:"connectorImage" gorm:"column:connector_image;type:varchar(255);not null;default:'ghcr.io/kite-org/kite:latest'"`
 	EnableAnalytics         bool         `json:"enableAnalytics" gorm:"column:enable_analytics;type:boolean;not null;default:false"`
 	EnableVersionCheck      bool         `json:"enableVersionCheck" gorm:"column:enable_version_check;type:boolean;not null;default:true"`
 	PasswordLoginDisabled   bool         `json:"passwordLoginDisabled" gorm:"column:password_login_disabled;type:boolean;not null;default:false"`
@@ -92,13 +110,16 @@ func GetGeneralSetting() (*GeneralSetting, error) {
 			updates["ai_model"] = setting.AIModel
 		}
 		if setting.KubectlImage == "" {
-			setting.KubectlImage = DefaultGeneralKubectlImage
-			updates["kubectl_image"] = DefaultGeneralKubectlImage
+			setting.KubectlImage = DefaultGeneralKubectlImageValue()
+			updates["kubectl_image"] = setting.KubectlImage
 		}
 		if setting.NodeTerminalImage == "" {
-			defaultNodeTerminalImage := DefaultGeneralNodeTerminalImageValue()
-			setting.NodeTerminalImage = defaultNodeTerminalImage
-			updates["node_terminal_image"] = defaultNodeTerminalImage
+			setting.NodeTerminalImage = DefaultGeneralNodeTerminalImageValue()
+			updates["node_terminal_image"] = setting.NodeTerminalImage
+		}
+		if setting.ConnectorImage == "" {
+			setting.ConnectorImage = DefaultGeneralConnectorImageValue()
+			updates["connector_image"] = setting.ConnectorImage
 		}
 		if err := ensureJWTSecret(&setting, updates); err != nil {
 			return nil, err
@@ -122,8 +143,9 @@ func GetGeneralSetting() (*GeneralSetting, error) {
 		AIModel:            DefaultGeneralAIModel,
 		AIMaxTokens:        4096,
 		KubectlEnabled:     true,
-		KubectlImage:       DefaultGeneralKubectlImage,
+		KubectlImage:       DefaultGeneralKubectlImageValue(),
 		NodeTerminalImage:  DefaultGeneralNodeTerminalImageValue(),
+		ConnectorImage:     DefaultGeneralConnectorImageValue(),
 		EnableAnalytics:    common.EnableAnalytics,
 		EnableVersionCheck: common.EnableVersionCheck,
 		EnableMFA:          true,

--- a/pkg/settings/handler.go
+++ b/pkg/settings/handler.go
@@ -27,6 +27,7 @@ func HandleGetGeneralSetting(c *gin.Context) {
 		"kubectlEnabled":        setting.KubectlEnabled,
 		"kubectlImage":          setting.KubectlImage,
 		"nodeTerminalImage":     setting.NodeTerminalImage,
+		"connectorImage":        setting.ConnectorImage,
 		"enableAnalytics":       setting.EnableAnalytics,
 		"enableVersionCheck":    setting.EnableVersionCheck,
 		"passwordLoginDisabled": setting.PasswordLoginDisabled,
@@ -46,6 +47,7 @@ type UpdateGeneralSettingRequest struct {
 	KubectlEnabled        *bool   `json:"kubectlEnabled"`
 	KubectlImage          *string `json:"kubectlImage"`
 	NodeTerminalImage     *string `json:"nodeTerminalImage"`
+	ConnectorImage        *string `json:"connectorImage"`
 	EnableAnalytics       *bool   `json:"enableAnalytics"`
 	EnableVersionCheck    *bool   `json:"enableVersionCheck"`
 	PasswordLoginDisabled *bool   `json:"passwordLoginDisabled"`
@@ -116,7 +118,7 @@ func HandleUpdateGeneralSetting(c *gin.Context) { //nolint:gocyclo
 		return
 	}
 	if kubectlImage == "" {
-		kubectlImage = model.DefaultGeneralKubectlImage
+		kubectlImage = model.DefaultGeneralKubectlImageValue()
 	}
 	nodeTerminalImage := strings.TrimSpace(currentSetting.NodeTerminalImage)
 	if req.NodeTerminalImage != nil {
@@ -124,6 +126,13 @@ func HandleUpdateGeneralSetting(c *gin.Context) { //nolint:gocyclo
 	}
 	if nodeTerminalImage == "" {
 		nodeTerminalImage = model.DefaultGeneralNodeTerminalImageValue()
+	}
+	connectorImage := strings.TrimSpace(currentSetting.ConnectorImage)
+	if req.ConnectorImage != nil {
+		connectorImage = strings.TrimSpace(*req.ConnectorImage)
+	}
+	if connectorImage == "" {
+		connectorImage = model.DefaultGeneralConnectorImageValue()
 	}
 
 	aiMaxTokens := currentSetting.AIMaxTokens
@@ -158,6 +167,9 @@ func HandleUpdateGeneralSetting(c *gin.Context) { //nolint:gocyclo
 	}
 	if req.NodeTerminalImage != nil {
 		updates["node_terminal_image"] = nodeTerminalImage
+	}
+	if req.ConnectorImage != nil {
+		updates["connector_image"] = connectorImage
 	}
 	if req.EnableAnalytics != nil {
 		updates["enable_analytics"] = *req.EnableAnalytics
@@ -199,6 +211,7 @@ func HandleUpdateGeneralSetting(c *gin.Context) { //nolint:gocyclo
 		"kubectlEnabled":        updated.KubectlEnabled,
 		"kubectlImage":          updated.KubectlImage,
 		"nodeTerminalImage":     updated.NodeTerminalImage,
+		"connectorImage":        updated.ConnectorImage,
 		"enableAnalytics":       updated.EnableAnalytics,
 		"enableVersionCheck":    updated.EnableVersionCheck,
 		"passwordLoginDisabled": updated.PasswordLoginDisabled,

--- a/routes.go
+++ b/routes.go
@@ -35,6 +35,7 @@ func setupAPIRouter(r *gin.RouterGroup, cm *cluster.ClusterManager) {
 	registerBaseRoutes(r)
 	r.GET("/api/v1/bootstrap", authHandler.Bootstrap)
 	r.GET("/api/v1/connector/connect", cm.ConnectConnector)
+	r.GET("/api/v1/connector/manifest", cm.GetConnectorManifest)
 	registerAuthRoutes(r, authHandler)
 	registerUserRoutes(r, authHandler)
 	registerAdminRoutes(r, authHandler, cm, helmChartsHandler)

--- a/ui/src/components/settings/cluster-management.tsx
+++ b/ui/src/components/settings/cluster-management.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useMemo, useRef, useState } from 'react'
 import {
   IconCopy,
   IconEdit,
@@ -35,6 +35,7 @@ import {
 } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
+import { Skeleton } from '@/components/ui/skeleton'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { Textarea } from '@/components/ui/textarea'
 import {
@@ -66,10 +67,15 @@ export function ClusterManagement() {
   const [deletingCluster, setDeletingCluster] = useState<Cluster | null>(null)
   const [connectorCommand, setConnectorCommand] = useState('')
   const [connectorYaml, setConnectorYaml] = useState('')
+  const [connectorYamlError, setConnectorYamlError] = useState<string | null>(
+    null
+  )
+  const [isConnectorYamlLoading, setIsConnectorYamlLoading] = useState(false)
   const [connectorManifestURL, setConnectorManifestURL] = useState('')
   const [connectorCopyError, setConnectorCopyError] = useState<
     'command' | 'yaml' | null
   >(null)
+  const connectorYamlRequestID = useRef(0)
 
   const getClusterTypeBadge = useCallback(
     (cluster: Cluster) => {
@@ -235,16 +241,14 @@ export function ClusterManagement() {
 
   const createMutation = useMutation({
     mutationFn: createCluster,
-    onSuccess: ({
+    onSuccess: async ({
       connectorServer,
       connectorToken,
       connectorManifestURL,
-      connectorYaml,
     }: {
       connectorServer?: string
       connectorToken?: string
       connectorManifestURL?: string
-      connectorYaml?: string
     }) => {
       queryClient.invalidateQueries({ queryKey: ['cluster-list'] })
       toast.success(
@@ -256,8 +260,42 @@ export function ClusterManagement() {
         setConnectorCommand(
           `kite connector --server='${connectorServer}' --token='${connectorToken}'`
         )
-        setConnectorYaml(connectorYaml || '')
+        setConnectorYaml('')
+        setConnectorYamlError(null)
         setConnectorManifestURL(connectorManifestURL || '')
+        setIsConnectorYamlLoading(true)
+        const requestID = ++connectorYamlRequestID.current
+        try {
+          if (!connectorManifestURL) throw new Error('Missing manifest URL')
+          const manifestURL = new URL(
+            connectorManifestURL,
+            window.location.origin
+          )
+          const response = await fetch(
+            `${manifestURL.pathname}${manifestURL.search}`,
+            {
+              cache: 'no-store',
+            }
+          )
+          if (!response.ok) throw new Error(`HTTP ${response.status}`)
+          const yaml = await response.text()
+          if (requestID === connectorYamlRequestID.current) {
+            setConnectorYaml(yaml)
+          }
+        } catch {
+          if (requestID === connectorYamlRequestID.current) {
+            setConnectorYamlError(
+              t(
+                'clusterManagement.connector.loadYamlError',
+                'Failed to load YAML from the manifest URL.'
+              )
+            )
+          }
+        } finally {
+          if (requestID === connectorYamlRequestID.current) {
+            setIsConnectorYamlLoading(false)
+          }
+        }
       }
     },
     onError: (error: Error) => {
@@ -452,8 +490,11 @@ export function ClusterManagement() {
         open={!!connectorCommand}
         onOpenChange={(open) => {
           if (!open) {
+            connectorYamlRequestID.current += 1
             setConnectorCommand('')
             setConnectorYaml('')
+            setConnectorYamlError(null)
+            setIsConnectorYamlLoading(false)
             setConnectorManifestURL('')
             setConnectorCopyError(null)
           }
@@ -562,14 +603,20 @@ export function ClusterManagement() {
                   </div>
                 </div>
               )}
-              {connectorManifestURL && (
-                <div className="space-y-1">
-                  <Label className="text-xs text-muted-foreground">
-                    {t(
-                      'clusterManagement.connector.orUseYaml',
-                      'Or deploy with YAML'
-                    )}
-                  </Label>
+              <div className="space-y-1">
+                <Label className="text-xs text-muted-foreground">
+                  {t(
+                    'clusterManagement.connector.orUseYaml',
+                    'Or deploy with YAML'
+                  )}
+                </Label>
+                {isConnectorYamlLoading ? (
+                  <Skeleton className="h-96 w-full" />
+                ) : connectorYamlError ? (
+                  <p role="alert" className="text-sm text-destructive">
+                    {connectorYamlError}
+                  </p>
+                ) : (
                   <Textarea
                     readOnly
                     className="h-96 resize-none font-mono text-xs"
@@ -579,27 +626,28 @@ export function ClusterManagement() {
                     )}
                     value={connectorYaml}
                   />
+                )}
+              </div>
+              {connectorYaml && (
+                <div className="flex justify-end">
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={async () => {
+                      try {
+                        await navigator.clipboard.writeText(connectorYaml)
+                        setConnectorCopyError(null)
+                        toast.success(t('common.messages.copied', 'Copied'))
+                      } catch {
+                        setConnectorCopyError('yaml')
+                      }
+                    }}
+                  >
+                    <IconCopy className="size-4" />
+                    {t('clusterManagement.connector.copyYaml', 'Copy YAML')}
+                  </Button>
                 </div>
               )}
-              <div className="flex justify-end">
-                <Button
-                  type="button"
-                  variant="outline"
-                  onClick={async () => {
-                    if (!connectorYaml) return
-                    try {
-                      await navigator.clipboard.writeText(connectorYaml)
-                      setConnectorCopyError(null)
-                      toast.success(t('common.messages.copied', 'Copied'))
-                    } catch {
-                      setConnectorCopyError('yaml')
-                    }
-                  }}
-                >
-                  <IconCopy className="size-4" />
-                  {t('clusterManagement.connector.copyYaml', 'Copy YAML')}
-                </Button>
-              </div>
               {connectorCopyError === 'yaml' && (
                 <p role="alert" className="text-sm text-destructive">
                   {t(
@@ -614,8 +662,11 @@ export function ClusterManagement() {
             <Button
               type="button"
               onClick={() => {
+                connectorYamlRequestID.current += 1
                 setConnectorCommand('')
                 setConnectorYaml('')
+                setConnectorYamlError(null)
+                setIsConnectorYamlLoading(false)
                 setConnectorManifestURL('')
                 setConnectorCopyError(null)
               }}

--- a/ui/src/components/settings/cluster-management.tsx
+++ b/ui/src/components/settings/cluster-management.tsx
@@ -34,6 +34,7 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { Textarea } from '@/components/ui/textarea'
 import {
@@ -65,6 +66,7 @@ export function ClusterManagement() {
   const [deletingCluster, setDeletingCluster] = useState<Cluster | null>(null)
   const [connectorCommand, setConnectorCommand] = useState('')
   const [connectorYaml, setConnectorYaml] = useState('')
+  const [connectorManifestURL, setConnectorManifestURL] = useState('')
   const [connectorCopyError, setConnectorCopyError] = useState<
     'command' | 'yaml' | null
   >(null)
@@ -233,7 +235,17 @@ export function ClusterManagement() {
 
   const createMutation = useMutation({
     mutationFn: createCluster,
-    onSuccess: ({ connectorServer, connectorToken }) => {
+    onSuccess: ({
+      connectorServer,
+      connectorToken,
+      connectorManifestURL,
+      connectorYaml,
+    }: {
+      connectorServer?: string
+      connectorToken?: string
+      connectorManifestURL?: string
+      connectorYaml?: string
+    }) => {
       queryClient.invalidateQueries({ queryKey: ['cluster-list'] })
       toast.success(
         t('clusterManagement.messages.created', 'Cluster created successfully')
@@ -244,67 +256,8 @@ export function ClusterManagement() {
         setConnectorCommand(
           `kite connector --server='${connectorServer}' --token='${connectorToken}'`
         )
-        setConnectorYaml(`apiVersion: v1
-kind: Secret
-metadata:
-  name: kite-connector-token
-  namespace: kube-system
-type: Opaque
-stringData:
-  token: ${JSON.stringify(connectorToken)}
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: kite-connector
-  namespace: kube-system
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: kite-connector
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: cluster-admin
-subjects:
-  - kind: ServiceAccount
-    name: kite-connector
-    namespace: kube-system
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: kite-connector
-  namespace: kube-system
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: kite-connector
-  template:
-    metadata:
-      labels:
-        app.kubernetes.io/name: kite-connector
-    spec:
-      serviceAccountName: kite-connector
-      containers:
-        - name: connector
-          image: ghcr.io/kite-org/kite:latest
-          command:
-            - /app/kite
-          args:
-            - connector
-            - --server=$(KITE_SERVER)
-            - --token=$(CONNECTOR_TOKEN)
-          env:
-            - name: KITE_SERVER
-              value: ${JSON.stringify(connectorServer)}
-            - name: CONNECTOR_TOKEN
-              valueFrom:
-                secretKeyRef:
-                  name: kite-connector-token
-                  key: token`)
+        setConnectorYaml(connectorYaml || '')
+        setConnectorManifestURL(connectorManifestURL || '')
       }
     },
     onError: (error: Error) => {
@@ -501,6 +454,7 @@ spec:
           if (!open) {
             setConnectorCommand('')
             setConnectorYaml('')
+            setConnectorManifestURL('')
             setConnectorCopyError(null)
           }
         }}
@@ -569,15 +523,64 @@ spec:
               )}
             </TabsContent>
             <TabsContent value="yaml" className="space-y-2">
-              <Textarea
-                readOnly
-                className="h-96 resize-none font-mono text-xs"
-                aria-label={t(
-                  'clusterManagement.connector.yaml',
-                  'Kubernetes YAML'
-                )}
-                value={connectorYaml}
-              />
+              {connectorManifestURL && (
+                <div className="space-y-1">
+                  <Label className="text-xs text-muted-foreground">
+                    {t(
+                      'clusterManagement.connector.applyUrl',
+                      'Apply directly with URL'
+                    )}
+                  </Label>
+                  <div className="flex gap-2">
+                    <Input
+                      readOnly
+                      className="font-mono text-xs"
+                      value={`kubectl apply -f ${connectorManifestURL}`}
+                    />
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="icon"
+                      aria-label={t(
+                        'clusterManagement.connector.copyApplyCommand',
+                        'Copy apply command'
+                      )}
+                      onClick={async () => {
+                        try {
+                          await navigator.clipboard.writeText(
+                            `kubectl apply -f ${connectorManifestURL}`
+                          )
+                          setConnectorCopyError(null)
+                          toast.success(t('common.messages.copied', 'Copied'))
+                        } catch {
+                          setConnectorCopyError('yaml')
+                        }
+                      }}
+                    >
+                      <IconCopy className="size-4" />
+                    </Button>
+                  </div>
+                </div>
+              )}
+              {connectorManifestURL && (
+                <div className="space-y-1">
+                  <Label className="text-xs text-muted-foreground">
+                    {t(
+                      'clusterManagement.connector.orUseYaml',
+                      'Or deploy with YAML'
+                    )}
+                  </Label>
+                  <Textarea
+                    readOnly
+                    className="h-96 resize-none font-mono text-xs"
+                    aria-label={t(
+                      'clusterManagement.connector.yaml',
+                      'Kubernetes YAML'
+                    )}
+                    value={connectorYaml}
+                  />
+                </div>
+              )}
               <div className="flex justify-end">
                 <Button
                   type="button"
@@ -613,6 +616,7 @@ spec:
               onClick={() => {
                 setConnectorCommand('')
                 setConnectorYaml('')
+                setConnectorManifestURL('')
                 setConnectorCopyError(null)
               }}
             >

--- a/ui/src/components/settings/cluster-management.tsx
+++ b/ui/src/components/settings/cluster-management.tsx
@@ -576,7 +576,7 @@ export function ClusterManagement() {
                     <Input
                       readOnly
                       className="font-mono text-xs"
-                      value={`kubectl apply -f ${connectorManifestURL}`}
+                      value={`kubectl apply -f "${connectorManifestURL}"`}
                     />
                     <Button
                       type="button"
@@ -589,7 +589,7 @@ export function ClusterManagement() {
                       onClick={async () => {
                         try {
                           await navigator.clipboard.writeText(
-                            `kubectl apply -f ${connectorManifestURL}`
+                            `kubectl apply -f "${connectorManifestURL}"`
                           )
                           setConnectorCopyError(null)
                           toast.success(t('common.messages.copied', 'Copied'))

--- a/ui/src/components/settings/general-management.tsx
+++ b/ui/src/components/settings/general-management.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import {
+  IconLink,
   IconMessage,
   IconRobot,
   IconSettings,
@@ -33,6 +34,7 @@ const DEFAULT_MODEL = 'gpt-4o-mini'
 const DEFAULT_ANTHROPIC_MODEL = 'claude-sonnet-4-5'
 const DEFAULT_KUBECTL_IMAGE = 'zzde/kubectl:latest'
 const DEFAULT_NODE_TERMINAL_IMAGE = 'busybox:latest'
+const DEFAULT_CONNECTOR_IMAGE = 'ghcr.io/kite-org/kite:latest'
 
 interface GeneralSettingsFormData {
   aiAgentEnabled: boolean
@@ -45,6 +47,7 @@ interface GeneralSettingsFormData {
   kubectlEnabled: boolean
   kubectlImage: string
   nodeTerminalImage: string
+  connectorImage: string
   enableAnalytics: boolean
   enableVersionCheck: boolean
   loginPrompt: string
@@ -65,6 +68,7 @@ export function GeneralManagement() {
     kubectlEnabled: true,
     kubectlImage: DEFAULT_KUBECTL_IMAGE,
     nodeTerminalImage: DEFAULT_NODE_TERMINAL_IMAGE,
+    connectorImage: DEFAULT_CONNECTOR_IMAGE,
     enableAnalytics: true,
     enableVersionCheck: true,
     loginPrompt: '',
@@ -83,6 +87,7 @@ export function GeneralManagement() {
       kubectlEnabled: data.kubectlEnabled ?? true,
       kubectlImage: data.kubectlImage || DEFAULT_KUBECTL_IMAGE,
       nodeTerminalImage: data.nodeTerminalImage || DEFAULT_NODE_TERMINAL_IMAGE,
+      connectorImage: data.connectorImage || DEFAULT_CONNECTOR_IMAGE,
       enableAnalytics: data.enableAnalytics ?? false,
       enableVersionCheck: data.enableVersionCheck ?? true,
       loginPrompt: data.loginPrompt || '',
@@ -162,6 +167,7 @@ export function GeneralManagement() {
       kubectlImage: formData.kubectlImage.trim() || DEFAULT_KUBECTL_IMAGE,
       nodeTerminalImage:
         formData.nodeTerminalImage.trim() || DEFAULT_NODE_TERMINAL_IMAGE,
+      connectorImage: formData.connectorImage.trim() || DEFAULT_CONNECTOR_IMAGE,
       enableAnalytics: formData.enableAnalytics,
       enableVersionCheck: formData.enableVersionCheck,
       loginPrompt: formData.loginPrompt.trim(),
@@ -406,6 +412,38 @@ export function GeneralManagement() {
                 }))
               }
               placeholder={DEFAULT_NODE_TERMINAL_IMAGE}
+            />
+          </div>
+        </div>
+
+        <div className="rounded-lg border p-3">
+          <div className="space-y-1">
+            <Label className="flex items-center gap-2 text-sm font-medium">
+              <IconLink className="h-4 w-4" />
+              {t('generalManagement.connector.title', 'Connector Image')}
+            </Label>
+            <p className="text-xs text-muted-foreground">
+              {t(
+                'generalManagement.connector.description',
+                'Container image used when generating the Kite Connector manifest for connector-type clusters.'
+              )}
+            </p>
+          </div>
+
+          <div className="mt-3 space-y-2">
+            <Label htmlFor="general-connector-image">
+              {t('generalManagement.connector.form.image', 'Image')}
+            </Label>
+            <Input
+              id="general-connector-image"
+              value={formData.connectorImage}
+              onChange={(e) =>
+                setFormData((prev) => ({
+                  ...prev,
+                  connectorImage: e.target.value,
+                }))
+              }
+              placeholder={DEFAULT_CONNECTOR_IMAGE}
             />
           </div>
         </div>

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -779,6 +779,13 @@
         "image": "Image"
       }
     },
+    "connector": {
+      "title": "Connector Image",
+      "description": "Container image used when generating the Kite Connector manifest for connector-type clusters.",
+      "form": {
+        "image": "Image"
+      }
+    },
     "runtime": {
       "title": "Runtime",
       "description": "Configure analytics and version checking behavior.",
@@ -887,6 +894,9 @@
       "yaml": "Kubernetes YAML",
       "copyCommand": "Copy command",
       "copyYaml": "Copy YAML",
+      "applyUrl": "Apply directly with URL",
+      "copyApplyCommand": "Copy apply command",
+      "orUseYaml": "Or deploy with YAML",
       "copyError": "Failed to copy. Copy the content manually."
     },
     "empty": {

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -897,6 +897,7 @@
       "applyUrl": "Apply directly with URL",
       "copyApplyCommand": "Copy apply command",
       "orUseYaml": "Or deploy with YAML",
+      "loadYamlError": "Failed to load YAML from the manifest URL.",
       "copyError": "Failed to copy. Copy the content manually."
     },
     "empty": {

--- a/ui/src/i18n/locales/zh.json
+++ b/ui/src/i18n/locales/zh.json
@@ -908,6 +908,7 @@
       "applyUrl": "通过 URL 直接部署",
       "copyApplyCommand": "复制部署命令",
       "orUseYaml": "或使用 YAML 部署",
+      "loadYamlError": "无法通过 Manifest URL 加载 YAML。",
       "copyError": "复制失败，请手动复制内容。"
     },
     "empty": {

--- a/ui/src/i18n/locales/zh.json
+++ b/ui/src/i18n/locales/zh.json
@@ -790,6 +790,13 @@
         "image": "镜像"
       }
     },
+    "connector": {
+      "title": "Connector 镜像",
+      "description": "为 Connector 类型集群生成 Kite Connector 部署清单时使用的容器镜像。",
+      "form": {
+        "image": "镜像"
+      }
+    },
     "runtime": {
       "title": "运行时",
       "description": "配置数据统计和版本检查。",
@@ -898,6 +905,9 @@
       "yaml": "Kubernetes YAML",
       "copyCommand": "复制命令行",
       "copyYaml": "复制 YAML",
+      "applyUrl": "通过 URL 直接部署",
+      "copyApplyCommand": "复制部署命令",
+      "orUseYaml": "或使用 YAML 部署",
       "copyError": "复制失败，请手动复制内容。"
     },
     "empty": {

--- a/ui/src/lib/api/admin.ts
+++ b/ui/src/lib/api/admin.ts
@@ -53,7 +53,6 @@ export const createCluster = async (
   connectorServer?: string
   connectorToken?: string
   connectorManifestURL?: string
-  connectorYaml?: string
 }> => {
   return await apiClient.post<{
     id: number
@@ -61,7 +60,6 @@ export const createCluster = async (
     connectorServer?: string
     connectorToken?: string
     connectorManifestURL?: string
-    connectorYaml?: string
   }>('/admin/clusters/', clusterData)
 }
 

--- a/ui/src/lib/api/admin.ts
+++ b/ui/src/lib/api/admin.ts
@@ -52,12 +52,16 @@ export const createCluster = async (
   message: string
   connectorServer?: string
   connectorToken?: string
+  connectorManifestURL?: string
+  connectorYaml?: string
 }> => {
   return await apiClient.post<{
     id: number
     message: string
     connectorServer?: string
     connectorToken?: string
+    connectorManifestURL?: string
+    connectorYaml?: string
   }>('/admin/clusters/', clusterData)
 }
 
@@ -364,6 +368,7 @@ export interface GeneralSetting {
   kubectlEnabled: boolean
   kubectlImage: string
   nodeTerminalImage: string
+  connectorImage: string
   enableAnalytics: boolean
   enableVersionCheck: boolean
   passwordLoginDisabled: boolean
@@ -382,6 +387,7 @@ export interface GeneralSettingUpdateRequest {
   kubectlEnabled?: boolean
   kubectlImage?: string
   nodeTerminalImage?: string
+  connectorImage?: string
   enableAnalytics?: boolean
   enableVersionCheck?: boolean
   passwordLoginDisabled?: boolean


### PR DESCRIPTION
feat(connector): add connector manifest generation endpoint and UI

<img width="600" alt="image" src="https://github.com/user-attachments/assets/0faa1820-bb08-4b77-9d94-bae3d40025ea" />


- Add `/api/v1/connector/manifest` endpoint that serves a Kubernetes
  deployment YAML authenticated by the connector token
- Introduce CONNECTOR_IMAGE env var and Connector Image setting for
  customizing the deployment image
- Refactor connectorServerURL into a reusable helper
- Update cluster creation flow to return manifest download URL
- Add comprehensive tests for manifest generation
- Add and update documentation for Kite Connector (EN/ZH)
- Fix Docker image tag to use lowercase repository owner in CI

## Summary

Adds a `/api/v1/connector/manifest` endpoint that serves the Kite Connector Kubernetes deployment YAML (Secret, ServiceAccount, ClusterRoleBinding, Deployment) authenticated by the connector token. Introduces a configurable Connector image via the `CONNECTOR_IMAGE` env var and a **Connector Image** general setting, refactors the server-URL derivation into a reusable helper, and updates the cluster creation flow to return a manifest download URL alongside the pre-generated YAML.

## Why

Previously the connector deployment YAML was hard-coded in the frontend, so any change to the manifest (e.g. image, layout) required a frontend rebuild and duplicated the template logic. Moving generation to the backend keeps a single source of truth, lets the image follow the platform configuration, and enables `kubectl apply -f <url>` one-step deployment that users requested.

## Related issue

Closes #590
Closes #683

## Validation

- `go test ./pkg/common/... ./pkg/connector/... ./pkg/cluster/...` passes, covering manifest generation, token validation, the manifest endpoint (valid/missing/malformed/unassociated tokens, disabled cluster), and the `CONNECTOR_IMAGE` env loading.
- `pnpm --dir ui run type-check` and `lint` pass.
- Manual flow verified: creating a Connector cluster returns `connectorManifestURL` and `connectorYaml`; `kubectl apply -f <url>` deploys successfully against a kind cluster.

## Checklist

- [x] I reviewed this PR myself before requesting review.
- [x] I understand the changes, including AI-generated parts (if any).
- [x] For new features, a feature request issue is linked.
- [x] I cleaned up AI noise (unnecessary comments, dead code, and unrelated changes).
- [x] This PR is reasonably scoped (or split into smaller PRs).