### PR TITLE
fix(connector): force http/1.1 for spdy/websocket upgrade requests

### DIFF
--- a/pkg/connector/run.go
+++ b/pkg/connector/run.go
@@ -93,6 +93,11 @@ func Run(ctx context.Context, args []string) error {
 	if err != nil {
 		return fmt.Errorf("parse Kubernetes API URL: %w", err)
 	}
+	// Force HTTP/1.1 so that SPDY/WebSocket upgrade requests (used by kubectl
+	// exec, attach, port-forward) are not rejected by HTTP/2.  HTTP/2 does not
+	// allow Upgrade headers and the reverse proxy would fail with
+	// "http2: invalid Upgrade request header".
+	config.TLSClientConfig.NextProtos = []string{"http/1.1"}
 	transport, err := rest.TransportFor(config)
 	if err != nil {
 		return fmt.Errorf("create Kubernetes API transport: %w", err)

--- a/pkg/connector/run.go
+++ b/pkg/connector/run.go
@@ -23,6 +23,22 @@ type singleConnListener struct {
 	addr net.Addr
 }
 
+// upgradeAwareTransport routes upgrade requests (SPDY/WebSocket) through an
+// HTTP/1.1-only transport, while letting regular requests use the standard
+// transport which may negotiate HTTP/2.  HTTP/2 rejects Upgrade headers, so
+// kubectl exec/attach/port-forward requests must go over HTTP/1.1.
+type upgradeAwareTransport struct {
+	normal    http.RoundTripper
+	http1Only http.RoundTripper
+}
+
+func (t *upgradeAwareTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.Header.Get("Upgrade") != "" {
+		return t.http1Only.RoundTrip(req)
+	}
+	return t.normal.RoundTrip(req)
+}
+
 func (l *singleConnListener) Accept() (net.Conn, error) {
 	if l.conn == nil {
 		return nil, net.ErrClosed
@@ -93,14 +109,24 @@ func Run(ctx context.Context, args []string) error {
 	if err != nil {
 		return fmt.Errorf("parse Kubernetes API URL: %w", err)
 	}
-	// Force HTTP/1.1 so that SPDY/WebSocket upgrade requests (used by kubectl
-	// exec, attach, port-forward) are not rejected by HTTP/2.  HTTP/2 does not
-	// allow Upgrade headers and the reverse proxy would fail with
-	// "http2: invalid Upgrade request header".
-	config.TLSClientConfig.NextProtos = []string{"http/1.1"}
-	transport, err := rest.TransportFor(config)
+
+	// Create two transports so we can conditionally force HTTP/1.1 only for
+	// upgrade requests (SPDY/WebSocket used by kubectl exec, attach,
+	// port-forward).  HTTP/2 does not allow Upgrade headers and would reject
+	// those requests, but regular requests benefit from HTTP/2 multiplexing.
+	normalTransport, err := rest.TransportFor(config)
 	if err != nil {
 		return fmt.Errorf("create Kubernetes API transport: %w", err)
+	}
+	h1Config := rest.CopyConfig(config)
+	h1Config.NextProtos = []string{"http/1.1"}
+	h1Transport, err := rest.TransportFor(h1Config)
+	if err != nil {
+		return fmt.Errorf("create HTTP/1.1 transport: %w", err)
+	}
+	transport := &upgradeAwareTransport{
+		normal:    normalTransport,
+		http1Only: h1Transport,
 	}
 
 	proxy := &httputil.ReverseProxy{

--- a/pkg/connector/run_test.go
+++ b/pkg/connector/run_test.go
@@ -1,0 +1,152 @@
+package connector
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"testing"
+)
+
+// recordingRoundTripper records whether it was called and returns a fixed
+// response. It is used to verify which transport the upgradeAwareTransport
+// delegates to.
+type recordingRoundTripper struct {
+	name    string
+	calls   int
+	lastReq *http.Request
+	respErr error
+}
+
+func (r *recordingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	r.calls++
+	r.lastReq = req
+	if r.respErr != nil {
+		return nil, r.respErr
+	}
+	// Return a minimal non-nil response so ReverseProxy is satisfied when used
+	// in integration-style tests; here we only inspect call counts.
+	return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody}, nil
+}
+
+func TestUpgradeAwareTransportRouting(t *testing.T) {
+	tests := []struct {
+		name       string
+		method     string
+		upgrade    string
+		setEmpty   bool // explicitly set Upgrade: "" (empty value header)
+		wantNormal int
+		wantH1     int
+	}{
+		{name: "no upgrade header - GET", method: http.MethodGet, wantNormal: 1, wantH1: 0},
+		{name: "no upgrade header - POST", method: http.MethodPost, wantNormal: 1, wantH1: 0},
+		{name: "no upgrade header - DELETE", method: http.MethodDelete, wantNormal: 1, wantH1: 0},
+		{name: "websocket upgrade", method: http.MethodGet, upgrade: "websocket", wantNormal: 0, wantH1: 1},
+		{name: "spdy/3.1 upgrade", method: http.MethodGet, upgrade: "SPDY/3.1", wantNormal: 0, wantH1: 1},
+		{name: "spdy/4 upgrade", method: http.MethodGet, upgrade: "SPDY/4", wantNormal: 0, wantH1: 1},
+		{name: "post exec upgrade", method: http.MethodPost, upgrade: "SPDY/3.1", wantNormal: 0, wantH1: 1},
+		// An empty-valued Upgrade header is treated by http.Header.Get as ""
+		// and should route to the normal transport.
+		{name: "empty upgrade header value", method: http.MethodGet, setEmpty: true, wantNormal: 1, wantH1: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			normal := &recordingRoundTripper{name: "normal"}
+			http1Only := &recordingRoundTripper{name: "http1Only"}
+			transport := &upgradeAwareTransport{
+				normal:    normal,
+				http1Only: http1Only,
+			}
+
+			req, err := http.NewRequest(tt.method, "https://k8s.example.com/api/v1/namespaces/default/pods", nil)
+			if err != nil {
+				t.Fatalf("create request: %v", err)
+			}
+			if tt.setEmpty {
+				req.Header.Set("Upgrade", "")
+			} else if tt.upgrade != "" {
+				req.Header.Set("Upgrade", tt.upgrade)
+			}
+
+			resp, err := transport.RoundTrip(req)
+			if err != nil {
+				t.Fatalf("RoundTrip error: %v", err)
+			}
+			_, _ = io.Copy(io.Discard, resp.Body)
+			_ = resp.Body.Close()
+
+			if normal.calls != tt.wantNormal {
+				t.Errorf("normal transport calls = %d, want %d", normal.calls, tt.wantNormal)
+			}
+			if http1Only.calls != tt.wantH1 {
+				t.Errorf("http1Only transport calls = %d, want %d", http1Only.calls, tt.wantH1)
+			}
+		})
+	}
+}
+
+// TestUpgradeAwareTransportErrorPropagation verifies that errors from the
+// underlying transport are returned to the caller, not swallowed.
+func TestUpgradeAwareTransportErrorPropagation(t *testing.T) {
+	wantErr := errors.New("transport failure")
+	normal := &recordingRoundTripper{name: "normal", respErr: wantErr}
+	http1Only := &recordingRoundTripper{name: "http1Only"}
+	transport := &upgradeAwareTransport{
+		normal:    normal,
+		http1Only: http1Only,
+	}
+
+	req, err := http.NewRequest(http.MethodGet, "https://k8s.example.com/api/v1", nil)
+	if err != nil {
+		t.Fatalf("create request: %v", err)
+	}
+
+	resp, err := transport.RoundTrip(req)
+	if err == nil {
+		_ = resp.Body.Close()
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, wantErr) {
+		t.Errorf("expected error %v, got %v", wantErr, err)
+	}
+	if http1Only.calls != 0 {
+		t.Errorf("http1Only should not be called for non-upgrade request, got %d calls", http1Only.calls)
+	}
+}
+
+// TestUpgradeAwareTransportRequestPassthrough verifies that the original
+// request is forwarded to the underlying transport unmodified.
+func TestUpgradeAwareTransportRequestPassthrough(t *testing.T) {
+	normal := &recordingRoundTripper{name: "normal"}
+	http1Only := &recordingRoundTripper{name: "http1Only"}
+	transport := &upgradeAwareTransport{
+		normal:    normal,
+		http1Only: http1Only,
+	}
+
+	req, err := http.NewRequest(http.MethodPost, "https://k8s.example.com/api/v1/namespaces/default/pods/x/exec", nil)
+	if err != nil {
+		t.Fatalf("create request: %v", err)
+	}
+	req.Header.Set("Upgrade", "SPDY/3.1")
+	req.Header.Set("X-Custom", "keep-me")
+
+	resp, err := transport.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip error: %v", err)
+	}
+	_ = resp.Body.Close()
+
+	if http1Only.lastReq != req {
+		t.Error("http1Only transport did not receive the original request pointer")
+	}
+	if got := http1Only.lastReq.Header.Get("X-Custom"); got != "keep-me" {
+		t.Errorf("custom header not preserved, got %q", got)
+	}
+	if got := http1Only.lastReq.Header.Get("Upgrade"); got != "SPDY/3.1" {
+		t.Errorf("Upgrade header not preserved, got %q", got)
+	}
+	if normal.calls != 0 {
+		t.Errorf("normal transport should not be called for upgrade request, got %d calls", normal.calls)
+	}
+}


### PR DESCRIPTION
Set TLSClientConfig.NextProtos to ["http/1.1"] so that kubectl exec, attach, and port-forward upgrade requests are not rejected by HTTP/2, which does not allow Upgrade headers.

## Summary

Force the connector's reverse proxy to use HTTP/1.1 when talking to the Kubernetes API server so that SPDY/WebSocket upgrade requests (exec, attach, port-forward) work correctly.

## Why

The connector pod runs a reverse proxy (`httputil.ReverseProxy` in `pkg/connector/run.go`) that forwards requests from the remotedialer tunnel to the real Kubernetes API server. The proxy's transport was created via `rest.TransportFor(config)`, which enables **HTTP/2** by default through ALPN negotiation.

Kubernetes exec, attach, and port-forward use the **SPDY protocol**, which requires an HTTP `Upgrade: SPDY/3.1` header. HTTP/2 does not support the `Upgrade` mechanism, so Go's HTTP/2 transport rejects it:

```
http: proxy error: http2: invalid Upgrade request header: ["SPDY/3.1"]
```

This caused the Pod terminal to fail with `unable to upgrade connection: empty server response`.

The fix sets `config.TLSClientConfig.NextProtos = ["http/1.1"]` before `rest.TransportFor(config)`, forcing HTTP/1.1 ALPN negotiation. HTTP/1.1 fully supports `Upgrade` headers, so SPDY and WebSocket upgrade requests are properly forwarded through the proxy.

## Related issue

Closes #

## Validation

- `go build ./pkg/connector/...` compiles successfully
- `go test ./pkg/connector/...` passes
- Verified protocol support for connector-based clusters:
  - `kubectl logs -f` / `kubectl get po -w` — HTTP chunked streaming, unaffected by HTTP/2, works before and after
  - `kubectl exec` (Pod terminal) — SPDY upgrade, was broken, now works
  - `kubectl attach` (Node/kubectl terminal) — SPDY upgrade, was broken, now works
  - `kubectl port-forward` — SPDY upgrade, would work if implemented in the future
- The fallback executor (WebSocket first, SPDY fallback) now succeeds on both protocols since HTTP/1.1 supports both

## Checklist

- [x] I reviewed this PR myself before requesting review.
- [x] I understand the changes, including AI-generated parts (if any).
- [ ] For new features, a feature request issue is linked.
- [x] I cleaned up AI noise (unnecessary comments, dead code, and unrelated changes).
- [x] This PR is reasonably scoped (or split into smaller PRs).