### PR TITLE
feat(cluster): add kubeconfig download with k8s api proxy support

### DIFF
--- a/app.go
+++ b/app.go
@@ -8,6 +8,8 @@ import (
 	"github.com/zxh326/kite/internal"
 	"github.com/zxh326/kite/pkg/cluster"
 	"github.com/zxh326/kite/pkg/common"
+	"github.com/zxh326/kite/pkg/email"
+	"github.com/zxh326/kite/pkg/i18n"
 	"github.com/zxh326/kite/pkg/middleware"
 	"github.com/zxh326/kite/pkg/model"
 	"github.com/zxh326/kite/pkg/rbac"
@@ -28,6 +30,7 @@ func initializeApp(ctx context.Context) (*cluster.ClusterManager, error) {
 	if _, err := model.GetGeneralSetting(); err != nil {
 		klog.Warningf("Failed to load general setting: %v", err)
 	}
+	email.StartCleanup()
 
 	rbac.InitRBAC()
 	templates.InitTemplates()
@@ -58,6 +61,7 @@ func buildEngine(cm *cluster.ClusterManager) *gin.Engine {
 	}
 	r.Use(gin.Recovery())
 	r.Use(middleware.Logger())
+	r.Use(i18n.Middleware())
 	r.Use(middleware.DevCORS(common.CORSAllowedOrigins))
 
 	base := r.Group(common.Base)

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -176,6 +176,7 @@ export default defineConfig({
             { text: "资源历史", link: "/zh/guide/resource-history" },
             { text: "自定义侧边栏", link: "/zh/guide/custom-sidebar" },
             { text: "Kube Proxy", link: "/zh/guide/kube-proxy" },
+            { text: "Kubeconfig 下载", link: "/zh/guide/kubeconfig-download" },
           ],
         },
         {

--- a/docs/api/apikey-management.md
+++ b/docs/api/apikey-management.md
@@ -1,0 +1,147 @@
+# API Key Management
+
+API key management APIs are under `/api/v1/admin/apikeys/`.
+
+These endpoints require an authenticated admin user, or an API key with the `admin` role.
+
+## List API keys
+
+```http
+GET /api/v1/admin/apikeys/
+```
+
+Query parameters:
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `page`    | int  | 1       | Page number (1-based) |
+| `size`    | int  | 20      | Page size |
+
+Example:
+
+```bash
+curl \
+  -H "Authorization: kite1-adminsecret" \
+  https://kite.example.com/api/v1/admin/apikeys/?page=1&size=20
+```
+
+Response example:
+
+```json
+{
+  "data": [
+    {
+      "id": 5,
+      "username": "kite5-ci-bot",
+      "provider": "apikey",
+      "apiKey": "kite5-abc123def456",
+      "roles": [
+        {
+          "id": 2,
+          "name": "viewer"
+        }
+      ],
+      "owner": null,
+      "createdAt": "2026-01-15T10:30:00Z",
+      "updatedAt": "2026-01-15T10:30:00Z"
+    }
+  ],
+  "total": 1,
+  "page": 1,
+  "size": 20
+}
+```
+
+## List independent API keys
+
+Returns API keys without an owner (manually created). Used by the RBAC assignment dialog.
+
+```http
+GET /api/v1/admin/apikeys/independent
+```
+
+Example:
+
+```bash
+curl \
+  -H "Authorization: kite1-adminsecret" \
+  https://kite.example.com/api/v1/admin/apikeys/independent
+```
+
+Response example:
+
+```json
+{
+  "apiKeys": [
+    {
+      "id": 5,
+      "username": "kite5-ci-bot",
+      "provider": "apikey"
+    }
+  ]
+}
+```
+
+## Create an API key
+
+```http
+POST /api/v1/admin/apikeys/
+Content-Type: application/json
+```
+
+Request body:
+
+```json
+{
+  "name": "ci-bot"
+}
+```
+
+Example:
+
+```bash
+curl \
+  -X POST \
+  -H "Authorization: kite1-adminsecret" \
+  -H "Content-Type: application/json" \
+  -d '{"name":"ci-bot"}' \
+  https://kite.example.com/api/v1/admin/apikeys/
+```
+
+Response example:
+
+```json
+{
+  "apiKey": {
+    "id": 6,
+    "username": "kite6-ci-bot",
+    "provider": "apikey",
+    "apiKey": "kite6-xyz789ghi012",
+    "createdAt": "2026-01-15T11:00:00Z",
+    "updatedAt": "2026-01-15T11:00:00Z"
+  }
+}
+```
+
+## Delete an API key
+
+```http
+DELETE /api/v1/admin/apikeys/:id
+```
+
+Example:
+
+```bash
+curl \
+  -X DELETE \
+  -H "Authorization: kite1-adminsecret" \
+  https://kite.example.com/api/v1/admin/apikeys/6
+```
+
+Response example:
+
+```json
+{
+  "message": "API key deleted successfully"
+}
+```

--- a/docs/api/authentication.md
+++ b/docs/api/authentication.md
@@ -130,9 +130,12 @@ After creating a key, copy the full value and use it as the `Authorization` head
 
 ## Permissions
 
-API keys use the same RBAC model as regular users.
+API keys use the same RBAC model as regular users. There are two types of API keys:
 
-- Creating an API key does not automatically grant any resource permissions.
+- **Standalone API Keys** (created manually in **Settings -> API Keys**): These have no owner and require roles to be assigned directly via RBAC role assignment. Use `subjectType: "apikey"` when assigning roles through the API, or select "API Key" in the RBAC assignment dialog.
+- **Kubeconfig API Keys** (auto-generated when downloading a kubeconfig): These are linked to the downloading user as their **owner** and dynamically inherit the owner's current RBAC roles. When the owner's roles change, the API key's permissions update automatically. Only one kubeconfig API key per user is valid at a time — downloading a new kubeconfig revokes the previous one.
+
+- Creating a standalone API key does not automatically grant any resource permissions.
 - Resource access under `/api/v1/...` is still checked by RBAC.
 - Admin APIs under `/api/v1/admin/...` require the caller to have the `admin` role.
 - Cluster resource APIs usually also require `x-cluster-name`.

--- a/docs/api/cluster-management.md
+++ b/docs/api/cluster-management.md
@@ -10,30 +10,42 @@ These endpoints require an authenticated admin user, or an API key with the `adm
 GET /api/v1/admin/clusters/
 ```
 
+Query parameters:
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `page`    | int  | 1       | Page number (1-based) |
+| `size`    | int  | 20      | Page size |
+
 Example:
 
 ```bash
 curl \
   -H "Authorization: kite1-adminsecret" \
-  https://kite.example.com/api/v1/admin/clusters/
+  https://kite.example.com/api/v1/admin/clusters/?page=1&size=20
 ```
 
 Response example:
 
 ```json
-[
-  {
-    "id": 1,
-    "name": "demo-cluster",
-    "description": "staging cluster",
-    "enabled": true,
-    "inCluster": false,
-    "isDefault": true,
-    "prometheusURL": "http://prometheus.monitoring.svc:9090",
-    "config": "",
-    "version": "v1.31.0"
-  }
-]
+{
+  "data": [
+    {
+      "id": 1,
+      "name": "demo-cluster",
+      "description": "staging cluster",
+      "enabled": true,
+      "inCluster": false,
+      "isDefault": true,
+      "prometheusURL": "http://prometheus.monitoring.svc:9090",
+      "config": "",
+      "version": "v1.31.0"
+    }
+  ],
+  "total": 1,
+  "page": 1,
+  "size": 20
+}
 ```
 
 ## Create a cluster

--- a/docs/api/rbac-management.md
+++ b/docs/api/rbac-management.md
@@ -130,10 +130,11 @@ Request body:
 }
 ```
 
-Supported `subjectType` values in the current server implementation:
+Supported `subjectType` values:
 
-- `user`
-- `group`
+- `user` — a regular user or service account
+- `group` — an OIDC group
+- `apikey` — a standalone API key (stored as `user` internally). Only API keys without an owner (manually created) can be assigned roles. Kubeconfig-generated API keys inherit roles dynamically from their owner and cannot be assigned roles directly.
 
 Example:
 

--- a/docs/api/rbac-management.md
+++ b/docs/api/rbac-management.md
@@ -10,19 +10,26 @@ These endpoints require an authenticated admin user, or an API key with the `adm
 GET /api/v1/admin/roles/
 ```
 
+Query parameters:
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `page`    | int  | 1       | Page number (1-based) |
+| `size`    | int  | 20      | Page size |
+
 Example:
 
 ```bash
 curl \
   -H "Authorization: kite1-adminsecret" \
-  https://kite.example.com/api/v1/admin/roles/
+  https://kite.example.com/api/v1/admin/roles/?page=1&size=20
 ```
 
 Response example:
 
 ```json
 {
-  "roles": [
+  "data": [
     {
       "id": 2,
       "name": "viewer",
@@ -34,7 +41,10 @@ Response example:
       "verbs": ["get", "log"],
       "assignments": []
     }
-  ]
+  ],
+  "total": 1,
+  "page": 1,
+  "size": 20
 }
 ```
 

--- a/docs/config/config-file.md
+++ b/docs/config/config-file.md
@@ -66,6 +66,7 @@ ldap:
   userFilter: "(uid=%s)"
   usernameAttribute: "uid"
   displayNameAttribute: "cn"
+  emailAttribute: "mail"
   groupBaseDn: "ou=groups,dc=example,dc=com"
   groupFilter: "(member=%s)"
   groupNameAttribute: "cn"
@@ -250,6 +251,7 @@ The super user is created on first startup if it doesn't exist. On subsequent st
 | `userInfoUrl`   | string  | User info endpoint (if no issuer)           | No       |
 | `scopes`        | string  | Comma-separated scopes                      | No       |
 | `usernameClaim` | string  | JWT claim for username                      | No       |
+| `nameClaim`     | string  | JWT claim for display name                  | No       |
 | `groupsClaim`   | string  | JWT claim for groups                        | No       |
 | `allowedGroups` | string  | Comma-separated list of allowed groups      | No       |
 | `enabled`       | boolean | Enable this provider                        | No       |
@@ -270,6 +272,21 @@ The super user is created on first startup if it doesn't exist. On subsequent st
 | `groupBaseDn`          | string  | Base DN for group searches           |                |
 | `groupFilter`          | string  | Group membership filter              | `(member=%s)`  |
 | `groupNameAttribute`   | string  | Group name attribute                 | `cn`           |
+
+### SMTP Configuration
+
+Configure email server for sending verification codes.
+
+```yaml
+smtp:
+  enabled: true
+  host: smtp.example.com
+  port: 587
+  username: user@example.com
+  password: secret
+  fromEmail: noreply@example.com
+  useTLS: true
+```
 
 ### RBAC Configuration
 

--- a/docs/config/oauth-setup.md
+++ b/docs/config/oauth-setup.md
@@ -25,6 +25,8 @@ Follow the instructions on the page to fill in the basic information to use OAut
 Kite supports overriding default OIDC claims and restricting access based on user groups. These options can be configured in the **Advanced Settings** section when adding or editing an OAuth Provider:
 
 - **Username Claim**: Overrides the default claim used to extract the user's username (e.g., `preferred_username`, `upn`, or `nickname`). If left empty, Kite uses standard claims like `email` or `name`.
+- **Name Claim**: Overrides the default claim used to extract the user's display name (e.g., `given_name`, `name`, or `displayName`). If left empty, Kite uses standard claims like `nickname`, `name`, or `displayName`.
+- **Email Claim**: Overrides the default claim used to extract the user's email address (e.g., `email`, `mail`, `userPrincipalName`). If left empty, Kite tries `email`, `mail`, and `userPrincipalName` in that order.
 - **Groups Claim**: Overrides the default claim used to extract the user's groups (e.g., `groups`, `memberOf`, or `roles`). If left empty, Kite defaults to standard group representations.
 - **Allowed Groups**: Restricts login to users who belong to specific groups. Enter a comma-separated list of group names (e.g., `admin, developers`). If configured, users must belong to at least one of these groups to log in. Users without a matching group are denied access.
 

--- a/docs/config/user-management.md
+++ b/docs/config/user-management.md
@@ -28,19 +28,28 @@ In this interface, you can:
 
 MFA and passkey login are enabled by default and can be managed by admins in **Settings -> Authentication**.
 
-Password users can manage their own security settings from the account settings dialog:
+All users can manage their own security settings from the account settings dialog:
 
+- Update their display nickname
 - Enable MFA with a TOTP authenticator app
 - Add or delete passkeys
 - Use passkeys to sign in when passkey login is enabled
 
-MFA and passkeys are available only for password users. OAuth and LDAP users should use the security policies from their identity provider.
+Password users can also change their account password from the account settings dialog. OAuth and LDAP users manage their password through their identity provider.
+
+MFA and passkeys are available for all user types. Password users authenticate security operations with their current password. OAuth and LDAP users authenticate security operations via email verification code (requires SMTP configuration) or MFA code if MFA is already enabled.
+
+## Email Configuration
+
+Users can have an email address associated with their account. For password users, the email can be set in Account Settings (requires current password verification). For OAuth and LDAP users, the email is automatically synced from the identity provider during login (configurable via `emailClaim` for OAuth and `emailAttribute` for LDAP).
+
+Email is required for OAuth/LDAP users to set up MFA or Passkeys, as the email verification code serves as step-up authentication. Configure SMTP settings in Settings → SMTP or via environment variables (`SMTP_HOST`, `SMTP_PORT`, `SMTP_USERNAME`, `SMTP_PASSWORD`, `SMTP_FROM_EMAIL`, `SMTP_USE_TLS`).
 
 ## Best Practices
 
 - Recommend prioritizing OAuth users to achieve unified identity management
 - Password users are suitable for special or temporary scenarios
-- Enable MFA or passkeys for password users
+- Enable MFA or passkeys for all users
 - Regularly review user lists and role assignments to ensure minimal permissions
 - Disable unused accounts to reduce security risks
 

--- a/docs/guide/kite-connector.md
+++ b/docs/guide/kite-connector.md
@@ -13,7 +13,7 @@ In private networks, edge environments, or firewall-restricted scenarios, the ta
 Kite Connector reverses the connection direction:
 
 - The Connector dials Kite Server from the cluster side; Kite does not need to enter the cluster network.
-- Kubernetes credentials stay in the Connector's runtime environment and are never uploaded to Kite Server.
+- During the WebSocket handshake, the Connector sends the Kubernetes API credentials (extracted from its kubeconfig or in-cluster ServiceAccount) to Kite Server. Kite stores them in memory only (never persisted to disk or database) and uses them to authenticate directly against kube-apiserver.
 - Kite still uses its existing Kubernetes Client to access the cluster, so resource management, logs, and terminals do not need a separate protocol.
 
 ## How It Works
@@ -24,13 +24,13 @@ The connection chain looks like this:
 Kite Kubernetes Client
         │
         ▼
-Kite Server authenticated HTTPS loopback proxy
+Kite Server (rest.Config with tunnel dialer + credentials)
         │
         ▼
 WebSocket tunnel (established by the Connector)
         │
         ▼
-Connector in-process Kubernetes API reverse proxy
+Connector raw TCP forwarder
         │
         ▼
 Target cluster kube-apiserver
@@ -39,10 +39,10 @@ Target cluster kube-apiserver
 The detailed process:
 
 1. When you create a Connector cluster in the Kite UI, Kite generates a random connection token, stores only its SHA-256 hash, and shows the raw token once after creation.
-2. The Connector connects to Kite Server's `/api/v1/connector/connect` WebSocket endpoint using the token. Kite validates the token and binds the connection to the corresponding cluster.
-3. Kite Server creates an authenticated HTTPS proxy on a random `127.0.0.1` port for that cluster. Its credentials and pinned certificate remain in process memory, and requests are tunneled to the Connector after authentication.
-4. The Connector serves its Kubernetes API reverse proxy over in-process connections and uses its local ServiceAccount or kubeconfig to reach kube-apiserver.
-5. The Connector strips any `Authorization` and `Impersonate-*` headers coming from Kite, then its local Kubernetes Transport injects the Connector's own cluster credentials.
+2. The Connector extracts Kubernetes API credentials (bearer token, CA cert, client cert/key) from its kubeconfig or in-cluster ServiceAccount, then connects to Kite Server's `/api/v1/connector/connect` WebSocket endpoint using the connection token. The credentials are sent via a header during the WebSocket handshake (protected by WSS/TLS). Kite validates the token, stores the credentials in memory, and binds the connection to the corresponding cluster.
+3. Kite Server builds a `rest.Config` using the stored credentials and a custom dialer that routes through the remotedialer tunnel. TLS and authentication are handled end-to-end by Kite Server's transport — no local proxy or HTTP listener is needed.
+4. When Kite requests a tunnel connection, the Connector creates a raw TCP connection to kube-apiserver using `net.Dial`. The Connector does not parse HTTP, inject headers, or manage transports — it simply forwards bytes.
+5. Header cleanup (stripping `Authorization` and `Impersonate-*` headers from the incoming request) is performed by Kite Server's `HandleK8sProxy` handler before the request enters the tunnel.
 
 A single Connector WebSocket can carry multiple Kubernetes API connections. Streaming requests such as logs, watches, and terminals also travel over the same tunnel.
 
@@ -134,19 +134,20 @@ The Connector then uses the API server and credentials from the kubeconfig's cur
 - Production must use `https://` with a Kite Server certificate issued by a CA trusted by the Connector's runtime environment. The Connector validates the certificate domain and trust chain by standard TLS rules, preventing connections to a forged Kite Server.
 - With `http://` there is no server identity verification, and neither the token nor the tunnel data is protected by TLS. Use it only for controlled local testing.
 - The connection currently uses a Bearer Token; mTLS, client certificate issuance, and certificate rotation are not yet implemented.
+- During the WebSocket handshake, the Connector sends Kubernetes API credentials (bearer token, CA cert, client cert/key) to Kite Server via the `X-Kite-K8s-Credentials` header. This transmission is protected by WSS/TLS encryption. The credentials are stored in Kite Server memory only (never persisted to disk or database) and are automatically cleared when the connection drops. When the ServiceAccount token rotates, the Connector automatically updates the credentials on reconnect.
 
 ### Kubernetes Permissions and Auditing
 
 - The permissions of the Connector's ServiceAccount or kubeconfig determine what Kite can do in the cluster. If you need features like logs or terminals, grant the corresponding Kubernetes RBAC permissions as well.
 - The generated YAML binds the Connector ServiceAccount to `cluster-admin`, granting administrative privileges over the entire cluster. Confirm this meets your security requirements before deploying.
 - Kite users are still governed by Kite's own RBAC, but the identity kube-apiserver sees is the ServiceAccount or kubeconfig user used by the Connector, not the actual logged-in Kite user.
-- The Connector does not accept Kubernetes `Authorization` or `Impersonate-*` headers passed in from Kite.
+- Header cleanup (stripping `Authorization` and `Impersonate-*` headers) is performed by Kite Server before requests enter the tunnel. The Connector itself is a pure TCP forwarder and does not process HTTP headers.
 
 ### Network and Availability
 
 - The Connector only needs outbound access to Kite Server and the target cluster's kube-apiserver; it does not expose any new listening port to the outside.
-- Kite Server's internal proxy uses an authenticated HTTPS endpoint bound only to `127.0.0.1`. The Connector side uses in-process connections and does not open a local operating-system port for the proxy.
+- Kite Server does not open any local listening port for connector clusters. It uses the stored credentials and the remotedialer tunnel dialer directly in its `rest.Config`. The Connector only makes outbound TCP connections to kube-apiserver.
 - The Ingress or reverse proxy in front of Kite must support WebSocket Upgrade and long-lived connections.
 - Connector session routing across multiple Kite Server replicas is not yet implemented. When using Connector clusters, run a single Kite Server replica first.
 - A tunnel disconnect aborts any running logs, watch, or terminal connections. After the Connector reconnects, clients must re-initiate these streaming requests.
-- Terminals and command execution prefer WebSocket and fall back to SPDY on upgrade failure; the API server and intermediate proxies must support the corresponding connection upgrade.
+- For connector clusters, terminals and command execution use the SPDY protocol (with the tunnel dialer injected via `UpgradeTransport`). Non-connector clusters use the standard WebSocket → SPDY fallback.

--- a/docs/guide/kubeconfig-download.md
+++ b/docs/guide/kubeconfig-download.md
@@ -34,11 +34,12 @@ Kite allows you to download a kubeconfig file that uses Kite as a proxy to acces
        │
        ├──────────────┬───────────────────────┐
        ▼ Direct       ▼ Connector tunnel       ▼
-┌──────────────┐ ┌──────────────┐          ┌──────────────┐
-│ K8s API Server│ │ 127.0.0.1   │          │  Agent       │
-│ (direct)      │ │ local proxy │──WSS────→│  (reverse)   │
-└──────────────┘ └──────────────┘          └──────┬───────┘
-                                                   │ HTTPS
+┌──────────────┐                            ┌──────────────┐
+│ K8s API Server│          WSS tunnel        │  Agent       │
+│ (direct)      │◀──────────────────────────│  (TCP        │
+└──────────────┘   rest.Config + dialer     │   forwarder) │
+                                            └──────┬───────┘
+                                                   │ raw TCP
                                                    ▼
                                            ┌──────────────┐
                                            │ K8s API Server│
@@ -48,8 +49,9 @@ Kite allows you to download a kubeconfig file that uses Kite as a proxy to acces
 
 When you download a kubeconfig, Kite:
 
-1. Creates a new **API Key** that inherits your current RBAC roles.
-2. Generates a kubeconfig YAML where:
+1. **Deletes any previously downloaded kubeconfig API keys** for the current user, so only one kubeconfig API key is valid at a time.
+2. Creates a new **API Key** linked to your account as its **owner**. The key dynamically inherits your RBAC roles — if your roles change later, the key's permissions update automatically without re-downloading.
+3. Generates a kubeconfig YAML where:
    - `server` points to Kite's K8s API proxy endpoint (`/api/v1/clusters/{uuid}/k8s-proxy`).
    - `token` is the newly created API Key.
    - `insecure-skip-tls-verify` is set to `true` (traffic goes through Kite).
@@ -125,26 +127,24 @@ The `UpgradeTransport` mechanism injects the cluster's own credentials (bearer t
 
 #### Connector Clusters (Remote, behind firewall)
 
-For connector-based clusters, the SPDY upgrade cannot directly reach the K8s API server. Instead, the request travels through the connector tunnel:
+For connector-based clusters, the request travels through the connector tunnel. The Agent is a pure TCP forwarder — it does not parse HTTP or manage transports. TLS and authentication are handled end-to-end by Kite Server's transport, using credentials that the Agent sent during the WebSocket handshake:
 
 ```
-┌──────────┐               ┌─────────────┐    WSS tunnel    ┌──────────┐   HTTPS   ┌────────────┐
-│   Kite   │ SPDY upgrade  │ Server-side │ ──────────────→ │  Agent   │ ────────→ │ K8s API    │
-│  Server  │ ───────────→  │ local proxy │  remotedialer   │ (Upgrade │ SPDY+TLS │ Server     │
-│          │ 127.0.0.1     │ (Upgrade    │  WebSocket      │ Aware    │ Bearer   │            │
-│          │ HTTP loopback │ AwareHandler)│  (encrypted)    │ Handler) │ Token    │            │
+┌──────────┐               ┌─────────────┐    WSS tunnel    ┌──────────┐   raw TCP  ┌────────────┐
+│   Kite   │ TLS + auth    │ Kite Server │ ──────────────→ │  Agent   │ ────────→ │ K8s API    │
+│  Server  │ ───────────→  │ rest.Config │  remotedialer   │ (TCP     │ net.Dial  │ Server     │
+│          │ (stored creds │ + dialer    │  WebSocket      │ forwarder)│           │            │
+│          │  + dialer)    │             │  (encrypted)    │          │           │            │
 └──────────┘               └─────────────┘                 └──────────┘           └────────────┘
 ```
 
 **Step-by-step for connector clusters:**
 
-1. **Kite builds a `rest.Config`** with `Transport` set to a custom `http.Transport` whose `DialContext` calls `connectorManager.Dialer(clusterID)`.
-2. **The `Dialer`** asks `remotedialer` to open a new tunnel connection to the agent, targeting `kubernetes-api`.
-3. **On the agent side**, `localDialer` receives the tunnel request. It creates a `net.Pipe()` and serves an `http.Server` with an `UpgradeAwareHandler` on the server end.
-4. **The SPDY upgrade request** flows through: `kubectl → Kite's UpgradeAwareHandler → remotedialer tunnel → agent's http.Server → agent's UpgradeAwareHandler → kube-apiserver`.
-5. **The agent's `UpgradeAwareHandler`** injects the cluster's real credentials (from the agent's kubeconfig) and forwards to the K8s API server over HTTPS.
-
-The local proxy on the Kite server listens on `127.0.0.1:<random-port>` using plain HTTP. This is safe because: (1) it only binds to loopback — no remote access; (2) the real network security is provided by the WSS-encrypted remotedialer tunnel; (3) SPDY/WebSocket executors create their own transports and ignore `config.Transport`, so TLS settings on the config would have no effect anyway.
+1. **Agent sends credentials**: During the WebSocket handshake, the Connector extracts Kubernetes API credentials (bearer token, CA cert, client cert/key) from its kubeconfig or in-cluster ServiceAccount and sends them to Kite Server via the `X-Kite-K8s-Credentials` header (protected by WSS/TLS).
+2. **Kite builds a `rest.Config`** using `creds.ToRestConfig(dialer)`, where `dialer` routes through the remotedialer tunnel. The config includes the real kube-apiserver host, TLS settings, and bearer token — all from the stored credentials.
+3. **The `Dialer`** asks `remotedialer` to open a new tunnel connection to the agent, targeting `kubernetes-api`.
+4. **On the agent side**, `localDialer` receives the tunnel request and creates a raw TCP connection to kube-apiserver using `net.Dial`. No HTTP parsing, no header injection, no transport management — pure byte forwarding.
+5. **TLS handshake** happens end-to-end between Kite Server's transport and kube-apiserver, transparently through the tunnel and the Agent's TCP connection.
 
 ### Phase 4: K8s API Server Responds
 
@@ -157,7 +157,7 @@ The K8s API server authenticates the cluster credentials and opens a SPDY connec
 | Stream 2 | Server → Client | stdout (command output) |
 | Stream 3 | Server → Client | stderr (error output) |
 
-These SPDY frames flow back through the same path: `K8s API → (agent UpgradeAwareHandler → tunnel → Kite local proxy →) Kite UpgradeAwareHandler → kubectl`.
+These SPDY frames flow back through the same path: `K8s API → Agent TCP forwarder → tunnel → Kite UpgradeAwareHandler → kubectl`.
 
 ### Phase 5: Interactive Session
 
@@ -169,11 +169,11 @@ K8s client components use `config.Transport` differently. Kite handles this with
 
 | Path | Component | Transport usage | Config |
 |------|-----------|----------------|--------|
-| kubectl/ktctl proxy | `UpgradeAwareHandler` | `utilnet.DialerFor(transport)` extracts `DialContext` | `Transport` + tunnel dialer |
-| terminal/files | `SPDY/WebSocket Executor` | Ignores `config.Transport`, creates own transport | Local proxy `Listen()` |
+| kubectl/ktctl proxy | `UpgradeAwareHandler` | `utilnet.DialerFor(transport)` extracts `DialContext` | `Transport` + tunnel dialer (direct clusters) or `Dial` + credentials (connector clusters) |
+| terminal/files | `SPDY/WebSocket Executor` | Ignores `config.Transport`, creates own transport | SPDY with `UpgradeTransport` injection (connector) or WebSocket → SPDY fallback (direct) |
 
-- **`getRestConfig`** (for `HandleK8sProxy`): Uses `Transport` + tunnel dialer. Works because `UpgradeAwareHandler.DialForUpgrade()` correctly extracts `DialContext` from the transport.
-- **`buildClientSet`** (for terminal/files): Uses local proxy `Listen()` on `127.0.0.1:<port>`. Works because SPDY/WebSocket executors connect to the real IP address without DNS resolution.
+- **`getRestConfig`** (for `HandleK8sProxy`): For direct clusters, uses `Transport` + `MirrorRequest` for auth. For connector clusters, uses `creds.ToRestConfig(dialer)` which sets `Host`, `TLSClientConfig`, `BearerToken`, and `Dial` — TLS and auth are handled end-to-end by the transport.
+- **`buildClientSet`** (for terminal/files): For connector clusters, the `K8sClient` is marked with `IsConnector = true`. When creating executors, `buildExecutor()` dispatches to `buildSPDYExecutorWithDialer()`, which manually creates a SPDY round tripper with `UpgradeTransport` set to an `*http.Transport` containing the tunnel dialer. This works because SPDY's `dialerFor()` extracts `DialContext` from the `UpgradeTransport`.
 
 Additionally, each transport is split by HTTP version:
 
@@ -244,8 +244,8 @@ All streaming protocols are supported through the proxy:
 
 ## Notes
 
-- Each download creates a **new API Key**. You can manage and revoke API keys in **Personal Settings → API Keys**.
-- API Keys inherit the user's roles **at the time of download**. If your roles change later, you need to re-download the kubeconfig.
+- Each download creates a **new API Key** and automatically revokes the previous kubeconfig API key. Only one kubeconfig API key per user is valid at a time.
+- Kubeconfig API Keys **dynamically inherit** the downloading user's current RBAC roles. When the user's roles change, the API Key's permissions update automatically — no need to re-download.
 - The kubeconfig uses `insecure-skip-tls-verify: true` because the TLS termination happens at the Kite server, not at the Kubernetes API Server.
 - For connector-based clusters, the proxy automatically routes through the connector tunnel.
 - Query parameters (e.g. `?watch=true`, `?container=...`, `?command=...`) are forwarded transparently by the proxy.

--- a/docs/guide/kubeconfig-download.md
+++ b/docs/guide/kubeconfig-download.md
@@ -1,0 +1,252 @@
+---
+outline: deep
+---
+
+# Kubeconfig Download
+
+Kite allows you to download a kubeconfig file that uses Kite as a proxy to access your clusters. This means you can use `kubectl` from your local machine without directly exposing the Kubernetes API Server, while Kite's RBAC permission control is still enforced.
+
+## How to Use
+
+1. Click the **Download** icon in the top navigation bar.
+2. In the dialog, select one or more clusters you want to access. The current cluster is selected by default.
+3. Click **Download** — a kubeconfig file will be generated and downloaded.
+
+## How It Works
+
+```
+┌─────────────┐
+│   kubectl   │  uses downloaded kubeconfig
+└──────┬──────┘
+       │ Authorization: Bearer kite-api-key
+       ▼
+┌─────────────────────────────────────────┐
+│         Kite Server (Reverse Proxy)     │
+│  ┌───────────────────────────────────┐  │
+│  │ 1. Auth: validate API Key         │  │
+│  │ 2. Cluster RBAC: CanAccessCluster │  │
+│  │ 3. Parse K8s API path             │  │
+│  │ 4. Resource RBAC: CanAccess       │  │
+│  │ 5. Inject cluster credentials     │  │
+│  │ 6. Proxy to K8s API Server        │  │
+│  └───────────────────────────────────┘  │
+└──────┬──────────────────────────────────┘
+       │
+       ├──────────────┬───────────────────────┐
+       ▼ Direct       ▼ Connector tunnel       ▼
+┌──────────────┐ ┌──────────────┐          ┌──────────────┐
+│ K8s API Server│ │ 127.0.0.1   │          │  Agent       │
+│ (direct)      │ │ local proxy │──WSS────→│  (reverse)   │
+└──────────────┘ └──────────────┘          └──────┬───────┘
+                                                   │ HTTPS
+                                                   ▼
+                                           ┌──────────────┐
+                                           │ K8s API Server│
+                                           │ (private)     │
+                                           └──────────────┘
+```
+
+When you download a kubeconfig, Kite:
+
+1. Creates a new **API Key** that inherits your current RBAC roles.
+2. Generates a kubeconfig YAML where:
+   - `server` points to Kite's K8s API proxy endpoint (`/api/v1/clusters/{uuid}/k8s-proxy`).
+   - `token` is the newly created API Key.
+   - `insecure-skip-tls-verify` is set to `true` (traffic goes through Kite).
+
+## Request Flow: `kubectl exec -it pod-name -- sh` End-to-End
+
+`kubectl exec` is the most complex case because it uses SPDY (or WebSocket) protocol upgrade. Here is the full journey of a single exec request.
+
+### Phase 1: kubectl Sends SPDY Upgrade Request
+
+kubectl reads the downloaded kubeconfig and constructs an HTTP POST request with SPDY upgrade headers:
+
+```
+POST /api/v1/clusters/{cluster-uuid}/k8s-proxy/api/v1/namespaces/default/pods/my-pod/exec?command=sh&stdin=true&stdout=true&tty=true HTTP/1.1
+Host: kite.example.com
+Authorization: Bearer kite<api-key>          ← from kubeconfig token field
+Connection: Upgrade
+Upgrade: SPDY/3.1
+Content-Length: 0
+```
+
+SPDY allows multiplexed, bidirectional streams over a single TCP connection. This is essential for `exec` where stdin/stdout/stderr/error streams must flow simultaneously.
+
+### Phase 2: Kite Server Receives and Authorizes
+
+The request hits Kite's `HandleK8sProxy` handler, which performs six steps:
+
+```
+┌──────────────────────────────────────────────────┐
+│              Kite Server                          │
+│                                                   │
+│  1. Auth: Strip "Bearer " prefix from             │
+│     Authorization header, validate API Key        │
+│     (RequireAuth middleware)                      │
+│                                                   │
+│  2. Cluster RBAC: CanAccessCluster(user, cluster) │
+│     — Does this user have access to the cluster?  │
+│                                                   │
+│  3. Path Parse: parseK8sAPIPath()                 │
+│     /api/v1/namespaces/default/pods/my-pod/exec   │
+│     → resource=pods, ns=default, subresource=exec │
+│                                                   │
+│  4. Resource RBAC: subresource "exec" → verb exec │
+│     CanAccess(user, pods, exec, cluster, default) │
+│                                                   │
+│  5. Strip incoming auth headers:                  │
+│     Del Authorization, Cookie, Impersonate-*      │
+│                                                   │
+│  6. Build proxy transport (force HTTP/1.1         │
+│     because Upgrade header is present)            │
+└──────────────────────────────────────────────────┘
+```
+
+If any check fails, Kite returns a Kubernetes-compatible `metav1.Status` JSON response so that kubectl can display a meaningful error message (e.g. `Error from server (Forbidden): user admin does not have permission to get pods in namespace kube-system on cluster my-cluster (get pods)`) instead of `unknown (get pods)`.
+
+### Phase 3: Kite Server Proxies to K8s API
+
+How Kite connects to the Kubernetes API server depends on the cluster type:
+
+#### Direct Clusters (InCluster / Kubeconfig)
+
+Kite's `UpgradeAwareHandler` upgrades the TCP connection and forwards the raw SPDY frames:
+
+```
+┌──────────────┐    SPDY Upgrade    ┌────────────────┐
+│  Kite Server │ ─────────────────→ │  K8s API Server │
+│  (Upgrade    │   HTTP/1.1 + TLS   │  (validates      │
+│  AwareHandler)│  Bearer Token      │   cluster token) │
+└──────────────┘                    └────────────────┘
+```
+
+The `UpgradeTransport` mechanism injects the cluster's own credentials (bearer token from kubeconfig) into the upgrade request via `MirrorRequest` — a round tripper that captures auth headers without actually sending a request.
+
+#### Connector Clusters (Remote, behind firewall)
+
+For connector-based clusters, the SPDY upgrade cannot directly reach the K8s API server. Instead, the request travels through the connector tunnel:
+
+```
+┌──────────┐               ┌─────────────┐    WSS tunnel    ┌──────────┐   HTTPS   ┌────────────┐
+│   Kite   │ SPDY upgrade  │ Server-side │ ──────────────→ │  Agent   │ ────────→ │ K8s API    │
+│  Server  │ ───────────→  │ local proxy │  remotedialer   │ (Upgrade │ SPDY+TLS │ Server     │
+│          │ 127.0.0.1     │ (Upgrade    │  WebSocket      │ Aware    │ Bearer   │            │
+│          │ HTTP loopback │ AwareHandler)│  (encrypted)    │ Handler) │ Token    │            │
+└──────────┘               └─────────────┘                 └──────────┘           └────────────┘
+```
+
+**Step-by-step for connector clusters:**
+
+1. **Kite builds a `rest.Config`** with `Transport` set to a custom `http.Transport` whose `DialContext` calls `connectorManager.Dialer(clusterID)`.
+2. **The `Dialer`** asks `remotedialer` to open a new tunnel connection to the agent, targeting `kubernetes-api`.
+3. **On the agent side**, `localDialer` receives the tunnel request. It creates a `net.Pipe()` and serves an `http.Server` with an `UpgradeAwareHandler` on the server end.
+4. **The SPDY upgrade request** flows through: `kubectl → Kite's UpgradeAwareHandler → remotedialer tunnel → agent's http.Server → agent's UpgradeAwareHandler → kube-apiserver`.
+5. **The agent's `UpgradeAwareHandler`** injects the cluster's real credentials (from the agent's kubeconfig) and forwards to the K8s API server over HTTPS.
+
+The local proxy on the Kite server listens on `127.0.0.1:<random-port>` using plain HTTP. This is safe because: (1) it only binds to loopback — no remote access; (2) the real network security is provided by the WSS-encrypted remotedialer tunnel; (3) SPDY/WebSocket executors create their own transports and ignore `config.Transport`, so TLS settings on the config would have no effect anyway.
+
+### Phase 4: K8s API Server Responds
+
+The K8s API server authenticates the cluster credentials and opens a SPDY connection with multiple streams:
+
+| Stream | Direction | Content |
+|--------|-----------|---------|
+| Stream 0 | Server → Client | Error messages (if any) |
+| Stream 1 | Client → Server | stdin (your keyboard input) |
+| Stream 2 | Server → Client | stdout (command output) |
+| Stream 3 | Server → Client | stderr (error output) |
+
+These SPDY frames flow back through the same path: `K8s API → (agent UpgradeAwareHandler → tunnel → Kite local proxy →) Kite UpgradeAwareHandler → kubectl`.
+
+### Phase 5: Interactive Session
+
+Once the SPDY connection is established, kubectl and the kubelet container runtime exchange data bidirectionally. Kite's proxy is transparent at this point — it just forwards bytes over the hijacked TCP connection.
+
+## Transport Strategy
+
+K8s client components use `config.Transport` differently. Kite handles this with two separate `rest.Config` paths:
+
+| Path | Component | Transport usage | Config |
+|------|-----------|----------------|--------|
+| kubectl/ktctl proxy | `UpgradeAwareHandler` | `utilnet.DialerFor(transport)` extracts `DialContext` | `Transport` + tunnel dialer |
+| terminal/files | `SPDY/WebSocket Executor` | Ignores `config.Transport`, creates own transport | Local proxy `Listen()` |
+
+- **`getRestConfig`** (for `HandleK8sProxy`): Uses `Transport` + tunnel dialer. Works because `UpgradeAwareHandler.DialForUpgrade()` correctly extracts `DialContext` from the transport.
+- **`buildClientSet`** (for terminal/files): Uses local proxy `Listen()` on `127.0.0.1:<port>`. Works because SPDY/WebSocket executors connect to the real IP address without DNS resolution.
+
+Additionally, each transport is split by HTTP version:
+
+- **Regular requests** (Get/List/Watch/Create): HTTP/2 allowed for multiplexing performance
+- **Upgrade requests** (exec/attach/port-forward): HTTP/1.1 forced, because HTTP/2 prohibits `Upgrade` headers
+
+## RBAC Permission Mapping
+
+Kite's reverse proxy enforces two layers of access control:
+
+| Layer | Check | Description |
+|-------|-------|-------------|
+| Cluster-level | `rbac.CanAccessCluster()` | Verifies the user has access to the target cluster |
+| Resource-level | `rbac.CanAccess()` | Parses the K8s API path and checks resource-level permissions |
+
+### HTTP Method to RBAC Verb Mapping
+
+Kite's RBAC system has only 6 verbs: `get`, `create`, `update`, `delete`, `log`, `exec`. There is no separate `list` or `watch` verb — both K8s `list` and `watch` are HTTP GET requests, so they are mapped to Kite's `get` verb. This means granting `verbs: ["get"]` in Kite RBAC covers `kubectl get pods` (single resource), `kubectl get pods` (list), and `kubectl get pods -w` (watch).
+
+| HTTP Method | K8s Verbs | Kite RBAC Verb |
+|-------------|-----------|----------------|
+| `GET` | `get`, `list`, `watch` | `get` |
+| `POST` | `create` | `create` |
+| `PUT` / `PATCH` | `update`, `patch` | `update` |
+| `DELETE` | `delete` | `delete` |
+
+### Sub-resource Mapping
+
+| Sub-resource | RBAC Verb |
+|-------------|-----------|
+| `/pods/{name}/exec` | `exec` |
+| `/pods/{name}/attach` | `exec` |
+| `/pods/{name}/log` | `log` |
+| `/pods/{name}/portforward` | `exec` |
+
+Discovery endpoints (`/api`, `/apis`, `/version`, `/openapi`) only require cluster-level access and skip resource-level RBAC.
+
+## Error Responses
+
+Error responses use the Kubernetes standard `metav1.Status` JSON format, ensuring client-go can parse and display them properly:
+
+```json
+{
+  "kind": "Status",
+  "apiVersion": "v1",
+  "status": "Failure",
+  "message": "user admin does not have permission to get pods in namespace kube-system on cluster my-cluster",
+  "reason": "Forbidden",
+  "code": 403
+}
+```
+
+This is important because client-go's `transformResponse` always tries to decode 4xx/5xx response bodies as `metav1.Status` objects. If the body is a valid Status, its `message` field replaces the default "unknown" text, so kubectl displays the actual error instead of `Error from server (Forbidden): unknown (get pods)`.
+
+## Supported kubectl Commands
+
+All streaming protocols are supported through the proxy:
+
+| Command | Protocol | Supported |
+|---------|----------|-----------|
+| `kubectl get pods` | HTTP | Yes |
+| `kubectl apply -f` | HTTP | Yes |
+| `kubectl logs -f` | HTTP chunked stream | Yes |
+| `kubectl get po -w` | HTTP chunked stream | Yes |
+| `kubectl exec -it` | SPDY / WebSocket upgrade | Yes |
+| `kubectl attach` | SPDY / WebSocket upgrade | Yes |
+| `kubectl port-forward` | SPDY upgrade | Yes |
+
+## Notes
+
+- Each download creates a **new API Key**. You can manage and revoke API keys in **Personal Settings → API Keys**.
+- API Keys inherit the user's roles **at the time of download**. If your roles change later, you need to re-download the kubeconfig.
+- The kubeconfig uses `insecure-skip-tls-verify: true` because the TLS termination happens at the Kite server, not at the Kubernetes API Server.
+- For connector-based clusters, the proxy automatically routes through the connector tunnel.
+- Query parameters (e.g. `?watch=true`, `?container=...`, `?command=...`) are forwarded transparently by the proxy.
+- The proxy cleans `Authorization` and `Impersonate-*` headers from incoming requests and injects the cluster's own credentials when forwarding to the K8s API Server.

--- a/docs/zh/api/apikey-management.md
+++ b/docs/zh/api/apikey-management.md
@@ -1,0 +1,147 @@
+# API 密钥管理
+
+API 密钥管理接口位于 `/api/v1/admin/apikeys/`。
+
+这些接口要求调用方已经是管理员用户，或者使用一个拥有 `admin` 角色的 API 密钥。
+
+## 获取 API 密钥列表
+
+```http
+GET /api/v1/admin/apikeys/
+```
+
+查询参数：
+
+| 参数   | 类型 | 默认值 | 说明 |
+|--------|------|--------|------|
+| `page` | int  | 1      | 页码（从 1 开始） |
+| `size` | int  | 20     | 每页条数 |
+
+示例：
+
+```bash
+curl \
+  -H "Authorization: kite1-adminsecret" \
+  https://kite.example.com/api/v1/admin/apikeys/?page=1&size=20
+```
+
+响应示例：
+
+```json
+{
+  "data": [
+    {
+      "id": 5,
+      "username": "kite5-ci-bot",
+      "provider": "apikey",
+      "apiKey": "kite5-abc123def456",
+      "roles": [
+        {
+          "id": 2,
+          "name": "viewer"
+        }
+      ],
+      "owner": null,
+      "createdAt": "2026-01-15T10:30:00Z",
+      "updatedAt": "2026-01-15T10:30:00Z"
+    }
+  ],
+  "total": 1,
+  "page": 1,
+  "size": 20
+}
+```
+
+## 获取独立 API 密钥列表
+
+返回没有 owner 的 API 密钥（手动创建的），用于 RBAC 分配对话框。
+
+```http
+GET /api/v1/admin/apikeys/independent
+```
+
+示例：
+
+```bash
+curl \
+  -H "Authorization: kite1-adminsecret" \
+  https://kite.example.com/api/v1/admin/apikeys/independent
+```
+
+响应示例：
+
+```json
+{
+  "apiKeys": [
+    {
+      "id": 5,
+      "username": "kite5-ci-bot",
+      "provider": "apikey"
+    }
+  ]
+}
+```
+
+## 创建 API 密钥
+
+```http
+POST /api/v1/admin/apikeys/
+Content-Type: application/json
+```
+
+请求体：
+
+```json
+{
+  "name": "ci-bot"
+}
+```
+
+示例：
+
+```bash
+curl \
+  -X POST \
+  -H "Authorization: kite1-adminsecret" \
+  -H "Content-Type: application/json" \
+  -d '{"name":"ci-bot"}' \
+  https://kite.example.com/api/v1/admin/apikeys/
+```
+
+响应示例：
+
+```json
+{
+  "apiKey": {
+    "id": 6,
+    "username": "kite6-ci-bot",
+    "provider": "apikey",
+    "apiKey": "kite6-xyz789ghi012",
+    "createdAt": "2026-01-15T11:00:00Z",
+    "updatedAt": "2026-01-15T11:00:00Z"
+  }
+}
+```
+
+## 删除 API 密钥
+
+```http
+DELETE /api/v1/admin/apikeys/:id
+```
+
+示例：
+
+```bash
+curl \
+  -X DELETE \
+  -H "Authorization: kite1-adminsecret" \
+  https://kite.example.com/api/v1/admin/apikeys/6
+```
+
+响应示例：
+
+```json
+{
+  "message": "API key deleted successfully"
+}
+```

--- a/docs/zh/api/authentication.md
+++ b/docs/zh/api/authentication.md
@@ -130,9 +130,12 @@ Authorization: kite12-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
 ## 权限说明
 
-API 密钥与普通用户共用同一套 RBAC 权限模型。
+API 密钥与普通用户共用同一套 RBAC 权限模型。API 密钥分为两种类型：
 
-- 创建 API 密钥本身不会自动获得任何资源权限。
+- **独立 API 密钥**（在 **设置 -> API 密钥** 中手动创建）：没有 Owner，需要通过 RBAC 角色分配直接为其分配角色。通过 API 分配角色时使用 `subjectType: "apikey"`，或在 RBAC 角色分配对话框中选择"API Key"。
+- **Kubeconfig API 密钥**（下载 kubeconfig 时自动生成）：关联到下载用户作为其 **Owner**，动态继承 Owner 当前的 RBAC 角色。Owner 角色变更后权限自动更新，无需重新下载。同一时间每个用户只有一个 kubeconfig API 密钥有效 —— 下载新 kubeconfig 会自动作废旧的。
+
+- 创建独立 API 密钥本身不会自动获得任何资源权限。
 - `/api/v1/...` 下的资源访问仍然会经过 RBAC 校验。
 - `/api/v1/admin/...` 下的管理接口要求调用方拥有 `admin` 角色。
 - 集群资源接口通常还需要传 `x-cluster-name`。

--- a/docs/zh/api/cluster-management.md
+++ b/docs/zh/api/cluster-management.md
@@ -10,30 +10,42 @@
 GET /api/v1/admin/clusters/
 ```
 
+查询参数：
+
+| 参数   | 类型 | 默认值 | 说明 |
+|--------|------|--------|------|
+| `page` | int  | 1      | 页码（从 1 开始） |
+| `size` | int  | 20     | 每页条数 |
+
 示例：
 
 ```bash
 curl \
   -H "Authorization: kite1-adminsecret" \
-  https://kite.example.com/api/v1/admin/clusters/
+  https://kite.example.com/api/v1/admin/clusters/?page=1&size=20
 ```
 
 响应示例：
 
 ```json
-[
-  {
-    "id": 1,
-    "name": "demo-cluster",
-    "description": "staging cluster",
-    "enabled": true,
-    "inCluster": false,
-    "isDefault": true,
-    "prometheusURL": "http://prometheus.monitoring.svc:9090",
-    "config": "",
-    "version": "v1.31.0"
-  }
-]
+{
+  "data": [
+    {
+      "id": 1,
+      "name": "demo-cluster",
+      "description": "staging cluster",
+      "enabled": true,
+      "inCluster": false,
+      "isDefault": true,
+      "prometheusURL": "http://prometheus.monitoring.svc:9090",
+      "config": "",
+      "version": "v1.31.0"
+    }
+  ],
+  "total": 1,
+  "page": 1,
+  "size": 20
+}
 ```
 
 ## 创建集群

--- a/docs/zh/api/rbac-management.md
+++ b/docs/zh/api/rbac-management.md
@@ -132,8 +132,9 @@ Content-Type: application/json
 
 当前服务端实现支持的 `subjectType`：
 
-- `user`
-- `group`
+- `user` — 普通用户或服务账号
+- `group` — OIDC 用户组
+- `apikey` — 独立 API 密钥（内部存储为 `user`）。只有没有 Owner 的 API 密钥（手动创建的）才能直接分配角色。通过 kubeconfig 下载生成的 API 密钥从 Owner 动态继承角色，不能直接分配。
 
 示例：
 

--- a/docs/zh/api/rbac-management.md
+++ b/docs/zh/api/rbac-management.md
@@ -10,19 +10,26 @@ RBAC 管理接口位于 `/api/v1/admin/roles/`。
 GET /api/v1/admin/roles/
 ```
 
+查询参数：
+
+| 参数   | 类型 | 默认值 | 说明 |
+|--------|------|--------|------|
+| `page` | int  | 1      | 页码（从 1 开始） |
+| `size` | int  | 20     | 每页条数 |
+
 示例：
 
 ```bash
 curl \
   -H "Authorization: kite1-adminsecret" \
-  https://kite.example.com/api/v1/admin/roles/
+  https://kite.example.com/api/v1/admin/roles/?page=1&size=20
 ```
 
 响应示例：
 
 ```json
 {
-  "roles": [
+  "data": [
     {
       "id": 2,
       "name": "viewer",
@@ -34,7 +41,10 @@ curl \
       "verbs": ["get", "log"],
       "assignments": []
     }
-  ]
+  ],
+  "total": 1,
+  "page": 1,
+  "size": 20
 }
 ```
 

--- a/docs/zh/config/config-file.md
+++ b/docs/zh/config/config-file.md
@@ -250,6 +250,7 @@ config:
 | `userInfoUrl`   | string  | 用户信息端点（无 issuer 时）            | 否   |
 | `scopes`        | string  | 逗号分隔的 scopes                       | 否   |
 | `usernameClaim` | string  | 用于用户名的 JWT claim                  | 否   |
+| `nameClaim`     | string  | 用于昵称的 JWT claim                    | 否   |
 | `groupsClaim`   | string  | 用于组的 JWT claim                      | 否   |
 | `allowedGroups` | string  | 逗号分隔的允许组列表                    | 否   |
 | `enabled`       | boolean | 启用此提供者                            | 否   |

--- a/docs/zh/config/user-management.md
+++ b/docs/zh/config/user-management.md
@@ -28,19 +28,28 @@ Kite 支持多种用户管理方式，结合 OAuth 与本地密码用户，配�
 
 MFA 和 Passkey 登录默认启用，管理员可以在 **设置 -> 认证** 中管理。
 
-密码用户可以在账号设置弹窗中管理自己的安全设置：
+所有用户都可以在账号设置弹窗中管理自己的安全设置：
 
+- 修改显示昵称
 - 使用 TOTP 认证器应用启用 MFA
 - 添加或删除 Passkey
 - 在启用 Passkey 登录后使用 Passkey 登录
 
-MFA 和 Passkey 仅适用于密码用户。OAuth 和 LDAP 用户应使用身份提供商侧的安全策略。
+密码用户还可以在账号设置弹窗中修改账号密码。OAuth 和 LDAP 用户通过其身份提供商管理密码。
+
+MFA 和 Passkey 已对所有用户类型开放。密码用户通过当前密码验证安全操作。OAuth 和 LDAP 用户通过邮箱验证码（需配置 SMTP）或已启用的 MFA 验证码进行安全操作验证。
+
+## 邮箱配置
+
+用户可以关联邮箱地址。密码用户可以在账号设置中设置邮箱（需要验证当前密码）。OAuth 和 LDAP 用户的邮箱在登录时从身份提供商自动同步（OAuth 通过 `emailClaim` 配置，LDAP 通过 `emailAttribute` 配置）。
+
+OAuth/LDAP 用户设置 MFA 或 Passkey 时需要邮箱，因为邮箱验证码用作安全操作的 step-up 认证。在设置 → SMTP 中配置 SMTP，或通过环境变量配置（`SMTP_HOST`、`SMTP_PORT`、`SMTP_USERNAME`、`SMTP_PASSWORD`、`SMTP_FROM_EMAIL`、`SMTP_USE_TLS`）。
 
 ## 最佳实践
 
 - 推荐优先使用 OAuth 用户，实现统一身份管理
 - 密码用户适用于特殊或临时场景
-- 为密码用户启用 MFA 或 Passkey
+- 为所有用户启用 MFA 或 Passkey
 - 定期审查用户列表和角色分配，确保权限最小化
 - 禁用未使用账号，降低安全风险
 

--- a/docs/zh/guide/kite-connector.md
+++ b/docs/zh/guide/kite-connector.md
@@ -13,7 +13,7 @@ Kite Connector 用于接入 Kite Server 无法主动访问的 Kubernetes 集群�
 Kite Connector 将连接方向反转：
 
 - Connector 从集群侧主动连接 Kite Server，不要求 Kite 主动进入集群网络。
-- Kubernetes 凭据保留在 Connector 运行环境中，不需要上传到 Kite Server。
+- WebSocket 握手时，Connector 将从 kubeconfig 或集群内 ServiceAccount 提取的 Kubernetes API 凭证发送给 Kite Server。Kite 仅在内存中保存（不持久化到磁盘或数据库），并用于直接向 kube-apiserver 认证。
 - Kite 仍然使用现有 Kubernetes Client 访问集群，资源管理、日志和终端等功能不需要单独实现一套协议。
 
 ## 原理
@@ -24,13 +24,13 @@ Kite Connector 将连接方向反转：
 Kite Kubernetes Client
         │
         ▼
-Kite Server 认证 HTTPS 回环代理
+Kite Server（rest.Config + 隧道 dialer + 凭证）
         │
         ▼
 WebSocket 隧道（由 Connector 主动建立）
         │
         ▼
-Connector 进程内 Kubernetes API 反向代理
+Connector 原始 TCP 转发器
         │
         ▼
 目标集群 kube-apiserver
@@ -39,10 +39,10 @@ Connector 进程内 Kubernetes API 反向代理
 具体过程：
 
 1. 在 Kite UI 中创建 Connector 集群时，Kite 生成一个随机连接 Token，只保存 Token 的 SHA-256 哈希，并在创建成功后展示一次原始 Token。
-2. Connector 使用 Token 连接 Kite Server 的 `/api/v1/connector/connect` WebSocket 接口。Kite 校验 Token 后，将连接绑定到对应集群。
-3. Kite Server 为该集群创建一个仅监听随机 `127.0.0.1` 端口的认证 HTTPS 代理。其凭据和固定证书只保存在进程内存中，请求通过认证后才会经隧道转发到 Connector。
-4. Connector 通过进程内连接提供 Kubernetes API 反向代理，并使用本地 ServiceAccount 或 kubeconfig 访问 kube-apiserver。
-5. Connector 会移除来自 Kite 的 `Authorization` 和 `Impersonate-*` 请求头，再由本地 Kubernetes Transport 注入 Connector 自己的集群凭据。
+2. Connector 从 kubeconfig 或集群内 ServiceAccount 提取 Kubernetes API 凭证（bearer token、CA 证书、客户端证书/密钥），然后使用连接 Token 连接 Kite Server 的 `/api/v1/connector/connect` WebSocket 接口。凭证通过 WebSocket 握手头发送（受 WSS/TLS 加密保护）。Kite 校验 Token 后，将凭证存储在内存中，并将连接绑定到对应集群。
+3. Kite Server 使用存储的凭证和 remotedialer 隧道 dialer 构造 `rest.Config`。TLS 和认证由 Kite Server 的 transport 端到端完成——不需要本地代理或 HTTP 监听端口。
+4. 当 Kite 请求隧道连接时，Connector 使用 `net.Dial` 创建到 kube-apiserver 的原始 TCP 连接。Connector 不解析 HTTP、不注入请求头、不管理 transport——只做纯字节转发。
+5. 请求头清洗（移除 `Authorization` 和 `Impersonate-*` 头）由 Kite Server 的 `HandleK8sProxy` 处理器在请求进入隧道之前完成。
 
 一条 Connector WebSocket 可以承载多个 Kubernetes API 连接。日志、Watch 和终端等流式请求也通过同一条隧道传输。
 
@@ -134,19 +134,20 @@ kite connector \
 - 生产环境必须使用 `https://`，并使用 Connector 运行环境信任的 CA 签发 Kite Server 证书。Connector 会按标准 TLS 规则校验证书域名和信任链，从而避免连接到伪造的 Kite Server。
 - 使用 `http://` 时没有服务端身份校验，Token 和隧道数据也不受 TLS 保护，只适合受控的本地测试。
 - 当前连接使用 Bearer Token，尚未实现 mTLS、客户端证书签发和证书轮换。
+- Connector 握手时会将 Kubernetes API 凭证（bearer token、CA 证书、客户端证书/密钥）通过 `X-Kite-K8s-Credentials` 头发送给 Kite Server。该传输受 WSS/TLS 加密保护，凭证仅在 Kite Server 内存中保存（不持久化），断开连接后自动清除。ServiceAccount Token 轮转时，Connector 重连即自动更新凭证。
 
 ### Kubernetes 权限与审计
 
 - Connector 的 ServiceAccount 或 kubeconfig 权限决定 Kite 能够在集群中执行哪些操作。若需要使用日志、终端等功能，应同时授予对应的 Kubernetes RBAC 权限。
 - 当前生成的 YAML 会把 Connector ServiceAccount 绑定到 `cluster-admin`，拥有整个集群的管理权限。部署前应确认这符合你的安全要求。
 - Kite 用户仍受 Kite 自身 RBAC 控制，但 kube-apiserver 看到的请求身份是 Connector 使用的 ServiceAccount 或 kubeconfig 用户，而不是实际的 Kite 登录用户。
-- Connector 不接受 Kite 传入的 Kubernetes `Authorization` 或 `Impersonate-*` 请求头。
+- 请求头清洗（移除 `Authorization` 和 `Impersonate-*` 头）由 Kite Server 在请求进入隧道前完成。Connector 本身是纯 TCP 转发器，不处理任何 HTTP 头。
 
 ### 网络与可用性
 
 - Connector 只需要主动访问 Kite Server 和目标集群 kube-apiserver，不需要向集群外暴露新的监听端口。
-- Kite Server 的内部代理使用仅绑定 `127.0.0.1` 的认证 HTTPS 端点；Connector 侧使用进程内连接。
+- Kite Server 不为 connector 集群打开任何本地监听端口，而是直接在 `rest.Config` 中使用存储的凭证和 remotedialer 隧道 dialer。Connector 只对外发起 TCP 连接到 kube-apiserver。
 - Kite 前方的 Ingress 或反向代理必须支持 WebSocket Upgrade 和长连接。
 - 当前尚未实现跨多个 Kite Server 副本的 Connector Session 路由。使用 Connector 集群时，应先使用单个 Kite Server 副本。
 - 隧道断开会中止正在运行的日志、Watch 或终端连接。Connector 重连后，需要由客户端重新发起这些流式请求。
-- 终端和命令执行优先使用 WebSocket，并在升级失败时回退到 SPDY；API Server 及中间代理需要支持对应的连接升级。
+- Connector 集群的终端和命令执行使用 SPDY 协议（通过 `UpgradeTransport` 注入隧道 dialer）。非 connector 集群使用标准的 WebSocket → SPDY 回退。

--- a/docs/zh/guide/kubeconfig-download.md
+++ b/docs/zh/guide/kubeconfig-download.md
@@ -21,7 +21,7 @@ Kite 允许你下载一个以 Kite 为代理访问集群的 kubeconfig 文件。
        │ Authorization: Bearer kite-api-key
        ▼
 ┌─────────────────────────────────────────┐
-│         Kite Server (反向代理)           │
+│         Kite Server（反向代理）          │
 │  ┌───────────────────────────────────┐  │
 │  │ 1. 认证：验证 API Key             │  │
 │  │ 2. 集群级 RBAC：CanAccessCluster  │  │
@@ -34,22 +34,24 @@ Kite 允许你下载一个以 Kite 为代理访问集群的 kubeconfig 文件。
        │
        ├──────────────┬───────────────────────┐
        ▼ 直连         ▼ Connector 隧道         ▼
-┌──────────────┐ ┌──────────────┐          ┌──────────────┐
-│ K8s API Server│ │ 127.0.0.1   │          │  Agent       │
-│ (直连集群)    │ │ 本地代理     │──WSS────→│  (反向连接)   │
-└──────────────┘ └──────────────┘          └──────┬───────┘
-                                                   │ HTTPS
+┌──────────────┐                            ┌──────────────┐
+│ K8s API Server│          WSS 隧道          │  Agent       │
+│（直连集群）    │◀──────────────────────────│ （TCP        │
+└──────────────┘   rest.Config + dialer     │  转发器）     │
+                                            └──────┬───────┘
+                                                   │ 原始 TCP
                                                    ▼
                                            ┌──────────────┐
                                            │ K8s API Server│
-                                           │ (内网集群)     │
+                                           │（内网集群）    │
                                            └──────────────┘
 ```
 
 当你下载 kubeconfig 时，Kite 会：
 
-1. 创建一个新的 **API Key**，继承你当前的所有 RBAC 角色。
-2. 生成 kubeconfig YAML 文件，其中：
+1. **删除该用户之前下载 kubeconfig 生成的所有旧 API Key**，确保同一时间只有一个 kubeconfig API Key 有效。
+2. 创建一个新的 **API Key**，并将其关联到你的账户作为 **Owner**。该 Key 会**动态继承**你的 RBAC 角色 —— 后续角色变更时权限自动更新，无需重新下载。
+3. 生成 kubeconfig YAML 文件，其中：
    - `server` 指向 Kite 的 K8s API 代理端点（`/api/v1/clusters/{uuid}/k8s-proxy`）。
    - `token` 为新创建的 API Key。
    - `insecure-skip-tls-verify` 设置为 `true`（流量通过 Kite 转发）。
@@ -124,26 +126,24 @@ Kite 的 `UpgradeAwareHandler` 升级 TCP 连接，直接转发 SPDY 帧：
 
 #### Connector 集群（远程，防火墙后）
 
-对于通过 Connector 连接的集群，SPDY 升级无法直接到达 K8s API Server，请求需要经过 Connector 隧道：
+对于通过 Connector 连接的集群，请求经过 Connector 隧道转发。Agent 是纯 TCP 转发器——不解析 HTTP、不管理 transport。TLS 和认证由 Kite Server 的 transport 端到端完成，使用 Agent 在 WebSocket 握手时发送的凭证：
 
 ```
-┌──────────┐               ┌─────────────┐    WSS 隧道     ┌──────────┐   HTTPS   ┌────────────┐
-│   Kite   │ SPDY 升级     │ 服务端       │ ──────────────→ │  Agent   │ ────────→ │ K8s API    │
-│  服务端   │ ───────────→ │ 本地代理      │  remotedialer   │ (Upgrade │ SPDY+TLS │ Server     │
-│          │ 127.0.0.1     │ (Upgrade    │  WebSocket      │ Aware    │ Bearer   │            │
-│          │ HTTP loopback │ AwareHandler)│  (加密)         │ Handler) │ Token    │            │
+┌──────────┐               ┌─────────────┐    WSS 隧道     ┌──────────┐  原始 TCP  ┌────────────┐
+│   Kite   │ TLS + 认证    │ Kite Server │ ──────────────→ │  Agent   │ ────────→ │ K8s API    │
+│  服务端   │ ───────────→ │ rest.Config │  remotedialer   │ (TCP     │ net.Dial  │ Server     │
+│          │ (存储的凭证   │ + dialer    │  WebSocket      │ 转发器)   │           │            │
+│          │  + dialer)    │             │  (加密)         │          │           │            │
 └──────────┘               └─────────────┘                 └──────────┘           └────────────┘
 ```
 
 **Connector 集群分步流程：**
 
-1. **Kite 构建 `rest.Config`**，设置 `Transport` 为一个自定义的 `http.Transport`，其 `DialContext` 调用 `connectorManager.Dialer(clusterID)`。
-2. **`Dialer`** 通过 `remotedialer` 向 Agent 发起隧道连接请求，目标地址为 `kubernetes-api`。
-3. **Agent 端的 `localDialer`** 收到隧道请求后，创建 `net.Pipe()`，在管道的服务端启动一个 `http.Server`，使用 `UpgradeAwareHandler` 处理请求。
-4. **SPDY 升级请求** 流经路径：`kubectl → Kite UpgradeAwareHandler → remotedialer 隧道 → Agent http.Server → Agent UpgradeAwareHandler → kube-apiserver`。
-5. **Agent 的 `UpgradeAwareHandler`** 注入集群的真实凭证（来自 Agent 的 kubeconfig），通过 HTTPS 转发给 K8s API Server。
-
-Kite 服务端的本地代理监听在 `127.0.0.1:<随机端口>`，使用明文 HTTP。这是安全的，因为：（1）只绑定 loopback，外部无法访问；（2）真正的网络安全由 WSS 加密的 remotedialer 隧道提供；（3）SPDY/WebSocket executor 会创建自己的 transport，忽略 `config.Transport`，所以 config 上的 TLS 设置本来也不起作用。
+1. **Agent 发送凭证**：WebSocket 握手时，Connector 从 kubeconfig 或集群内 ServiceAccount 提取 Kubernetes API 凭证（bearer token、CA 证书、客户端证书/密钥），通过 `X-Kite-K8s-Credentials` 头发送给 Kite Server（受 WSS/TLS 加密保护）。
+2. **Kite 构建 `rest.Config`**，使用 `creds.ToRestConfig(dialer)`，其中 `dialer` 通过 remotedialer 隧道路由。config 包含真实的 kube-apiserver 地址、TLS 设置和 bearer token——全部来自存储的凭证。
+3. **`Dialer`** 通过 `remotedialer` 向 Agent 发起隧道连接请求，目标地址为 `kubernetes-api`。
+4. **Agent 端的 `localDialer`** 收到隧道请求后，使用 `net.Dial` 创建到 kube-apiserver 的原始 TCP 连接。不解析 HTTP、不注入请求头、不管理 transport——纯字节转发。
+5. **TLS 握手**在 Kite Server 的 transport 和 kube-apiserver 之间端到端完成，透明地穿过隧道和 Agent 的 TCP 连接。
 
 ### 阶段 4：K8s API Server 响应
 
@@ -156,7 +156,7 @@ K8s API Server 验证集群凭证后，打开 SPDY 连接，建立多个流：
 | Stream 2 | Server → Client | stdout（命令输出） |
 | Stream 3 | Server → Client | stderr（错误输出） |
 
-这些 SPDY 帧沿原路返回：`K8s API → (Agent UpgradeAwareHandler → 隧道 → Kite 本地代理 →) Kite UpgradeAwareHandler → kubectl`。
+这些 SPDY 帧沿原路返回：`K8s API → Agent TCP 转发器 → 隧道 → Kite UpgradeAwareHandler → kubectl`。
 
 ### 阶段 5：交互式会话
 
@@ -168,11 +168,11 @@ K8s 客户端组件对 `config.Transport` 的使用方式不同。Kite 通过两
 
 | 路径 | 组件 | Transport 使用方式 | 配置 |
 |------|------|-------------------|------|
-| kubectl/ktctl proxy | `UpgradeAwareHandler` | `utilnet.DialerFor(transport)` 提取 `DialContext` | `Transport` + 隧道 dialer |
-| terminal/files | `SPDY/WebSocket Executor` | 忽略 `config.Transport`，自建 transport | 本地代理 `Listen()` |
+| kubectl/ktctl proxy | `UpgradeAwareHandler` | `utilnet.DialerFor(transport)` 提取 `DialContext` | `Transport` + 隧道 dialer（直连集群）或 `Dial` + 凭证（connector 集群） |
+| terminal/files | `SPDY/WebSocket Executor` | 忽略 `config.Transport`，自建 transport | SPDY + `UpgradeTransport` 注入（connector）或 WebSocket → SPDY 回退（直连） |
 
-- **`getRestConfig`**（用于 `HandleK8sProxy`）：使用 `Transport` + 隧道 dialer。有效，因为 `UpgradeAwareHandler.DialForUpgrade()` 会正确提取 `DialContext`。
-- **`buildClientSet`**（用于终端/文件）：使用本地代理 `Listen()`（`127.0.0.1:<端口>`）。有效，因为 SPDY/WebSocket executor 连接的是真实 IP 地址，无需 DNS 解析。
+- **`getRestConfig`**（用于 `HandleK8sProxy`）：直连集群使用 `Transport` + `MirrorRequest` 认证。Connector 集群使用 `creds.ToRestConfig(dialer)`，设置 `Host`、`TLSClientConfig`、`BearerToken` 和 `Dial`——TLS 和认证由 transport 端到端完成。
+- **`buildClientSet`**（用于终端/文件）：Connector 集群的 `K8sClient` 标记 `IsConnector = true`。创建 executor 时，`buildExecutor()` 分发到 `buildSPDYExecutorWithDialer()`，手动创建 SPDY round tripper 并设置 `UpgradeTransport` 为包含隧道 dialer 的 `*http.Transport`。这有效，因为 SPDY 的 `dialerFor()` 会从 `UpgradeTransport` 中提取 `DialContext`。
 
 此外，每个 transport 按 HTTP 版本分离：
 
@@ -243,8 +243,8 @@ Discovery 端点（`/api`、`/apis`、`/version`、`/openapi`）仅需集群级�
 
 ## 注意事项
 
-- 每次下载都会创建一个 **新的 API Key**。你可以在 **个人设置 → API Keys** 中管理和删除 API Key。
-- API Key 继承的是用户 **下载时** 的角色。如果后续角色变更，需要重新下载 kubeconfig。
+- 每次下载都会创建一个 **新的 API Key**，并自动作废上一个 kubeconfig API Key。同一时间每个用户只有一个 kubeconfig API Key 有效。
+- kubeconfig API Key **动态继承**下载用户的当前 RBAC 角色。用户角色变更后，API Key 的权限会自动更新，无需重新下载。
 - kubeconfig 使用 `insecure-skip-tls-verify: true`，因为 TLS 终止在 Kite 服务端，而非 Kubernetes API Server。
 - 对于通过 Connector 连接的集群，代理会自动通过 connector 隧道路由请求。
 - 查询参数（如 `?watch=true`、`?container=...`、`?command=...`）会被代理透明转发。

--- a/docs/zh/guide/kubeconfig-download.md
+++ b/docs/zh/guide/kubeconfig-download.md
@@ -1,0 +1,251 @@
+---
+outline: deep
+---
+
+# Kubeconfig 下载
+
+Kite 允许你下载一个以 Kite 为代理访问集群的 kubeconfig 文件。这意味着你可以在本地使用 `kubectl`，无需直接暴露 Kubernetes API Server，同时 Kite 的 RBAC 权限控制依然生效。
+
+## 如何使用
+
+1. 点击顶部导航栏的 **下载** 图标。
+2. 在弹出的对话框中，选择一个或多个你需要访问的集群。当前集群默认选中。
+3. 点击 **下载** — 将生成并下载 kubeconfig 文件。
+
+## 工作原理
+
+```
+┌─────────────┐
+│   kubectl   │  使用下载的 kubeconfig
+└──────┬──────┘
+       │ Authorization: Bearer kite-api-key
+       ▼
+┌─────────────────────────────────────────┐
+│         Kite Server (反向代理)           │
+│  ┌───────────────────────────────────┐  │
+│  │ 1. 认证：验证 API Key             │  │
+│  │ 2. 集群级 RBAC：CanAccessCluster  │  │
+│  │ 3. 解析 K8s API 路径              │  │
+│  │ 4. 资源级 RBAC：CanAccess         │  │
+│  │ 5. 注入集群认证信息               │  │
+│  │ 6. 代理到 K8s API Server          │  │
+│  └───────────────────────────────────┘  │
+└──────┬──────────────────────────────────┘
+       │
+       ├──────────────┬───────────────────────┐
+       ▼ 直连         ▼ Connector 隧道         ▼
+┌──────────────┐ ┌──────────────┐          ┌──────────────┐
+│ K8s API Server│ │ 127.0.0.1   │          │  Agent       │
+│ (直连集群)    │ │ 本地代理     │──WSS────→│  (反向连接)   │
+└──────────────┘ └──────────────┘          └──────┬───────┘
+                                                   │ HTTPS
+                                                   ▼
+                                           ┌──────────────┐
+                                           │ K8s API Server│
+                                           │ (内网集群)     │
+                                           └──────────────┘
+```
+
+当你下载 kubeconfig 时，Kite 会：
+
+1. 创建一个新的 **API Key**，继承你当前的所有 RBAC 角色。
+2. 生成 kubeconfig YAML 文件，其中：
+   - `server` 指向 Kite 的 K8s API 代理端点（`/api/v1/clusters/{uuid}/k8s-proxy`）。
+   - `token` 为新创建的 API Key。
+   - `insecure-skip-tls-verify` 设置为 `true`（流量通过 Kite 转发）。
+
+## 请求链路：`kubectl exec -it pod-name -- sh` 全流程
+
+`kubectl exec` 是最复杂的场景，因为它使用 SPDY（或 WebSocket）协议升级。以下是一次 exec 请求的完整链路。
+
+### 阶段 1：kubectl 发送 SPDY 升级请求
+
+kubectl 读取下载的 kubeconfig，构造一个带 SPDY 升级头的 HTTP POST 请求：
+
+```
+POST /api/v1/clusters/{cluster-uuid}/k8s-proxy/api/v1/namespaces/default/pods/my-pod/exec?command=sh&stdin=true&stdout=true&tty=true HTTP/1.1
+Host: kite.example.com
+Authorization: Bearer kite<api-key>          ← 来自 kubeconfig 的 token 字段
+Connection: Upgrade
+Upgrade: SPDY/3.1
+Content-Length: 0
+```
+
+SPDY 允许在单个 TCP 连接上多路复用双向流。这对于 `exec` 至关重要，因为 stdin/stdout/stderr/error 流需要同时传输。
+
+### 阶段 2：Kite 服务端接收并鉴权
+
+请求到达 Kite 的 `HandleK8sProxy` 处理器，执行六个步骤：
+
+```
+┌──────────────────────────────────────────────────┐
+│              Kite 服务端                          │
+│                                                   │
+│  1. 认证：从 Authorization 头剥离 "Bearer "       │
+│     前缀，验证 API Key（RequireAuth 中间件）       │
+│                                                   │
+│  2. 集群级 RBAC：CanAccessCluster(user, cluster)  │
+│     — 该用户是否有权访问目标集群？                 │
+│                                                   │
+│  3. 路径解析：parseK8sAPIPath()                   │
+│     /api/v1/namespaces/default/pods/my-pod/exec   │
+│     → resource=pods, ns=default, subresource=exec │
+│                                                   │
+│  4. 资源级 RBAC：子资源 "exec" → verb exec        │
+│     CanAccess(user, pods, exec, cluster, default) │
+│                                                   │
+│  5. 清除传入的认证头：                             │
+│     Del Authorization, Cookie, Impersonate-*      │
+│                                                   │
+│  6. 构建代理 transport（强制 HTTP/1.1，           │
+│     因为存在 Upgrade 头）                         │
+└──────────────────────────────────────────────────┘
+```
+
+如果任何一步检查失败，Kite 返回 Kubernetes 标准的 `metav1.Status` JSON 响应，使 kubectl 能显示有意义的错误信息（如 `Error from server (Forbidden): user admin does not have permission to get pods in namespace kube-system on cluster my-cluster (get pods)`），而不是 `unknown (get pods)`。
+
+### 阶段 3：Kite 服务端代理到 K8s API
+
+Kite 连接 Kubernetes API Server 的方式取决于集群类型：
+
+#### 直连集群（InCluster / Kubeconfig）
+
+Kite 的 `UpgradeAwareHandler` 升级 TCP 连接，直接转发 SPDY 帧：
+
+```
+┌──────────────┐    SPDY 升级     ┌────────────────┐
+│  Kite 服务端  │ ──────────────→ │  K8s API Server │
+│  (Upgrade    │   HTTP/1.1 + TLS │  (验证            │
+│  AwareHandler)│  Bearer Token    │   集群 token)    │
+└──────────────┘                  └────────────────┘
+```
+
+`UpgradeTransport` 机制通过 `MirrorRequest` 注入集群自身的凭证（kubeconfig 中的 Bearer Token）到升级请求中。`MirrorRequest` 是一个特殊的 RoundTripper，它捕获认证头而不实际发送请求。
+
+#### Connector 集群（远程，防火墙后）
+
+对于通过 Connector 连接的集群，SPDY 升级无法直接到达 K8s API Server，请求需要经过 Connector 隧道：
+
+```
+┌──────────┐               ┌─────────────┐    WSS 隧道     ┌──────────┐   HTTPS   ┌────────────┐
+│   Kite   │ SPDY 升级     │ 服务端       │ ──────────────→ │  Agent   │ ────────→ │ K8s API    │
+│  服务端   │ ───────────→ │ 本地代理      │  remotedialer   │ (Upgrade │ SPDY+TLS │ Server     │
+│          │ 127.0.0.1     │ (Upgrade    │  WebSocket      │ Aware    │ Bearer   │            │
+│          │ HTTP loopback │ AwareHandler)│  (加密)         │ Handler) │ Token    │            │
+└──────────┘               └─────────────┘                 └──────────┘           └────────────┘
+```
+
+**Connector 集群分步流程：**
+
+1. **Kite 构建 `rest.Config`**，设置 `Transport` 为一个自定义的 `http.Transport`，其 `DialContext` 调用 `connectorManager.Dialer(clusterID)`。
+2. **`Dialer`** 通过 `remotedialer` 向 Agent 发起隧道连接请求，目标地址为 `kubernetes-api`。
+3. **Agent 端的 `localDialer`** 收到隧道请求后，创建 `net.Pipe()`，在管道的服务端启动一个 `http.Server`，使用 `UpgradeAwareHandler` 处理请求。
+4. **SPDY 升级请求** 流经路径：`kubectl → Kite UpgradeAwareHandler → remotedialer 隧道 → Agent http.Server → Agent UpgradeAwareHandler → kube-apiserver`。
+5. **Agent 的 `UpgradeAwareHandler`** 注入集群的真实凭证（来自 Agent 的 kubeconfig），通过 HTTPS 转发给 K8s API Server。
+
+Kite 服务端的本地代理监听在 `127.0.0.1:<随机端口>`，使用明文 HTTP。这是安全的，因为：（1）只绑定 loopback，外部无法访问；（2）真正的网络安全由 WSS 加密的 remotedialer 隧道提供；（3）SPDY/WebSocket executor 会创建自己的 transport，忽略 `config.Transport`，所以 config 上的 TLS 设置本来也不起作用。
+
+### 阶段 4：K8s API Server 响应
+
+K8s API Server 验证集群凭证后，打开 SPDY 连接，建立多个流：
+
+| 流 | 方向 | 内容 |
+|----|------|------|
+| Stream 0 | Server → Client | 错误信息（如有） |
+| Stream 1 | Client → Server | stdin（你的键盘输入） |
+| Stream 2 | Server → Client | stdout（命令输出） |
+| Stream 3 | Server → Client | stderr（错误输出） |
+
+这些 SPDY 帧沿原路返回：`K8s API → (Agent UpgradeAwareHandler → 隧道 → Kite 本地代理 →) Kite UpgradeAwareHandler → kubectl`。
+
+### 阶段 5：交互式会话
+
+SPDY 连接建立后，kubectl 和容器运行时双向交换数据。此时 Kite 的代理是透明的——它只是在劫持的 TCP 连接上转发字节流。
+
+## Transport 策略
+
+K8s 客户端组件对 `config.Transport` 的使用方式不同。Kite 通过两条独立的 `rest.Config` 路径处理：
+
+| 路径 | 组件 | Transport 使用方式 | 配置 |
+|------|------|-------------------|------|
+| kubectl/ktctl proxy | `UpgradeAwareHandler` | `utilnet.DialerFor(transport)` 提取 `DialContext` | `Transport` + 隧道 dialer |
+| terminal/files | `SPDY/WebSocket Executor` | 忽略 `config.Transport`，自建 transport | 本地代理 `Listen()` |
+
+- **`getRestConfig`**（用于 `HandleK8sProxy`）：使用 `Transport` + 隧道 dialer。有效，因为 `UpgradeAwareHandler.DialForUpgrade()` 会正确提取 `DialContext`。
+- **`buildClientSet`**（用于终端/文件）：使用本地代理 `Listen()`（`127.0.0.1:<端口>`）。有效，因为 SPDY/WebSocket executor 连接的是真实 IP 地址，无需 DNS 解析。
+
+此外，每个 transport 按 HTTP 版本分离：
+
+- **普通请求**（Get/List/Watch/Create）：允许 HTTP/2，享受多路复用性能
+- **升级请求**（exec/attach/port-forward）：强制 HTTP/1.1，因为 HTTP/2 规范禁止 `Upgrade` 头
+
+## RBAC 权限映射
+
+Kite 的反向代理执行两层访问控制：
+
+| 层级 | 检查 | 说明 |
+|------|------|------|
+| 集群级 | `rbac.CanAccessCluster()` | 验证用户是否有权访问目标集群 |
+| 资源级 | `rbac.CanAccess()` | 解析 K8s API 路径并检查资源级权限 |
+
+### HTTP Method 到 RBAC Verb 的映射
+
+Kite 的 RBAC 系统只有 6 个 verb：`get`、`create`、`update`、`delete`、`log`、`exec`。没有单独的 `list` 或 `watch` verb —— K8s 的 `list` 和 `watch` 都是 HTTP GET 请求，因此都会映射到 Kite 的 `get` verb。这意味着在 Kite RBAC 中配置 `verbs: ["get"]` 就可以涵盖 `kubectl get pods`（单个资源）、`kubectl get pods`（列表）和 `kubectl get pods -w`（watch）。
+
+| HTTP Method | K8s Verbs | Kite RBAC Verb |
+|-------------|-----------|----------------|
+| `GET` | `get`、`list`、`watch` | `get` |
+| `POST` | `create` | `create` |
+| `PUT` / `PATCH` | `update`、`patch` | `update` |
+| `DELETE` | `delete` | `delete` |
+
+### 子资源映射
+
+| 子资源 | RBAC Verb |
+|--------|-----------|
+| `/pods/{name}/exec` | `exec` |
+| `/pods/{name}/attach` | `exec` |
+| `/pods/{name}/log` | `log` |
+| `/pods/{name}/portforward` | `exec` |
+
+Discovery 端点（`/api`、`/apis`、`/version`、`/openapi`）仅需集群级权限，跳过资源级 RBAC。
+
+## 错误响应
+
+错误响应使用 Kubernetes 标准的 `metav1.Status` JSON 格式，确保 client-go 能正确解析：
+
+```json
+{
+  "kind": "Status",
+  "apiVersion": "v1",
+  "status": "Failure",
+  "message": "user admin does not have permission to get pods in namespace kube-system on cluster my-cluster",
+  "reason": "Forbidden",
+  "code": 403
+}
+```
+
+这很重要，因为 client-go 的 `transformResponse` 对所有 4xx/5xx 响应都会尝试解码 body 为 `metav1.Status` 对象。如果 body 是有效的 Status，其 `message` 字段会替换默认的 "unknown" 文本，kubectl 就能显示实际错误信息，而不是 `Error from server (Forbidden): unknown (get pods)`。
+
+## 支持的 kubectl 命令
+
+所有流式协议均通过代理支持：
+
+| 命令 | 协议 | 支持 |
+|------|------|------|
+| `kubectl get pods` | HTTP | 是 |
+| `kubectl apply -f` | HTTP | 是 |
+| `kubectl logs -f` | HTTP chunked 流 | 是 |
+| `kubectl get po -w` | HTTP chunked 流 | 是 |
+| `kubectl exec -it` | SPDY / WebSocket 升级 | 是 |
+| `kubectl attach` | SPDY / WebSocket 升级 | 是 |
+| `kubectl port-forward` | SPDY 升级 | 是 |
+
+## 注意事项
+
+- 每次下载都会创建一个 **新的 API Key**。你可以在 **个人设置 → API Keys** 中管理和删除 API Key。
+- API Key 继承的是用户 **下载时** 的角色。如果后续角色变更，需要重新下载 kubeconfig。
+- kubeconfig 使用 `insecure-skip-tls-verify: true`，因为 TLS 终止在 Kite 服务端，而非 Kubernetes API Server。
+- 对于通过 Connector 连接的集群，代理会自动通过 connector 隧道路由请求。
+- 查询参数（如 `?watch=true`、`?container=...`、`?command=...`）会被代理透明转发。
+- 代理会清除传入请求中的 `Authorization` 和 `Impersonate-*` 头，并注入集群自身的认证信息再转发到 K8s API Server。

--- a/e2e/specs/backend-api.spec.ts
+++ b/e2e/specs/backend-api.spec.ts
@@ -178,11 +178,12 @@ test('backend APIs work end to end against the real test environment', async ({
       200
     )
     expect(clusters.map((cluster) => cluster.name)).toContain(clusterName)
-    const adminClusters = await expectJSON<Array<{ name: string }>>(
-      await request.get('/api/v1/admin/clusters/'),
-      200
+    const adminClustersResp = await expectJSON<{
+      data: Array<{ name: string }>
+    }>(await request.get('/api/v1/admin/clusters/'), 200)
+    expect(adminClustersResp.data.map((cluster) => cluster.name)).toContain(
+      clusterName
     )
-    expect(adminClusters.map((cluster) => cluster.name)).toContain(clusterName)
     const dummyCluster = await expectJSON<{ id: number }>(
       await request.post('/api/v1/admin/clusters/', {
         data: {
@@ -203,11 +204,13 @@ test('backend APIs work end to end against the real test environment', async ({
       }),
       200
     )
-    const clustersAfterUpdate = await expectJSON<
-      Array<{ id: number; description: string; enabled: boolean }>
-    >(await request.get('/api/v1/admin/clusters/'), 200)
+    const clustersAfterUpdateResp = await expectJSON<{
+      data: Array<{ id: number; description: string; enabled: boolean }>
+    }>(await request.get('/api/v1/admin/clusters/'), 200)
     expect(
-      clustersAfterUpdate.find((cluster) => cluster.id === dummyClusterId)
+      clustersAfterUpdateResp.data.find(
+        (cluster) => cluster.id === dummyClusterId
+      )
     ).toMatchObject({
       description: 'updated backend API E2E cluster',
       enabled: false,
@@ -456,10 +459,10 @@ test('backend APIs work end to end against the real test environment', async ({
     apiKeyId = apiKeyResponse.apiKey.id
     expect(apiKeyResponse.apiKey.username).toBe(apiKeyName)
     expect(apiKeyResponse.apiKey.apiKey).toBeTruthy()
-    const apiKeys = await expectJSON<{
-      apiKeys: Array<{ id: number; username: string; apiKey: string }>
+    const apiKeysResp = await expectJSON<{
+      data: Array<{ id: number; username: string; apiKey: string }>
     }>(await request.get('/api/v1/admin/apikeys/'), 200)
-    const listedAPIKey = apiKeys.apiKeys.find((item) => item.id === apiKeyId)
+    const listedAPIKey = apiKeysResp.data.find((item) => item.id === apiKeyId)
     expect(listedAPIKey?.username).toBe(apiKeyName)
     expect(listedAPIKey?.apiKey).toMatch(/^kite\d+-/)
     const apiKeyToken = listedAPIKey!.apiKey
@@ -521,10 +524,10 @@ test('backend APIs work end to end against the real test environment', async ({
       role: { id: number; name: string }
     }>(await request.get(`/api/v1/admin/roles/${roleId}`), 200)
     expect(fetchedRole.role.name).toBe(roleName)
-    const roles = await expectJSON<{
-      roles: Array<{ id: number; name: string }>
+    const rolesResp = await expectJSON<{
+      data: Array<{ id: number; name: string }>
     }>(await request.get('/api/v1/admin/roles/'), 200)
-    expect(roles.roles).toContainEqual(
+    expect(rolesResp.data).toContainEqual(
       expect.objectContaining({ id: roleId, name: roleName })
     )
     const updatedRole = await expectJSON<{

--- a/go.mod
+++ b/go.mod
@@ -58,6 +58,7 @@ require (
 	github.com/go-viper/mapstructure/v2 v2.5.0 // indirect
 	github.com/go-webauthn/x v0.2.6 // indirect
 	github.com/google/go-tpm v0.9.8 // indirect
+	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
 	github.com/pb33f/ordered-map/v2 v2.3.1 // indirect
 	github.com/philhofer/fwd v1.2.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
@@ -122,7 +123,7 @@ require (
 	github.com/gofrs/flock v0.13.0 // indirect
 	github.com/google/btree v1.1.3 // indirect
 	github.com/google/gnostic-models v0.7.1 // indirect
-	github.com/google/uuid v1.6.0 // indirect
+	github.com/google/uuid v1.6.0
 	github.com/gopherjs/gopherjs v1.12.80 // indirect
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674
 	github.com/gosuri/uitable v0.0.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -341,6 +341,8 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f h1:KUppIJq7/+SVif2QVs3tOP0zanoHgBEVAwHxUSIzRqU=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
+github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f h1:y5//uYreIhSUg3J1GEMiLbxo1LJaP8RfCpH6pymGZus=
+github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/neelance/astrewrite v0.0.0-20160511093645-99348263ae86/go.mod h1:kHJEU3ofeGjhHklVoIGuVj85JJwZ6kWPaJwCIxgnFmo=
 github.com/neelance/sourcemap v0.0.0-20151028013722-8c68805598ab/go.mod h1:Qr6/a/Q4r9LP1IltGz7tA7iOK1WonHEYhu1HRBA7ZiM=
 github.com/onsi/ginkgo/v2 v2.28.1 h1:S4hj+HbZp40fNKuLUQOYLDgZLwNUVn19N3Atb98NCyI=

--- a/internal/config.go
+++ b/internal/config.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/google/uuid"
 	"github.com/zxh326/kite/pkg/common"
 	"github.com/zxh326/kite/pkg/model"
 	"github.com/zxh326/kite/pkg/rbac"
@@ -248,6 +249,7 @@ func applyClusters(clusters []ClusterConfig) error {
 				InCluster:     c.InCluster,
 				IsDefault:     c.Default,
 				Enable:        true,
+				UUID:          uuid.NewString(),
 			}
 			if err := tx.Create(cluster).Error; err != nil {
 				return err

--- a/internal/config.go
+++ b/internal/config.go
@@ -22,6 +22,7 @@ type KiteConfig struct {
 	Clusters  []ClusterConfig  `yaml:"clusters"`
 	OAuth     []OAuthConfig    `yaml:"oauth"`
 	LDAP      *LDAPConfig      `yaml:"ldap"`
+	SMTP      *SMTPConfig      `yaml:"smtp"`
 	RBAC      *RBACConfig      `yaml:"rbac"`
 }
 
@@ -52,6 +53,8 @@ type OAuthConfig struct {
 	Issuer        string `yaml:"issuer"`
 	Enabled       *bool  `yaml:"enabled"`
 	UsernameClaim string `yaml:"usernameClaim"`
+	NameClaim     string `yaml:"nameClaim"`
+	EmailClaim    string `yaml:"emailClaim"`
 	GroupsClaim   string `yaml:"groupsClaim"`
 	AllowedGroups string `yaml:"allowedGroups"`
 }
@@ -66,9 +69,20 @@ type LDAPConfig struct {
 	UserFilter           string `yaml:"userFilter"`
 	UsernameAttribute    string `yaml:"usernameAttribute"`
 	DisplayNameAttribute string `yaml:"displayNameAttribute"`
+	EmailAttribute       string `yaml:"emailAttribute"`
 	GroupBaseDN          string `yaml:"groupBaseDn"`
 	GroupFilter          string `yaml:"groupFilter"`
 	GroupNameAttribute   string `yaml:"groupNameAttribute"`
+}
+
+type SMTPConfig struct {
+	Enabled   bool   `yaml:"enabled"`
+	Host      string `yaml:"host"`
+	Port      int    `yaml:"port"`
+	Username  string `yaml:"username"`
+	Password  string `yaml:"password"`
+	FromEmail string `yaml:"fromEmail"`
+	UseTLS    bool   `yaml:"useTLS"`
 }
 
 type RBACConfig struct {
@@ -154,6 +168,15 @@ func applyConfig(path string, cfg *KiteConfig) AppliedSections {
 		} else {
 			sections["ldap"] = true
 			klog.Info("Applied LDAP settings from config file")
+		}
+	}
+
+	if cfg.SMTP != nil {
+		if err := applySMTP(cfg.SMTP); err != nil {
+			klog.Errorf("Failed to apply SMTP config: %v", err)
+		} else {
+			sections["smtp"] = true
+			klog.Info("Applied SMTP settings from config file")
 		}
 	}
 
@@ -283,6 +306,8 @@ func applyOAuth(providers []OAuthConfig) error {
 				Issuer:        p.Issuer,
 				Enabled:       enabled,
 				UsernameClaim: p.UsernameClaim,
+				NameClaim:     p.NameClaim,
+				EmailClaim:    p.EmailClaim,
 				GroupsClaim:   p.GroupsClaim,
 				AllowedGroups: p.AllowedGroups,
 			}
@@ -305,12 +330,27 @@ func applyLDAP(cfg *LDAPConfig) error {
 		UserFilter:           cfg.UserFilter,
 		UsernameAttribute:    cfg.UsernameAttribute,
 		DisplayNameAttribute: cfg.DisplayNameAttribute,
+		EmailAttribute:       cfg.EmailAttribute,
 		GroupBaseDN:          cfg.GroupBaseDN,
 		GroupFilter:          cfg.GroupFilter,
 		GroupNameAttribute:   cfg.GroupNameAttribute,
 	}
 
 	_, err := model.UpdateLDAPSetting(setting)
+	return err
+}
+
+func applySMTP(cfg *SMTPConfig) error {
+	setting := &model.SMTPSetting{
+		Enabled:   cfg.Enabled,
+		Host:      cfg.Host,
+		Port:      cfg.Port,
+		Username:  cfg.Username,
+		Password:  model.SecretString(cfg.Password),
+		FromEmail: cfg.FromEmail,
+		UseTLS:    cfg.UseTLS,
+	}
+	_, err := model.UpdateSMTPSetting(setting)
 	return err
 }
 

--- a/pkg/apikeys/handler.go
+++ b/pkg/apikeys/handler.go
@@ -44,7 +44,7 @@ func ListAPIKeys(c *gin.Context) {
 	}
 
 	var apiKeys []model.User
-	if err := query.Preload("Owner").Order("id desc").Offset((page - 1) * size).Limit(size).Find(&apiKeys).Error; err != nil {
+	if err := query.Preload("Owner").Order("id").Offset((page - 1) * size).Limit(size).Find(&apiKeys).Error; err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to list API keys"})
 		return
 	}

--- a/pkg/apikeys/handler.go
+++ b/pkg/apikeys/handler.go
@@ -4,8 +4,10 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/gin-gonic/gin"
+	"github.com/zxh326/kite/pkg/common"
 	"github.com/zxh326/kite/pkg/model"
 	"github.com/zxh326/kite/pkg/rbac"
 )
@@ -15,8 +17,34 @@ type CreateAPIKeyRequest struct {
 }
 
 func ListAPIKeys(c *gin.Context) {
-	apiKeys, err := model.ListAPIKeyUsers()
-	if err != nil {
+	page := 1
+	size := 20
+	if p := strings.TrimSpace(c.Query("page")); p != "" {
+		if parsed, err := strconv.Atoi(p); err == nil && parsed > 0 {
+			page = parsed
+		} else {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid page parameter"})
+			return
+		}
+	}
+	if s := strings.TrimSpace(c.Query("size")); s != "" {
+		if parsed, err := strconv.Atoi(s); err == nil && parsed > 0 {
+			size = parsed
+		} else {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid size parameter"})
+			return
+		}
+	}
+
+	query := model.DB.Model(&model.User{}).Where("provider = ?", common.APIKeyProvider)
+	var total int64
+	if err := query.Count(&total).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to count API keys"})
+		return
+	}
+
+	var apiKeys []model.User
+	if err := query.Preload("Owner").Order("id desc").Offset((page - 1) * size).Limit(size).Find(&apiKeys).Error; err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to list API keys"})
 		return
 	}
@@ -29,7 +57,12 @@ func ListAPIKeys(c *gin.Context) {
 			apiKeys[i].Owner.Password = ""
 		}
 	}
-	c.JSON(http.StatusOK, gin.H{"apiKeys": apiKeys})
+	c.JSON(http.StatusOK, gin.H{
+		"data":  apiKeys,
+		"total": total,
+		"page":  page,
+		"size":  size,
+	})
 }
 
 // ListIndependentAPIKeys returns API keys without an owner (manually created).

--- a/pkg/apikeys/handler.go
+++ b/pkg/apikeys/handler.go
@@ -23,6 +23,23 @@ func ListAPIKeys(c *gin.Context) {
 	for i := range apiKeys {
 		apiKeys[i].Roles = rbac.GetUserRoles(apiKeys[i])
 		apiKeys[i].APIKey = model.SecretString(apiKeys[i].GetAPIKey())
+		// Don't expose the owner's API key or password
+		if apiKeys[i].Owner != nil {
+			apiKeys[i].Owner.APIKey = ""
+			apiKeys[i].Owner.Password = ""
+		}
+	}
+	c.JSON(http.StatusOK, gin.H{"apiKeys": apiKeys})
+}
+
+// ListIndependentAPIKeys returns API keys without an owner (manually created).
+// Used by the RBAC assignment dialog to list API keys that can have roles
+// assigned directly.
+func ListIndependentAPIKeys(c *gin.Context) {
+	apiKeys, err := model.ListIndependentAPIKeyUsers()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to list API keys"})
+		return
 	}
 	c.JSON(http.StatusOK, gin.H{"apiKeys": apiKeys})
 }

--- a/pkg/apikeys/handler_test.go
+++ b/pkg/apikeys/handler_test.go
@@ -48,15 +48,18 @@ func TestAPIKeyLifecycleControlsAuthentication(t *testing.T) {
 		t.Fatalf("list status = %d, want %d: %s", listResponse.Code, http.StatusOK, listResponse.Body.String())
 	}
 	var listed struct {
-		APIKeys []model.User `json:"apiKeys"`
+		Data  []model.User `json:"data"`
+		Total int64        `json:"total"`
+		Page  int          `json:"page"`
+		Size  int          `json:"size"`
 	}
 	if err := json.Unmarshal(listResponse.Body.Bytes(), &listed); err != nil {
 		t.Fatalf("decoding list response: %v", err)
 	}
-	if len(listed.APIKeys) != 1 || listed.APIKeys[0].ID != created.APIKey.ID {
-		t.Fatalf("listed API keys = %#v", listed.APIKeys)
+	if len(listed.Data) != 1 || listed.Data[0].ID != created.APIKey.ID {
+		t.Fatalf("listed API keys = %#v", listed)
 	}
-	fullKey := string(listed.APIKeys[0].APIKey)
+	fullKey := string(listed.Data[0].APIKey)
 	wantPrefix := fmt.Sprintf("kite%d-", created.APIKey.ID)
 	if !strings.HasPrefix(fullKey, wantPrefix) || !strings.HasSuffix(fullKey, string(created.APIKey.APIKey)) {
 		t.Fatalf("listed API key = %q, want prefix %q and created secret", fullKey, wantPrefix)
@@ -132,4 +135,54 @@ func performAPIKeyRequest(router *gin.Engine, method string, path string, body s
 	}
 	router.ServeHTTP(recorder, request)
 	return recorder
+}
+
+func TestListAPIKeysPaginates(t *testing.T) {
+	setupAPIKeyTestDB(t)
+	router := gin.New()
+	router.GET("/apikeys", ListAPIKeys)
+
+	for _, name := range []string{"k1", "k2", "k3"} {
+		if _, err := model.NewAPIKeyUser(name); err != nil {
+			t.Fatalf("creating API key %s: %v", name, err)
+		}
+	}
+
+	resp := performAPIKeyRequest(router, http.MethodGet, "/apikeys?page=1&size=2", "")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status = %d: %s", resp.Code, resp.Body.String())
+	}
+	var body struct {
+		Data  []model.User `json:"data"`
+		Total int64        `json:"total"`
+		Page  int          `json:"page"`
+		Size  int          `json:"size"`
+	}
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decoding response: %v", err)
+	}
+	if body.Total != 3 || body.Page != 1 || body.Size != 2 || len(body.Data) != 2 {
+		t.Fatalf("pagination response = %#v", body)
+	}
+
+	page2 := performAPIKeyRequest(router, http.MethodGet, "/apikeys?page=2&size=2", "")
+	if err := json.Unmarshal(page2.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decoding page2: %v", err)
+	}
+	if body.Total != 3 || body.Page != 2 || len(body.Data) != 1 {
+		t.Fatalf("page2 response = %#v", body)
+	}
+}
+
+func TestListAPIKeysRejectsInvalidQueryParameters(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	for _, query := range []string{"page=0", "size=abc"} {
+		recorder := httptest.NewRecorder()
+		ctx, _ := gin.CreateTestContext(recorder)
+		ctx.Request = httptest.NewRequest(http.MethodGet, "/apikeys?"+query, nil)
+		ListAPIKeys(ctx)
+		if recorder.Code != http.StatusBadRequest {
+			t.Fatalf("query %q: status = %d, want %d", query, recorder.Code, http.StatusBadRequest)
+		}
+	}
 }

--- a/pkg/auth/ldap.go
+++ b/pkg/auth/ldap.go
@@ -29,6 +29,7 @@ type ldapConfig struct {
 	UserFilter           string
 	UsernameAttribute    string
 	DisplayNameAttribute string
+	EmailAttribute       string
 	GroupBaseDN          string
 	GroupFilter          string
 	GroupNameAttribute   string
@@ -98,9 +99,12 @@ func (a *LDAPAuthenticator) Authenticate(setting *model.LDAPSetting, username, p
 		displayName = canonicalUsername
 	}
 
+	email := strings.TrimSpace(entry.GetAttributeValue(cfg.EmailAttribute))
+
 	return &model.User{
 		Username:   canonicalUsername,
 		Name:       displayName,
+		Email:      email,
 		Provider:   model.AuthProviderLDAP,
 		Password:   "",
 		OIDCGroups: groups,
@@ -127,6 +131,7 @@ func newLDAPConfig(setting *model.LDAPSetting) (ldapConfig, error) {
 		UserFilter:           normalized.UserFilter,
 		UsernameAttribute:    normalized.UsernameAttribute,
 		DisplayNameAttribute: normalized.DisplayNameAttribute,
+		EmailAttribute:       normalized.EmailAttribute,
 		GroupBaseDN:          normalized.GroupBaseDN,
 		GroupFilter:          normalized.GroupFilter,
 		GroupNameAttribute:   normalized.GroupNameAttribute,
@@ -169,7 +174,7 @@ func findLDAPUser(conn *ldap.Conn, cfg ldapConfig, username string) (*ldap.Entry
 		0,
 		false,
 		filter,
-		[]string{cfg.UsernameAttribute, cfg.DisplayNameAttribute},
+		[]string{cfg.UsernameAttribute, cfg.DisplayNameAttribute, cfg.EmailAttribute},
 		nil,
 	)
 

--- a/pkg/auth/ldap_setting_handler.go
+++ b/pkg/auth/ldap_setting_handler.go
@@ -20,6 +20,7 @@ type UpdateLDAPSettingRequest struct {
 	UserFilter           *string `json:"userFilter"`
 	UsernameAttribute    *string `json:"usernameAttribute"`
 	DisplayNameAttribute *string `json:"displayNameAttribute"`
+	EmailAttribute       *string `json:"emailAttribute"`
 	GroupBaseDN          *string `json:"groupBaseDn"`
 	GroupFilter          *string `json:"groupFilter"`
 	GroupNameAttribute   *string `json:"groupNameAttribute"`
@@ -80,6 +81,7 @@ func ldapSettingResponse(setting *model.LDAPSetting) gin.H {
 		"userFilter":             setting.UserFilter,
 		"usernameAttribute":      setting.UsernameAttribute,
 		"displayNameAttribute":   setting.DisplayNameAttribute,
+		"emailAttribute":         setting.EmailAttribute,
 		"groupBaseDn":            setting.GroupBaseDN,
 		"groupFilter":            setting.GroupFilter,
 		"groupNameAttribute":     setting.GroupNameAttribute,
@@ -114,6 +116,9 @@ func mergeLDAPSetting(current *model.LDAPSetting, req UpdateLDAPSettingRequest) 
 	}
 	if req.DisplayNameAttribute != nil {
 		merged.DisplayNameAttribute = strings.TrimSpace(*req.DisplayNameAttribute)
+	}
+	if req.EmailAttribute != nil {
+		merged.EmailAttribute = strings.TrimSpace(*req.EmailAttribute)
 	}
 	if req.GroupBaseDN != nil {
 		merged.GroupBaseDN = strings.TrimSpace(*req.GroupBaseDN)

--- a/pkg/auth/middleware.go
+++ b/pkg/auth/middleware.go
@@ -65,6 +65,12 @@ func (h *AuthHandler) RequireAuth() gin.HandlerFunc {
 		}
 		authHeader := c.GetHeader("Authorization")
 		if authHeader != "" {
+			// kubectl sends "Authorization: Bearer <token>", while the
+			// Kite API client sends "Authorization: kite<token>" directly.
+			// Strip the "Bearer " prefix so both formats work.
+			if after, ok := strings.CutPrefix(authHeader, "Bearer "); ok {
+				authHeader = after
+			}
 			if after, ok := strings.CutPrefix(authHeader, "kite"); ok {
 				h.RequireAPIKeyAuth(c, after)
 				return

--- a/pkg/auth/oauth_provider.go
+++ b/pkg/auth/oauth_provider.go
@@ -62,6 +62,8 @@ type GenericProvider struct {
 	UserInfoURL   string
 	Name          string
 	UsernameClaim string
+	NameClaim     string
+	EmailClaim    string
 	GroupsClaim   string
 	AllowedGroups []string
 }
@@ -159,6 +161,8 @@ func NewGenericProvider(op model.OAuthProvider) (*GenericProvider, error) {
 		UserInfoURL:   op.UserInfoURL,
 		Name:          string(op.Name),
 		UsernameClaim: op.UsernameClaim,
+		NameClaim:     op.NameClaim,
+		EmailClaim:    op.EmailClaim,
 		GroupsClaim:   op.GroupsClaim,
 		AllowedGroups: allowedGroups,
 	}
@@ -235,7 +239,8 @@ func (g *GenericProvider) GetUserInfo(accessToken string) (*model.User, error) {
 		Provider:   g.Name,
 		Sub:        extractSub(userInfo),
 		Username:   extractUsername(userInfo, g.UsernameClaim),
-		Name:       extractName(userInfo),
+		Name:       extractName(userInfo, g.NameClaim),
+		Email:      extractEmail(userInfo, g.EmailClaim),
 		AvatarURL:  extractAvatarURL(userInfo),
 		OIDCGroups: g.extractOIDCGroups(userInfo, accessToken),
 	}
@@ -314,7 +319,10 @@ func extractUsername(userInfo map[string]interface{}, customClaim string) string
 	return ""
 }
 
-func extractName(userInfo map[string]interface{}) string {
+func extractName(userInfo map[string]interface{}, customClaim string) string {
+	if value := customClaimValue(userInfo, customClaim); value != "" {
+		return value
+	}
 	if nickname, ok := userInfo["nickname"]; ok {
 		return fmt.Sprintf("%v", nickname)
 	}
@@ -322,7 +330,20 @@ func extractName(userInfo map[string]interface{}) string {
 		return v
 	}
 	if nested, ok := unwrapDataField(userInfo); ok {
-		return extractName(nested)
+		return extractName(nested, customClaim)
+	}
+	return ""
+}
+
+func extractEmail(userInfo map[string]interface{}, customClaim string) string {
+	if value := customClaimValue(userInfo, customClaim); value != "" {
+		return value
+	}
+	if v := firstClaimValue(userInfo, "email", "mail", "userPrincipalName"); v != "" {
+		return v
+	}
+	if nested, ok := unwrapDataField(userInfo); ok {
+		return extractEmail(nested, customClaim)
 	}
 	return ""
 }

--- a/pkg/auth/oauth_provider_handler.go
+++ b/pkg/auth/oauth_provider_handler.go
@@ -123,6 +123,8 @@ func (h *AuthHandler) UpdateOAuthProvider(c *gin.Context) {
 		"scopes":         provider.Scopes,
 		"issuer":         provider.Issuer,
 		"username_claim": provider.UsernameClaim,
+		"name_claim":     provider.NameClaim,
+		"email_claim":    provider.EmailClaim,
 		"groups_claim":   provider.GroupsClaim,
 		"allowed_groups": provider.AllowedGroups,
 		"enabled":        provider.Enabled,

--- a/pkg/cluster/cluster_handler.go
+++ b/pkg/cluster/cluster_handler.go
@@ -110,7 +110,7 @@ func (cm *ClusterManager) GetClusterList(c *gin.Context) {
 	}
 
 	var clusters []model.Cluster
-	if err := model.DB.Order("id desc").Offset((page - 1) * size).Limit(size).Find(&clusters).Error; err != nil {
+	if err := model.DB.Order("id").Offset((page - 1) * size).Limit(size).Find(&clusters).Error; err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
@@ -119,17 +119,17 @@ func (cm *ClusterManager) GetClusterList(c *gin.Context) {
 	result := make([]gin.H, 0, len(clusters))
 	for _, cluster := range clusters {
 		clusterInfo := gin.H{
-			"id":               cluster.ID,
-			"name":             cluster.Name,
-			"description":      cluster.Description,
-			"enabled":          cluster.Enable,
-			"inCluster":        cluster.InCluster,
-			"connector":        cluster.Connector,
-			"connected":        cluster.Connector && cm.connectorManager.Connected(cluster.ID),
-			"isDefault":        cluster.IsDefault,
-			"prometheusURL":    cluster.PrometheusURL,
-			"uuid":             cluster.UUID,
-			"config":           "",
+			"id":            cluster.ID,
+			"name":          cluster.Name,
+			"description":   cluster.Description,
+			"enabled":       cluster.Enable,
+			"inCluster":     cluster.InCluster,
+			"connector":     cluster.Connector,
+			"connected":     cluster.Connector && cm.connectorManager.Connected(cluster.ID),
+			"isDefault":     cluster.IsDefault,
+			"prometheusURL": cluster.PrometheusURL,
+			"uuid":          cluster.UUID,
+			"config":        "",
 		}
 
 		if cluster.Connector {

--- a/pkg/cluster/cluster_handler.go
+++ b/pkg/cluster/cluster_handler.go
@@ -84,8 +84,33 @@ func (cm *ClusterManager) GetClusters(c *gin.Context) {
 }
 
 func (cm *ClusterManager) GetClusterList(c *gin.Context) {
-	clusters, err := model.ListClusters()
-	if err != nil {
+	page := 1
+	size := 20
+	if p := strings.TrimSpace(c.Query("page")); p != "" {
+		if parsed, err := strconv.Atoi(p); err == nil && parsed > 0 {
+			page = parsed
+		} else {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid page parameter"})
+			return
+		}
+	}
+	if s := strings.TrimSpace(c.Query("size")); s != "" {
+		if parsed, err := strconv.Atoi(s); err == nil && parsed > 0 {
+			size = parsed
+		} else {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid size parameter"})
+			return
+		}
+	}
+
+	var total int64
+	if err := model.DB.Model(&model.Cluster{}).Count(&total).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	var clusters []model.Cluster
+	if err := model.DB.Order("id desc").Offset((page - 1) * size).Limit(size).Find(&clusters).Error; err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
@@ -121,7 +146,12 @@ func (cm *ClusterManager) GetClusterList(c *gin.Context) {
 		result = append(result, clusterInfo)
 	}
 
-	c.JSON(http.StatusOK, result)
+	c.JSON(http.StatusOK, gin.H{
+		"data":  result,
+		"total": total,
+		"page":  page,
+		"size":  size,
+	})
 }
 
 func (cm *ClusterManager) CreateCluster(c *gin.Context) {

--- a/pkg/cluster/cluster_handler.go
+++ b/pkg/cluster/cluster_handler.go
@@ -42,6 +42,18 @@ func (cm *ClusterManager) GetClusters(c *gin.Context) {
 	clusters, errors, defaultContext := cm.snapshotState()
 	result := make([]common.ClusterInfo, 0, len(clusters))
 	user := c.MustGet("user").(model.User)
+
+	// Build a name→UUID lookup from the DB so the frontend can reference
+	// clusters by UUID for the kubeconfig download.
+	uuidMap := make(map[string]string)
+	if model.DB != nil {
+		if dbClusters, err := model.ListClusters(); err == nil {
+			for _, dc := range dbClusters {
+				uuidMap[dc.Name] = dc.UUID
+			}
+		}
+	}
+
 	for name, cluster := range clusters {
 		if !rbac.CanAccessCluster(user, name) {
 			continue
@@ -50,6 +62,7 @@ func (cm *ClusterManager) GetClusters(c *gin.Context) {
 			Name:      name,
 			Version:   cluster.Version,
 			IsDefault: name == defaultContext,
+			UUID:      uuidMap[name],
 		})
 	}
 	for name, errMsg := range errors {
@@ -60,6 +73,7 @@ func (cm *ClusterManager) GetClusters(c *gin.Context) {
 			Name:      name,
 			Version:   "",
 			IsDefault: false,
+			UUID:      uuidMap[name],
 			Error:     errMsg,
 		})
 	}
@@ -89,6 +103,7 @@ func (cm *ClusterManager) GetClusterList(c *gin.Context) {
 			"connected":     cluster.Connector && cm.connectorManager.Connected(cluster.ID),
 			"isDefault":     cluster.IsDefault,
 			"prometheusURL": cluster.PrometheusURL,
+			"uuid":          cluster.UUID,
 			"config":        "",
 		}
 
@@ -340,6 +355,34 @@ func (cm *ClusterManager) GetConnectorManifest(c *gin.Context) {
 	c.Header("Cache-Control", "no-store")
 	c.Header("Content-Disposition", `attachment; filename="kite-connector.yaml"`)
 	c.Data(http.StatusOK, "text/yaml; charset=utf-8", []byte(manifest))
+}
+
+func (cm *ClusterManager) DownloadKubeconfig(c *gin.Context) {
+	user := c.MustGet("user").(model.User)
+
+	clusterUUIDs := strings.Split(c.Query("clusters"), ",")
+	var validUUIDs []string
+	for _, id := range clusterUUIDs {
+		id = strings.TrimSpace(id)
+		if id != "" {
+			validUUIDs = append(validUUIDs, id)
+		}
+	}
+	if len(validUUIDs) == 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "at least one cluster must be selected"})
+		return
+	}
+
+	serverURL := connectorServerURL(c)
+	yaml, err := GenerateKubeconfig(user, validUUIDs, serverURL)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.Header("Cache-Control", "no-store")
+	c.Header("Content-Disposition", `attachment; filename="kubeconfig"`)
+	c.Data(http.StatusOK, "text/yaml; charset=utf-8", []byte(yaml))
 }
 
 func (cm *ClusterManager) ImportClustersFromKubeconfig(c *gin.Context) {

--- a/pkg/cluster/cluster_handler.go
+++ b/pkg/cluster/cluster_handler.go
@@ -94,17 +94,21 @@ func (cm *ClusterManager) GetClusterList(c *gin.Context) {
 	result := make([]gin.H, 0, len(clusters))
 	for _, cluster := range clusters {
 		clusterInfo := gin.H{
-			"id":            cluster.ID,
-			"name":          cluster.Name,
-			"description":   cluster.Description,
-			"enabled":       cluster.Enable,
-			"inCluster":     cluster.InCluster,
-			"connector":     cluster.Connector,
-			"connected":     cluster.Connector && cm.connectorManager.Connected(cluster.ID),
-			"isDefault":     cluster.IsDefault,
-			"prometheusURL": cluster.PrometheusURL,
-			"uuid":          cluster.UUID,
-			"config":        "",
+			"id":               cluster.ID,
+			"name":             cluster.Name,
+			"description":      cluster.Description,
+			"enabled":          cluster.Enable,
+			"inCluster":        cluster.InCluster,
+			"connector":        cluster.Connector,
+			"connected":        cluster.Connector && cm.connectorManager.Connected(cluster.ID),
+			"isDefault":        cluster.IsDefault,
+			"prometheusURL":    cluster.PrometheusURL,
+			"uuid":             cluster.UUID,
+			"config":           "",
+		}
+
+		if cluster.Connector {
+			clusterInfo["connectorVersion"] = cm.connectorManager.GetVersion(cluster.ID)
 		}
 
 		if clientSet, exists := clusterState[cluster.Name]; exists {

--- a/pkg/cluster/cluster_handler_test.go
+++ b/pkg/cluster/cluster_handler_test.go
@@ -60,12 +60,17 @@ func TestClusterConfigurationLifecyclePreservesSecretsAndDefault(t *testing.T) {
 	if list.Code != http.StatusOK {
 		t.Fatalf("list status = %d, want %d", list.Code, http.StatusOK)
 	}
-	var listed []map[string]any
-	if err := json.Unmarshal(list.Body.Bytes(), &listed); err != nil {
+	var listResp struct {
+		Data  []map[string]any `json:"data"`
+		Total int64            `json:"total"`
+		Page  int              `json:"page"`
+		Size  int              `json:"size"`
+	}
+	if err := json.Unmarshal(list.Body.Bytes(), &listResp); err != nil {
 		t.Fatalf("decoding list response: %v", err)
 	}
-	if len(listed) != 1 || listed[0]["config"] != "" || listed[0]["version"] != "v1.36.2" {
-		t.Fatalf("listed clusters = %#v", listed)
+	if len(listResp.Data) != 1 || listResp.Data[0]["config"] != "" || listResp.Data[0]["version"] != "v1.36.2" {
+		t.Fatalf("listed clusters = %#v", listResp.Data)
 	}
 	if strings.Contains(list.Body.String(), "secret-kubeconfig") {
 		t.Fatal("cluster list exposed kubeconfig")
@@ -183,4 +188,58 @@ func performClusterRequest(router *gin.Engine, method string, path string, body 
 	}
 	router.ServeHTTP(recorder, request)
 	return recorder
+}
+
+func TestGetClusterListPaginates(t *testing.T) {
+	setupClusterHandlerTestDB(t)
+	for _, name := range []string{"c1", "c2", "c3"} {
+		if err := model.AddCluster(&model.Cluster{Name: name, Enable: true}); err != nil {
+			t.Fatalf("creating cluster %s: %v", name, err)
+		}
+	}
+	manager := &ClusterManager{clusters: map[string]*ClientSet{}, errors: map[string]string{}}
+	router := gin.New()
+	router.GET("/clusters", manager.GetClusterList)
+
+	list := performClusterRequest(router, http.MethodGet, "/clusters?page=1&size=2", "")
+	if list.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d: %s", list.Code, http.StatusOK, list.Body.String())
+	}
+	var resp struct {
+		Data  []map[string]any `json:"data"`
+		Total int64            `json:"total"`
+		Page  int              `json:"page"`
+		Size  int              `json:"size"`
+	}
+	if err := json.Unmarshal(list.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decoding response: %v", err)
+	}
+	if resp.Total != 3 || resp.Page != 1 || resp.Size != 2 || len(resp.Data) != 2 {
+		t.Fatalf("pagination response = %#v", resp)
+	}
+
+	page2 := performClusterRequest(router, http.MethodGet, "/clusters?page=2&size=2", "")
+	if page2.Code != http.StatusOK {
+		t.Fatalf("page2 status = %d", page2.Code)
+	}
+	if err := json.Unmarshal(page2.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decoding page2 response: %v", err)
+	}
+	if resp.Total != 3 || resp.Page != 2 || len(resp.Data) != 1 {
+		t.Fatalf("page2 response = %#v", resp)
+	}
+}
+
+func TestGetClusterListRejectsInvalidQueryParameters(t *testing.T) {
+	setupClusterHandlerTestDB(t)
+	manager := &ClusterManager{clusters: map[string]*ClientSet{}, errors: map[string]string{}}
+	router := gin.New()
+	router.GET("/clusters", manager.GetClusterList)
+
+	for _, query := range []string{"page=0", "size=abc"} {
+		resp := performClusterRequest(router, http.MethodGet, "/clusters?"+query, "")
+		if resp.Code != http.StatusBadRequest {
+			t.Fatalf("query %q: status = %d, want %d", query, resp.Code, http.StatusBadRequest)
+		}
+	}
 }

--- a/pkg/cluster/cluster_manager.go
+++ b/pkg/cluster/cluster_manager.go
@@ -429,19 +429,13 @@ func (cm *ClusterManager) buildClientSet(cluster *model.Cluster) (*ClientSet, er
 	if !cluster.Connector {
 		return buildClientSet(cluster)
 	}
-	address, token, caData, err := cm.connectorManager.Listen(cluster.ID)
+	address, err := cm.connectorManager.Listen(cluster.ID)
 	if err != nil {
 		return nil, err
 	}
 	return newClientSet(cluster.Name, &rest.Config{
-		Host:        "https://" + address,
-		BearerToken: token,
-		TLSClientConfig: rest.TLSClientConfig{
-			CAData: caData,
-		},
-		Proxy: func(*http.Request) (*url.URL, error) {
-			return nil, nil
-		},
+		Host:  "http://" + address,
+		Proxy: func(*http.Request) (*url.URL, error) { return nil, nil },
 	}, cluster.PrometheusURL)
 }
 

--- a/pkg/cluster/cluster_manager.go
+++ b/pkg/cluster/cluster_manager.go
@@ -429,14 +429,18 @@ func (cm *ClusterManager) buildClientSet(cluster *model.Cluster) (*ClientSet, er
 	if !cluster.Connector {
 		return buildClientSet(cluster)
 	}
-	address, err := cm.connectorManager.Listen(cluster.ID)
+	creds := cm.connectorManager.GetCredentials(cluster.ID)
+	if creds == nil {
+		return nil, fmt.Errorf("connector cluster %s has no credentials (agent not connected?)", cluster.Name)
+	}
+	dialer := cm.connectorManager.Dialer(cluster.ID)
+	restConfig := creds.ToRestConfig(dialer)
+	cs, err := newClientSet(cluster.Name, restConfig, cluster.PrometheusURL)
 	if err != nil {
 		return nil, err
 	}
-	return newClientSet(cluster.Name, &rest.Config{
-		Host:  "http://" + address,
-		Proxy: func(*http.Request) (*url.URL, error) { return nil, nil },
-	}, cluster.PrometheusURL)
+	cs.K8sClient.IsConnector = true
+	return cs, nil
 }
 
 func (cm *ClusterManager) syncClusters() error {

--- a/pkg/cluster/k8s_proxy.go
+++ b/pkg/cluster/k8s_proxy.go
@@ -1,0 +1,346 @@
+package cluster
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"path"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/zxh326/kite/pkg/common"
+	"github.com/zxh326/kite/pkg/connector"
+	"github.com/zxh326/kite/pkg/model"
+	"github.com/zxh326/kite/pkg/rbac"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/proxy"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/klog/v2"
+)
+
+// discoveryPaths are K8s API paths that only require cluster-level access.
+var discoveryPaths = map[string]bool{
+	"/api":     true,
+	"/apis":    true,
+	"/version": true,
+	"/openapi": true,
+}
+
+// subResourceVerbs maps sub-resources to their RBAC verb.
+var subResourceVerbs = map[string]string{
+	"exec":        string(common.VerbExec),
+	"attach":      string(common.VerbExec),
+	"log":         string(common.VerbLog),
+	"portforward": string(common.VerbExec),
+}
+
+// HandleK8sProxy proxies K8s API requests through Kite with RBAC enforcement.
+// Route: ANY /api/v1/clusters/:clusterUUID/k8s-proxy/*path
+func (cm *ClusterManager) HandleK8sProxy(c *gin.Context) {
+	user := c.MustGet("user").(model.User)
+	clusterUUID := c.Param("clusterUUID")
+	proxyPath := c.Param("path")
+
+	// Path traversal protection: decode and check for ".."
+	decodedPath, err := url.PathUnescape(proxyPath)
+	if err != nil {
+		writeK8sStatus(c, http.StatusBadRequest, "invalid proxy path", metav1.StatusReasonBadRequest)
+		return
+	}
+	if strings.Contains(decodedPath, "..") {
+		writeK8sStatus(c, http.StatusBadRequest, "invalid proxy path: path traversal detected", metav1.StatusReasonBadRequest)
+		return
+	}
+
+	cluster, err := model.GetClusterByUUID(clusterUUID)
+	if err != nil {
+		writeK8sStatus(c, http.StatusNotFound, fmt.Sprintf("cluster %q not found", clusterUUID), metav1.StatusReasonNotFound)
+		return
+	}
+
+	// Layer 1: cluster-level access control
+	if !rbac.CanAccessCluster(user, cluster.Name) {
+		writeK8sStatus(c, http.StatusForbidden,
+			rbac.NoAccess(user.Key(), "access", "cluster", "", cluster.Name), metav1.StatusReasonForbidden)
+		return
+	}
+
+	// Layer 2: resource-level RBAC (skip for discovery endpoints)
+	if !isDiscoveryPath(decodedPath) {
+		resource, namespace, verb, subResource := parseK8sAPIPath(decodedPath, c.Request.Method)
+		if resource != "" {
+			checkVerb := verb
+			if subResource != "" {
+				if v, ok := subResourceVerbs[subResource]; ok {
+					checkVerb = v
+				}
+			}
+			if namespace == "" {
+				namespace = common.AllNamespaces
+			}
+			if !rbac.CanAccess(user, resource, checkVerb, cluster.Name, namespace) {
+				writeK8sStatus(c, http.StatusForbidden,
+					rbac.NoAccess(user.Key(), checkVerb, resource, namespace, cluster.Name), metav1.StatusReasonForbidden)
+				return
+			}
+		}
+	}
+
+	// Get the rest.Config for the cluster
+	restConfig, err := cm.getRestConfig(cluster)
+	if err != nil {
+		klog.Errorf("failed to get rest config for cluster %s: %v", cluster.Name, err)
+		writeK8sStatus(c, http.StatusInternalServerError, "failed to connect to cluster", metav1.StatusReasonInternalError)
+		return
+	}
+
+	// Build the target URL
+	targetURL, err := buildK8sProxyURL(restConfig.Host, decodedPath)
+	if err != nil {
+		writeK8sStatus(c, http.StatusBadRequest, err.Error(), metav1.StatusReasonBadRequest)
+		return
+	}
+	// Preserve query parameters on the target URL.
+	//
+	// NewUpgradeAwareHandler only copies req.URL.RawQuery onto the proxy
+	// location in its *non-upgrade* ServeHTTP branch. For SPDY/WebSocket
+	// upgrades (kubectl exec, port-forward, attach, websocket exec) the
+	// tryUpgrade path directly uses h.Location as-is, so query params
+	// (stdin=true, stdout=true, tty=true, container=..., command=...,
+	// watch=true, timeoutSeconds=..., etc.) would otherwise be lost and
+	// the K8s API would reply with errors like "you must specify at least
+	// 1 of stdin, stdout, stderr".
+	targetURL.RawQuery = c.Request.URL.RawQuery
+
+	// Build transport with cluster credentials. Only force HTTP/1.1 for
+	// upgrade requests (kubectl exec, attach, port-forward); regular API
+	// calls can use HTTP/2 for better multiplexing performance.
+	forceHTTP1 := c.Request.Header.Get("Upgrade") != ""
+	transport, err := buildProxyTransport(restConfig, forceHTTP1)
+	if err != nil {
+		klog.Errorf("failed to build transport for cluster %s: %v", cluster.Name, err)
+		writeK8sStatus(c, http.StatusInternalServerError, "failed to create transport", metav1.StatusReasonInternalError)
+		return
+	}
+
+	// Clean auth and impersonation headers from the incoming request
+	c.Request.Header.Del("Authorization")
+	c.Request.Header.Del("Cookie")
+	for name := range c.Request.Header {
+		if strings.HasPrefix(strings.ToLower(name), "impersonate-") {
+			c.Request.Header.Del(name)
+		}
+	}
+
+	// NewUpgradeAwareHandler.tryUpgrade writes the request directly to the
+	// backend connection via req.Write(conn), bypassing transport.RoundTrip.
+	// This means the auth round trippers inside rest.TransportFor (bearer token,
+	// exec provider, auth provider) are NOT applied for SPDY/WebSocket upgrade
+	// requests (kubectl exec, attach, port-forward), causing the K8s API server
+	// to return 401 "unauthorized".
+	//
+	// UpgradeTransport solves this: DialForUpgrade calls WrapRequest(req) which
+	// runs the auth round trippers against a MirrorRequest round tripper that
+	// captures the modified request (with auth headers added) without actually
+	// sending it. The modified request is then written to the backend connection.
+	responder := &k8sProxyResponder{}
+	handler := proxy.NewUpgradeAwareHandler(targetURL, transport, false, false, responder)
+	authConfig := rest.CopyConfig(restConfig)
+	authConfig.WrapTransport = func(http.RoundTripper) http.RoundTripper {
+		return proxy.MirrorRequest
+	}
+	authTransport, err := rest.TransportFor(authConfig)
+	if err != nil {
+		klog.Errorf("failed to create auth transport for cluster %s: %v", cluster.Name, err)
+		writeK8sStatus(c, http.StatusInternalServerError, "failed to create transport", metav1.StatusReasonInternalError)
+		return
+	}
+	handler.UpgradeTransport = proxy.NewUpgradeRequestRoundTripper(transport, authTransport)
+	handler.FlushInterval = 200 * time.Millisecond
+
+	handler.ServeHTTP(c.Writer, c.Request)
+}
+
+// getRestConfig returns a rest.Config for the given cluster.
+func (cm *ClusterManager) getRestConfig(cluster *model.Cluster) (*rest.Config, error) {
+	if cluster.InCluster {
+		return rest.InClusterConfig()
+	}
+	if cluster.Connector {
+		dialer := cm.connectorManager.Dialer(cluster.ID)
+		transport := &http.Transport{
+			DialContext: dialer,
+			Proxy:       func(*http.Request) (*url.URL, error) { return nil, nil },
+		}
+		return &rest.Config{
+			Host:      "http://" + connector.KubernetesAPITarget,
+			Transport: transport,
+		}, nil
+	}
+	config, err := clientcmd.RESTConfigFromKubeConfig([]byte(string(cluster.Config)))
+	if err != nil {
+		return nil, fmt.Errorf("parse kubeconfig: %w", err)
+	}
+	return config, nil
+}
+
+// buildK8sProxyURL constructs the target URL for the K8s API server.
+func buildK8sProxyURL(host, proxyPath string) (*url.URL, error) {
+	target, err := url.Parse(host)
+	if err != nil {
+		return nil, fmt.Errorf("parse cluster host: %w", err)
+	}
+	target.Path = path.Join(target.Path, "/"+strings.TrimPrefix(proxyPath, "/"))
+	target.RawPath = ""
+	target.RawQuery = ""
+	return target, nil
+}
+
+// buildProxyTransport creates an HTTP transport from the rest.Config.
+// When forceHTTP1 is true, the transport is restricted to HTTP/1.1 for
+// SPDY/WebSocket upgrade support (kubectl exec, attach, port-forward).
+func buildProxyTransport(restConfig *rest.Config, forceHTTP1 bool) (http.RoundTripper, error) {
+	cfg := rest.CopyConfig(restConfig)
+	if forceHTTP1 {
+		cfg.NextProtos = []string{"http/1.1"}
+	}
+	return rest.TransportFor(cfg)
+}
+
+// isDiscoveryPath returns true for K8s API discovery endpoints.
+func isDiscoveryPath(p string) bool {
+	p = strings.TrimSuffix(p, "/")
+	if discoveryPaths[p] {
+		return true
+	}
+	// /api/v1, /apis/<group>/<version>, /openapi/v2, /openapi/v3, etc.
+	for prefix := range discoveryPaths {
+		if strings.HasPrefix(p, prefix+"/") {
+			// Exclude resource paths like /api/v1/namespaces/.../pods
+			// by checking that the path has at most 3 segments after the prefix
+			rest := strings.TrimPrefix(p, prefix+"/")
+			segments := strings.Split(rest, "/")
+			if prefix == "/api" {
+				// /api/v1 is discovery, /api/v1/namespaces is not
+				return len(segments) <= 1
+			}
+			if prefix == "/apis" {
+				// /apis/<group>/<version> is discovery, /apis/<group>/<version>/namespaces is not
+				return len(segments) <= 2
+			}
+			// /openapi/v2, /openapi/v3 are discovery
+			return len(segments) <= 1
+		}
+	}
+	return false
+}
+
+// parseK8sAPIPath extracts resource, namespace, and verb from a K8s API path.
+// Examples:
+//
+//	/api/v1/namespaces/default/pods → resource=pods, ns=default, verb=get
+//	/apis/apps/v1/namespaces/default/deployments → resource=deployments, ns=default, verb=get
+//	/api/v1/namespaces/default/pods/my-pod/exec → resource=pods, ns=default, verb=exec, subResource=exec
+func parseK8sAPIPath(apiPath, method string) (resource, namespace, verb, subResource string) {
+	verb = methodToVerb(method)
+	path := strings.TrimPrefix(apiPath, "/")
+	segments := strings.Split(path, "/")
+	if len(segments) < 3 {
+		return "", "", verb, ""
+	}
+
+	var idx int
+	switch {
+	case segments[0] == "api" && segments[1] == "v1":
+		idx = 2
+	case segments[0] == "apis" && len(segments) >= 3:
+		idx = 3
+	default:
+		return "", "", verb, ""
+	}
+
+	// At this point segments[idx] could be "namespaces" (namespace-scoped) or a resource (cluster-scoped)
+	if idx >= len(segments) {
+		return "", "", verb, ""
+	}
+
+	if segments[idx] == "namespaces" {
+		// /api/v1/namespaces/:ns/:resource[/:name[/:subresource]]
+		if idx+2 >= len(segments) {
+			// /api/v1/namespaces/:ns — the resource is "namespaces" itself
+			return "namespaces", "", verb, ""
+		}
+		namespace = segments[idx+1]
+		resource = segments[idx+2]
+		if idx+4 < len(segments) {
+			subResource = segments[idx+4]
+		}
+	} else {
+		// Cluster-scoped resource: /api/v1/:resource[/:name[/:subresource]]
+		resource = segments[idx]
+		namespace = ""
+		if idx+2 < len(segments) {
+			subResource = segments[idx+2]
+		}
+	}
+
+	// Normalize: if subResource is actually the resource name (no name segment),
+	// we may have miscounted. But for RBAC purposes, the resource and verb are what matter.
+	// Reset subResource if it looks like a resource name (we only care about known sub-resources)
+	if subResource != "" {
+		if _, ok := subResourceVerbs[subResource]; !ok {
+			subResource = ""
+		}
+	}
+
+	return resource, namespace, verb, subResource
+}
+
+func methodToVerb(method string) string {
+	switch method {
+	case http.MethodPost:
+		return string(common.VerbCreate)
+	case http.MethodPut, http.MethodPatch:
+		return string(common.VerbUpdate)
+	case http.MethodDelete:
+		return string(common.VerbDelete)
+	default:
+		return string(common.VerbGet)
+	}
+}
+
+// k8sProxyResponder implements proxy.ErrorResponder.
+type k8sProxyResponder struct{}
+
+func (r *k8sProxyResponder) Error(w http.ResponseWriter, req *http.Request, err error) {
+	klog.Errorf("k8s proxy responder error: path=%s, method=%s, err=%v", req.URL.Path, req.Method, err)
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusBadGateway)
+	if err := json.NewEncoder(w).Encode(metav1.Status{
+		TypeMeta: metav1.TypeMeta{Kind: "Status", APIVersion: "v1"},
+		Status:   metav1.StatusFailure,
+		Message:  fmt.Sprintf("proxy error: %s", err.Error()),
+		Reason:   metav1.StatusReasonServiceUnavailable,
+		Code:     http.StatusBadGateway,
+	}); err != nil {
+		klog.Errorf("failed to encode proxy error response: %v", err)
+	}
+}
+
+// writeK8sStatus writes a Kubernetes-compatible metav1.Status JSON response.
+// client-go's transformResponse always tries to decode 4xx/5xx bodies as
+// Status objects (because newUnstructuredResponseError sets
+// isUnexpectedResponse=true), so returning a proper Status lets kubectl
+// display our message instead of "unknown (get pods)".
+func writeK8sStatus(c *gin.Context, code int, message string, reason metav1.StatusReason) {
+	c.JSON(code, metav1.Status{
+		TypeMeta: metav1.TypeMeta{Kind: "Status", APIVersion: "v1"},
+		Status:   metav1.StatusFailure,
+		Message:  message,
+		Reason:   reason,
+		Code:     int32(code),
+	})
+}

--- a/pkg/cluster/k8s_proxy.go
+++ b/pkg/cluster/k8s_proxy.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/zxh326/kite/pkg/common"
-	"github.com/zxh326/kite/pkg/connector"
 	"github.com/zxh326/kite/pkg/model"
 	"github.com/zxh326/kite/pkg/rbac"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -170,15 +169,12 @@ func (cm *ClusterManager) getRestConfig(cluster *model.Cluster) (*rest.Config, e
 		return rest.InClusterConfig()
 	}
 	if cluster.Connector {
-		dialer := cm.connectorManager.Dialer(cluster.ID)
-		transport := &http.Transport{
-			DialContext: dialer,
-			Proxy:       func(*http.Request) (*url.URL, error) { return nil, nil },
+		creds := cm.connectorManager.GetCredentials(cluster.ID)
+		if creds == nil {
+			return nil, fmt.Errorf("connector cluster %s has no credentials (agent not connected?)", cluster.Name)
 		}
-		return &rest.Config{
-			Host:      "http://" + connector.KubernetesAPITarget,
-			Transport: transport,
-		}, nil
+		dialer := cm.connectorManager.Dialer(cluster.ID)
+		return creds.ToRestConfig(dialer), nil
 	}
 	config, err := clientcmd.RESTConfigFromKubeConfig([]byte(string(cluster.Config)))
 	if err != nil {

--- a/pkg/cluster/k8s_proxy_test.go
+++ b/pkg/cluster/k8s_proxy_test.go
@@ -1,0 +1,468 @@
+package cluster
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/glebarez/sqlite"
+	"github.com/zxh326/kite/pkg/common"
+	"github.com/zxh326/kite/pkg/model"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+func setupProxyTestDB(t *testing.T) {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	if err != nil {
+		t.Fatalf("failed to open test db: %v", err)
+	}
+	if err := db.AutoMigrate(&model.Cluster{}, &model.User{}, &model.Role{}, &model.RoleAssignment{}); err != nil {
+		t.Fatalf("failed to migrate: %v", err)
+	}
+	model.DB = db
+}
+
+func TestParseK8sAPIPath(t *testing.T) {
+	tests := []struct {
+		name        string
+		path        string
+		method      string
+		resource    string
+		namespace   string
+		verb        string
+		subResource string
+	}{
+		{
+			name:      "core list pods",
+			path:      "/api/v1/namespaces/default/pods",
+			method:    "GET",
+			resource:  "pods",
+			namespace: "default",
+			verb:      "get",
+		},
+		{
+			name:      "core get single pod",
+			path:      "/api/v1/namespaces/default/pods/my-pod",
+			method:    "GET",
+			resource:  "pods",
+			namespace: "default",
+			verb:      "get",
+		},
+		{
+			name:        "core exec pod",
+			path:        "/api/v1/namespaces/default/pods/my-pod/exec",
+			method:      "POST",
+			resource:    "pods",
+			namespace:   "default",
+			verb:        "create",
+			subResource: "exec",
+		},
+		{
+			name:        "core attach pod",
+			path:        "/api/v1/namespaces/default/pods/my-pod/attach",
+			method:      "POST",
+			resource:    "pods",
+			namespace:   "default",
+			verb:        "create",
+			subResource: "attach",
+		},
+		{
+			name:        "core log pod",
+			path:        "/api/v1/namespaces/default/pods/my-pod/log",
+			method:      "GET",
+			resource:    "pods",
+			namespace:   "default",
+			verb:        "get",
+			subResource: "log",
+		},
+		{
+			name:        "core portforward pod",
+			path:        "/api/v1/namespaces/default/pods/my-pod/portforward",
+			method:      "POST",
+			resource:    "pods",
+			namespace:   "default",
+			verb:        "create",
+			subResource: "portforward",
+		},
+		{
+			name:      "apps list deployments",
+			path:      "/apis/apps/v1/namespaces/default/deployments",
+			method:    "GET",
+			resource:  "deployments",
+			namespace: "default",
+			verb:      "get",
+		},
+		{
+			name:      "apps create deployment",
+			path:      "/apis/apps/v1/namespaces/default/deployments",
+			method:    "POST",
+			resource:  "deployments",
+			namespace: "default",
+			verb:      "create",
+		},
+		{
+			name:      "apps update deployment",
+			path:      "/apis/apps/v1/namespaces/default/deployments/my-deploy",
+			method:    "PUT",
+			resource:  "deployments",
+			namespace: "default",
+			verb:      "update",
+		},
+		{
+			name:      "apps patch deployment",
+			path:      "/apis/apps/v1/namespaces/default/deployments/my-deploy",
+			method:    "PATCH",
+			resource:  "deployments",
+			namespace: "default",
+			verb:      "update",
+		},
+		{
+			name:      "apps delete deployment",
+			path:      "/apis/apps/v1/namespaces/default/deployments/my-deploy",
+			method:    "DELETE",
+			resource:  "deployments",
+			namespace: "default",
+			verb:      "delete",
+		},
+		{
+			name:      "cluster-scoped nodes",
+			path:      "/api/v1/nodes",
+			method:    "GET",
+			resource:  "nodes",
+			namespace: "",
+			verb:      "get",
+		},
+		{
+			name:      "cluster-scoped single node",
+			path:      "/api/v1/nodes/my-node",
+			method:    "GET",
+			resource:  "nodes",
+			namespace: "",
+			verb:      "get",
+		},
+		{
+			name:      "cluster-scoped namespaces list",
+			path:      "/api/v1/namespaces",
+			method:    "GET",
+			resource:  "namespaces",
+			namespace: "",
+			verb:      "get",
+		},
+		{
+			name:   "discovery api v1",
+			path:   "/api/v1",
+			method: "GET",
+			verb:   "get",
+		},
+		{
+			name:   "discovery apis group",
+			path:   "/apis/apps/v1",
+			method: "GET",
+			verb:   "get",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resource, namespace, verb, subResource := parseK8sAPIPath(tt.path, tt.method)
+			if resource != tt.resource {
+				t.Errorf("resource = %q, want %q", resource, tt.resource)
+			}
+			if namespace != tt.namespace {
+				t.Errorf("namespace = %q, want %q", namespace, tt.namespace)
+			}
+			if verb != tt.verb {
+				t.Errorf("verb = %q, want %q", verb, tt.verb)
+			}
+			if subResource != tt.subResource {
+				t.Errorf("subResource = %q, want %q", subResource, tt.subResource)
+			}
+		})
+	}
+}
+
+func TestIsDiscoveryPath(t *testing.T) {
+	tests := []struct {
+		path string
+		want bool
+	}{
+		{"/api", true},
+		{"/api/", true},
+		{"/api/v1", true},
+		{"/apis", true},
+		{"/apis/apps/v1", true},
+		{"/version", true},
+		{"/openapi/v2", true},
+		{"/openapi", true},
+		{"/api/v1/namespaces/default/pods", false},
+		{"/apis/apps/v1/namespaces/default/deployments", false},
+		{"/api/v1/nodes", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			if got := isDiscoveryPath(tt.path); got != tt.want {
+				t.Errorf("isDiscoveryPath(%q) = %v, want %v", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSanitizeClusterName(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"simple", "simple"},
+		{"with space", "with-space"},
+		{"with/slash", "with-slash"},
+		{"with:colon", "with-colon"},
+		{"中文集群", "中文集群"},
+		{`a\b:c*d?e"f<g>h|i`, "a-b-c-d-e-f-g-h-i"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			if got := sanitizeClusterName(tt.input); got != tt.want {
+				t.Errorf("sanitizeClusterName(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMethodToVerb(t *testing.T) {
+	tests := []struct {
+		method string
+		want   string
+	}{
+		{"GET", "get"},
+		{"POST", "create"},
+		{"PUT", "update"},
+		{"PATCH", "update"},
+		{"DELETE", "delete"},
+		{"HEAD", "get"},
+		{"OPTIONS", "get"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.method, func(t *testing.T) {
+			if got := methodToVerb(tt.method); got != tt.want {
+				t.Errorf("methodToVerb(%q) = %q, want %q", tt.method, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGenerateKubeconfig(t *testing.T) {
+	setupProxyTestDB(t)
+
+	role := &model.Role{
+		Name:       "test-role",
+		Clusters:   model.SliceString{"*"},
+		Resources:  model.SliceString{"*"},
+		Namespaces: model.SliceString{"*"},
+		Verbs:      model.SliceString{"*"},
+	}
+	if err := model.DB.Create(role).Error; err != nil {
+		t.Fatalf("create role: %v", err)
+	}
+
+	if err := model.AddRoleAssignment("test-role", model.SubjectTypeUser, "testuser"); err != nil {
+		t.Fatalf("assign role: %v", err)
+	}
+
+	cluster := &model.Cluster{
+		Name:   "test-cluster",
+		Config: "fake-config",
+		Enable: true,
+	}
+	if err := model.AddCluster(cluster); err != nil {
+		t.Fatalf("create cluster: %v", err)
+	}
+
+	user := model.User{
+		Model:    model.Model{ID: 1},
+		Username: "testuser",
+		Roles: []common.Role{{
+			Name:     "test-role",
+			Clusters: []string{"*"},
+		}},
+	}
+
+	yaml, err := GenerateKubeconfig(user, []string{cluster.UUID}, "https://kite.example.com")
+	if err != nil {
+		t.Fatalf("GenerateKubeconfig failed: %v", err)
+	}
+
+	if yaml == "" {
+		t.Fatal("expected non-empty kubeconfig")
+	}
+
+	// The proxy URL should point to Kite's k8s-proxy endpoint.
+	wantURL := "https://kite.example.com/api/v1/clusters/" + cluster.UUID + "/k8s-proxy"
+	if !strings.Contains(yaml, wantURL) {
+		t.Errorf("kubeconfig does not contain proxy URL %q", wantURL)
+	}
+
+	// insecure-skip-tls-verify must be set.
+	if !strings.Contains(yaml, "insecure-skip-tls-verify: true") {
+		t.Error("kubeconfig does not contain insecure-skip-tls-verify")
+	}
+
+	// The token should be a kite API key (starts with "kite").
+	if !strings.Contains(yaml, "token: kite") {
+		t.Error("kubeconfig does not contain a kite API key token")
+	}
+
+	// An API key user should have been created.
+	apiKeys, err := model.ListAPIKeyUsers()
+	if err != nil {
+		t.Fatalf("list api keys: %v", err)
+	}
+	if len(apiKeys) != 1 {
+		t.Fatalf("expected 1 API key user, got %d", len(apiKeys))
+	}
+}
+
+func TestGenerateKubeconfigMultiCluster(t *testing.T) {
+	setupProxyTestDB(t)
+
+	role := &model.Role{
+		Name:       "test-role",
+		Clusters:   model.SliceString{"*"},
+		Resources:  model.SliceString{"*"},
+		Namespaces: model.SliceString{"*"},
+		Verbs:      model.SliceString{"*"},
+	}
+	if err := model.DB.Create(role).Error; err != nil {
+		t.Fatalf("create role: %v", err)
+	}
+	if err := model.AddRoleAssignment("test-role", model.SubjectTypeUser, "testuser"); err != nil {
+		t.Fatalf("assign role: %v", err)
+	}
+
+	cluster1 := &model.Cluster{Name: "cluster-1", Config: "cfg1", Enable: true}
+	cluster2 := &model.Cluster{Name: "cluster-2", Config: "cfg2", Enable: true}
+	if err := model.AddCluster(cluster1); err != nil {
+		t.Fatalf("create cluster1: %v", err)
+	}
+	if err := model.AddCluster(cluster2); err != nil {
+		t.Fatalf("create cluster2: %v", err)
+	}
+
+	user := model.User{
+		Model:    model.Model{ID: 1},
+		Username: "testuser",
+		Roles: []common.Role{{
+			Name:     "test-role",
+			Clusters: []string{"*"},
+		}},
+	}
+
+	yaml, err := GenerateKubeconfig(user, []string{cluster1.UUID, cluster2.UUID}, "https://kite.example.com")
+	if err != nil {
+		t.Fatalf("GenerateKubeconfig failed: %v", err)
+	}
+
+	// Both clusters should appear in the kubeconfig.
+	if !strings.Contains(yaml, "cluster-1") {
+		t.Error("kubeconfig does not contain cluster-1")
+	}
+	if !strings.Contains(yaml, "cluster-2") {
+		t.Error("kubeconfig does not contain cluster-2")
+	}
+
+	// Current context should be the first cluster.
+	if !strings.Contains(yaml, "current-context: cluster-1") {
+		t.Error("current-context should be cluster-1")
+	}
+}
+
+func TestGenerateKubeconfigAccessDenied(t *testing.T) {
+	setupProxyTestDB(t)
+
+	cluster := &model.Cluster{
+		Name:   "denied-cluster",
+		Config: "fake-config",
+		Enable: true,
+	}
+	if err := model.AddCluster(cluster); err != nil {
+		t.Fatalf("create cluster: %v", err)
+	}
+
+	user := model.User{
+		Model:    model.Model{ID: 1},
+		Username: "testuser",
+		// No roles — should be denied
+	}
+
+	_, err := GenerateKubeconfig(user, []string{cluster.UUID}, "https://kite.example.com")
+	if err == nil {
+		t.Fatal("expected error for access denied, got nil")
+	}
+}
+
+func TestGenerateKubeconfigClusterNotFound(t *testing.T) {
+	setupProxyTestDB(t)
+
+	user := model.User{
+		Model:    model.Model{ID: 1},
+		Username: "testuser",
+		Roles: []common.Role{{
+			Name:     "test-role",
+			Clusters: []string{"*"},
+		}},
+	}
+
+	_, err := GenerateKubeconfig(user, []string{"nonexistent-uuid"}, "https://kite.example.com")
+	if err == nil {
+		t.Fatal("expected error for nonexistent cluster, got nil")
+	}
+}
+
+func TestBuildK8sProxyURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		host     string
+		path     string
+		wantPath string
+	}{
+		{
+			name:     "standard https",
+			host:     "https://k8s.example.com",
+			path:     "/api/v1/namespaces/default/pods",
+			wantPath: "/api/v1/namespaces/default/pods",
+		},
+		{
+			name:     "with port",
+			host:     "https://k8s.example.com:6443",
+			path:     "/apis/apps/v1/deployments",
+			wantPath: "/apis/apps/v1/deployments",
+		},
+		{
+			name:     "connector http",
+			host:     "http://127.0.0.1:12345",
+			path:     "/api/v1",
+			wantPath: "/api/v1",
+		},
+		{
+			name:     "root path",
+			host:     "https://k8s.example.com",
+			path:     "/version",
+			wantPath: "/version",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			u, err := buildK8sProxyURL(tt.host, tt.path)
+			if err != nil {
+				t.Fatalf("buildK8sProxyURL error: %v", err)
+			}
+			if u.Path != tt.wantPath {
+				t.Errorf("path = %q, want %q", u.Path, tt.wantPath)
+			}
+		})
+	}
+}

--- a/pkg/cluster/kubeconfig.go
+++ b/pkg/cluster/kubeconfig.go
@@ -23,7 +23,10 @@ func sanitizeClusterName(name string) string {
 }
 
 // GenerateKubeconfig creates a kubeconfig YAML that uses Kite as a proxy.
-// It creates a new API key that inherits the user's current roles.
+// It creates a new API key with OwnerUserID set to the current user so that
+// permissions are inherited dynamically. Any existing kubeconfig API keys
+// (those with the same owner_user_id) are deleted first so that only one
+// kubeconfig API key per user is valid at a time.
 func GenerateKubeconfig(user model.User, clusterUUIDs []string, serverURL string) (string, error) {
 	clusters := make([]*model.Cluster, 0, len(clusterUUIDs))
 	for _, uuidStr := range clusterUUIDs {
@@ -41,24 +44,30 @@ func GenerateKubeconfig(user model.User, clusterUUIDs []string, serverURL string
 		return "", fmt.Errorf("no clusters selected")
 	}
 
+	// Delete previous kubeconfig API keys for this user so only one is valid.
+	oldKeys, err := model.ListAPIKeyUsersByOwner(user.ID)
+	if err != nil {
+		return "", fmt.Errorf("failed to list old API keys: %w", err)
+	}
+	for _, oldKey := range oldKeys {
+		_ = model.DeleteUserByID(oldKey.ID)
+	}
+
 	apiKeyName := fmt.Sprintf("kubeconfig-%s-%d", user.Key(), time.Now().UnixNano())
 	apiKeyUser, err := model.NewAPIKeyUser(apiKeyName)
 	if err != nil {
 		return "", fmt.Errorf("failed to create API key: %w", err)
 	}
 
-	// If anything fails after API key creation, clean up the key so we don't
-	// leave orphaned credentials.
-	cleanupOnError := func() {
+	// Set owner so permissions are inherited dynamically.
+	apiKeyUser.OwnerUserID = &user.ID
+	if err := model.DB.Model(&model.User{}).Where("id = ?", apiKeyUser.ID).Update("owner_user_id", user.ID).Error; err != nil {
 		_ = model.DeleteUserByID(apiKeyUser.ID)
+		return "", fmt.Errorf("failed to set API key owner: %w", err)
 	}
 
-	// Inherit the user's current roles.
-	for _, role := range rbac.GetUserRoles(user) {
-		if err := model.AddRoleAssignment(role.Name, model.SubjectTypeUser, apiKeyUser.Username); err != nil {
-			cleanupOnError()
-			return "", fmt.Errorf("failed to assign role %s: %w", role.Name, err)
-		}
+	cleanupOnError := func() {
+		_ = model.DeleteUserByID(apiKeyUser.ID)
 	}
 
 	token := apiKeyUser.GetAPIKey()

--- a/pkg/cluster/kubeconfig.go
+++ b/pkg/cluster/kubeconfig.go
@@ -1,0 +1,96 @@
+package cluster
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/zxh326/kite/pkg/model"
+	"github.com/zxh326/kite/pkg/rbac"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+)
+
+// sanitizeClusterName removes characters that are invalid in kubeconfig
+// context/cluster names and file systems, while preserving Unicode letters.
+func sanitizeClusterName(name string) string {
+	replacer := strings.NewReplacer(
+		"/", "-", "\\", "-", ":", "-", "*", "-",
+		"?", "-", "\"", "-", "<", "-", ">", "-", "|", "-",
+		" ", "-",
+	)
+	return replacer.Replace(name)
+}
+
+// GenerateKubeconfig creates a kubeconfig YAML that uses Kite as a proxy.
+// It creates a new API key that inherits the user's current roles.
+func GenerateKubeconfig(user model.User, clusterUUIDs []string, serverURL string) (string, error) {
+	clusters := make([]*model.Cluster, 0, len(clusterUUIDs))
+	for _, uuidStr := range clusterUUIDs {
+		cluster, err := model.GetClusterByUUID(uuidStr)
+		if err != nil {
+			return "", fmt.Errorf("cluster not found: %s", uuidStr)
+		}
+		if !rbac.CanAccessCluster(user, cluster.Name) {
+			return "", fmt.Errorf("access denied to cluster: %s", cluster.Name)
+		}
+		clusters = append(clusters, cluster)
+	}
+
+	if len(clusters) == 0 {
+		return "", fmt.Errorf("no clusters selected")
+	}
+
+	apiKeyName := fmt.Sprintf("kubeconfig-%s-%d", user.Key(), time.Now().UnixNano())
+	apiKeyUser, err := model.NewAPIKeyUser(apiKeyName)
+	if err != nil {
+		return "", fmt.Errorf("failed to create API key: %w", err)
+	}
+
+	// If anything fails after API key creation, clean up the key so we don't
+	// leave orphaned credentials.
+	cleanupOnError := func() {
+		_ = model.DeleteUserByID(apiKeyUser.ID)
+	}
+
+	// Inherit the user's current roles.
+	for _, role := range rbac.GetUserRoles(user) {
+		if err := model.AddRoleAssignment(role.Name, model.SubjectTypeUser, apiKeyUser.Username); err != nil {
+			cleanupOnError()
+			return "", fmt.Errorf("failed to assign role %s: %w", role.Name, err)
+		}
+	}
+
+	token := apiKeyUser.GetAPIKey()
+	username := sanitizeClusterName(user.Key())
+
+	config := clientcmdapi.NewConfig()
+	for _, cluster := range clusters {
+		clusterName := sanitizeClusterName(cluster.Name)
+		proxyURL := fmt.Sprintf("%s/api/v1/clusters/%s/k8s-proxy", strings.TrimRight(serverURL, "/"), cluster.UUID)
+
+		config.Clusters[clusterName] = &clientcmdapi.Cluster{
+			Server:                proxyURL,
+			InsecureSkipTLSVerify: true,
+		}
+		config.Contexts[clusterName] = &clientcmdapi.Context{
+			Cluster:   clusterName,
+			AuthInfo:  username,
+			Namespace: "default",
+		}
+	}
+	config.AuthInfos[username] = &clientcmdapi.AuthInfo{
+		Token: token,
+	}
+
+	// Set current context to the first selected cluster.
+	config.CurrentContext = sanitizeClusterName(clusters[0].Name)
+
+	yaml, err := clientcmd.Write(*config)
+	if err != nil {
+		cleanupOnError()
+		return "", fmt.Errorf("failed to marshal kubeconfig: %w", err)
+	}
+
+	return string(yaml), nil
+}

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"os"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -71,6 +72,16 @@ var (
 
 	// ConfigFilePath is the path to the external config file (set via KITE_CONFIG_FILE env)
 	ConfigFilePath = ""
+
+	// SMTP env overrides (set via SMTP_HOST, SMTP_PORT, etc.)
+	// When non-empty, these take priority over DB-stored SMTP settings.
+	SMTPHost       = ""
+	SMTPPort       = 0
+	SMTPUsername   = ""
+	SMTPPassword   = ""
+	SMTPFromEmail  = ""
+	SMTPUseTLS     = true
+	SMTPEnvEnabled = false
 
 	// ManagedSections tracks which configuration sections are managed by the config file.
 	// Keys: "clusters", "oauth", "ldap", "rbac", "superUser"
@@ -194,4 +205,33 @@ func LoadEnvs() {
 		}
 	}
 	klog.Infof("Trusted proxies configured: %v", TrustedProxies)
+
+	loadSMTPEnvs()
+}
+
+func loadSMTPEnvs() {
+	if v := os.Getenv("SMTP_HOST"); v != "" {
+		SMTPHost = v
+		SMTPEnvEnabled = true
+	}
+	if v := os.Getenv("SMTP_PORT"); v != "" {
+		if port, err := strconv.Atoi(v); err == nil {
+			SMTPPort = port
+		}
+	}
+	if v := os.Getenv("SMTP_USERNAME"); v != "" {
+		SMTPUsername = v
+	}
+	if v := os.Getenv("SMTP_PASSWORD"); v != "" {
+		SMTPPassword = v
+	}
+	if v := os.Getenv("SMTP_FROM_EMAIL"); v != "" {
+		SMTPFromEmail = v
+	}
+	if v := os.Getenv("SMTP_USE_TLS"); v != "" {
+		SMTPUseTLS = v == "true"
+	}
+	if SMTPEnvEnabled && SMTPPort == 0 {
+		SMTPPort = 587
+	}
 }

--- a/pkg/common/types.go
+++ b/pkg/common/types.go
@@ -46,6 +46,7 @@ type ClusterInfo struct {
 	Name      string `json:"name"`
 	Version   string `json:"version"`
 	IsDefault bool   `json:"isDefault"`
+	UUID      string `json:"uuid,omitempty"`
 	Error     string `json:"error,omitempty"`
 }
 

--- a/pkg/connector/credentials.go
+++ b/pkg/connector/credentials.go
@@ -1,0 +1,170 @@
+package connector
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+
+	restclient "k8s.io/client-go/rest"
+)
+
+// K8sCredentials holds the Kubernetes API server credentials that the Agent
+// extracts from its kubeconfig/InClusterConfig and sends to the Server during
+// the WebSocket handshake. The Server uses these to build a rest.Config that
+// performs TLS + auth directly, so the Agent can be a pure TCP forwarder.
+type K8sCredentials struct {
+	Host        string `json:"host"`     // e.g. "https://10.0.0.1:443"
+	BearerToken string `json:"token"`    // bearer token (if any)
+	CAData      []byte `json:"caData"`   // CA cert PEM (if any)
+	CertData    []byte `json:"certData"` // client cert PEM (if any)
+	KeyData     []byte `json:"keyData"`  // client key PEM (if any)
+	Insecure    bool   `json:"insecure"` // skip TLS verification
+}
+
+// credentialHeader is the HTTP header used to transmit credentials
+// from Agent to Server during the WebSocket handshake.
+const credentialHeader = "X-Kite-K8s-Credentials"
+
+// extractCredentials reads auth-relevant fields from a rest.Config, resolving
+// any file-based references (CAFile, CertFile, KeyFile) into in-memory data.
+func extractCredentials(config *restclient.Config) (*K8sCredentials, error) {
+	tls := config.TLSClientConfig
+	creds := &K8sCredentials{
+		Host:        config.Host,
+		BearerToken: config.BearerToken,
+		Insecure:    tls.Insecure,
+	}
+
+	if len(tls.CAData) > 0 {
+		creds.CAData = tls.CAData
+	} else if tls.CAFile != "" {
+		data, err := os.ReadFile(tls.CAFile)
+		if err != nil {
+			return nil, fmt.Errorf("read CA file: %w", err)
+		}
+		creds.CAData = data
+	}
+
+	if len(tls.CertData) > 0 {
+		creds.CertData = tls.CertData
+	} else if tls.CertFile != "" {
+		data, err := os.ReadFile(tls.CertFile)
+		if err != nil {
+			return nil, fmt.Errorf("read cert file: %w", err)
+		}
+		creds.CertData = data
+	}
+
+	if len(tls.KeyData) > 0 {
+		creds.KeyData = tls.KeyData
+	} else if tls.KeyFile != "" {
+		data, err := os.ReadFile(tls.KeyFile)
+		if err != nil {
+			return nil, fmt.Errorf("read key file: %w", err)
+		}
+		creds.KeyData = data
+	}
+
+	return creds, nil
+}
+
+// MarshalHeader serializes credentials to a base64-encoded JSON string
+// suitable for use as an HTTP header value.
+func (c *K8sCredentials) MarshalHeader() (string, error) {
+	data, err := json.Marshal(c)
+	if err != nil {
+		return "", fmt.Errorf("marshal credentials: %w", err)
+	}
+	return base64.StdEncoding.EncodeToString(data), nil
+}
+
+// UnmarshalHeader decodes credentials from a base64-encoded JSON header value.
+func UnmarshalHeader(value string) (*K8sCredentials, error) {
+	data, err := base64.StdEncoding.DecodeString(value)
+	if err != nil {
+		return nil, fmt.Errorf("decode credentials header: %w", err)
+	}
+	var creds K8sCredentials
+	if err := json.Unmarshal(data, &creds); err != nil {
+		return nil, fmt.Errorf("unmarshal credentials: %w", err)
+	}
+	return &creds, nil
+}
+
+// ToRestConfig creates a rest.Config from credentials with a custom dialer.
+// The dialer routes connections through the remotedialer tunnel.
+func (c *K8sCredentials) ToRestConfig(dialer func(ctx context.Context, network, addr string) (net.Conn, error)) *restclient.Config {
+	return &restclient.Config{
+		Host:        c.Host,
+		BearerToken: c.BearerToken,
+		TLSClientConfig: restclient.TLSClientConfig{
+			Insecure: c.Insecure,
+			CAData:   c.CAData,
+			CertData: c.CertData,
+			KeyData:  c.KeyData,
+		},
+		Dial: dialer,
+	}
+}
+
+// TLSConfig returns a *tls.Config suitable for SPDY round tripper creation.
+func (c *K8sCredentials) TLSConfig() *tls.Config {
+	if !c.Insecure && len(c.CAData) == 0 && len(c.CertData) == 0 {
+		return nil
+	}
+	cfg := &tls.Config{
+		InsecureSkipVerify: c.Insecure,
+	}
+	if len(c.CAData) > 0 {
+		pool := x509.NewCertPool()
+		pool.AppendCertsFromPEM(c.CAData)
+		cfg.RootCAs = pool
+	}
+	if len(c.CertData) > 0 && len(c.KeyData) > 0 {
+		cert, err := tls.X509KeyPair(c.CertData, c.KeyData)
+		if err == nil {
+			cfg.Certificates = []tls.Certificate{cert}
+		}
+	}
+	return cfg
+}
+
+// parseHostPort extracts host:port from a Kubernetes API server URL.
+// e.g. "https://10.0.0.1:443" → "10.0.0.1:443"
+func parseHostPort(apiURL string) (string, error) {
+	var host, port string
+	// Strip scheme
+	for _, prefix := range []string{"https://", "http://"} {
+		if len(apiURL) > len(prefix) && apiURL[:len(prefix)] == prefix {
+			apiURL = apiURL[len(prefix):]
+			break
+		}
+	}
+	host, port, err := net.SplitHostPort(apiURL)
+	if err != nil {
+		// No port specified, default based on scheme
+		return "", fmt.Errorf("parse API server host:port from %q: %w", apiURL, err)
+	}
+	return net.JoinHostPort(host, port), nil
+}
+
+// credentialsHeaderName returns the HTTP header name used for credential transport.
+func credentialsHeaderName() string {
+	return credentialHeader
+}
+
+// SetCredentialHeader sets the credentials header on an HTTP header map.
+func SetCredentialHeader(headers http.Header, creds *K8sCredentials) error {
+	value, err := creds.MarshalHeader()
+	if err != nil {
+		return err
+	}
+	headers.Set(credentialHeader, value)
+	return nil
+}

--- a/pkg/connector/manager.go
+++ b/pkg/connector/manager.go
@@ -4,23 +4,16 @@ import (
 	"context"
 	"crypto/aes"
 	"crypto/cipher"
-	"crypto/ed25519"
 	"crypto/rand"
 	"crypto/sha256"
-	"crypto/subtle"
-	"crypto/tls"
-	"crypto/x509"
-	"crypto/x509/pkix"
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
-	"encoding/pem"
 	"errors"
+	"fmt"
 	"io"
-	"math/big"
 	"net"
 	"net/http"
-	"net/http/httputil"
 	"net/url"
 	"strconv"
 	"strings"
@@ -32,11 +25,12 @@ import (
 	"github.com/zxh326/kite/pkg/model"
 	"golang.org/x/crypto/hkdf"
 	"gorm.io/gorm"
+	"k8s.io/apimachinery/pkg/util/proxy"
 	"k8s.io/klog/v2"
 )
 
 const (
-	kubernetesAPITarget  = "kubernetes-api"
+	KubernetesAPITarget  = "kubernetes-api"
 	connectorTokenSize   = 32
 	manifestGrantTimeout = 10 * time.Minute
 	manifestGrantAAD     = "kite:connector-manifest-grant:v1"
@@ -56,26 +50,23 @@ type manifestGrant struct {
 }
 
 type localProxy struct {
-	listener  net.Listener
-	server    *http.Server
-	transport *http.Transport
-	token     string
-	caData    []byte
+	address string
+	server  *http.Server
 }
 
 type Manager struct {
 	server    *remotedialer.Server
 	onChange  func()
 	jwtSecret string
+	proxies   map[uint]*localProxy
 	mu        sync.Mutex
-	proxies   map[string]*localProxy
 }
 
 func NewManager(onChange func()) *Manager {
 	m := &Manager{
 		onChange:  onChange,
 		jwtSecret: common.JwtSecret,
-		proxies:   make(map[string]*localProxy),
+		proxies:   make(map[uint]*localProxy),
 	}
 	m.server = remotedialer.New(m.authorize, remotedialer.DefaultErrorWriter)
 	return m
@@ -239,114 +230,73 @@ func (m *Manager) Dialer(clusterID uint) func(context.Context, string, string) (
 	clientKey := strconv.FormatUint(uint64(clusterID), 10)
 	dialer := m.server.Dialer(clientKey)
 	return func(ctx context.Context, network, _ string) (net.Conn, error) {
-		return dialer(ctx, network, kubernetesAPITarget)
+		return dialer(ctx, network, KubernetesAPITarget)
 	}
 }
 
-func (m *Manager) Listen(clusterID uint) (string, string, []byte, error) {
-	clientKey := strconv.FormatUint(uint64(clusterID), 10)
+// Listen creates (or returns an existing) local HTTP proxy on 127.0.0.1 that
+// forwards all requests through the connector tunnel to the agent. The SPDY
+// and WebSocket executors used by terminal/exec/files ignore config.Transport
+// and create their own transports with net.Dialer, which would fail to resolve
+// the "kubernetes-api" hostname. By providing a local listener on a real IP,
+// those executors connect to 127.0.0.1:<port> (no DNS) and the local
+// UpgradeAwareHandler handles SPDY/WebSocket upgrades and forwards through
+// the tunnel to the agent's own UpgradeAwareHandler → kube-apiserver.
+func (m *Manager) Listen(clusterID uint) (string, error) {
 	m.mu.Lock()
-	defer m.mu.Unlock()
-	cluster, err := model.GetClusterByID(clusterID)
-	if err != nil {
-		return "", "", nil, err
+	if lp, ok := m.proxies[clusterID]; ok {
+		m.mu.Unlock()
+		return lp.address, nil
 	}
-	if !cluster.Connector || !cluster.Enable {
-		return "", "", nil, errors.New("connector cluster is unavailable")
-	}
-	if proxy, ok := m.proxies[clientKey]; ok {
-		return proxy.listener.Addr().String(), proxy.token, proxy.caData, nil
-	}
+	m.mu.Unlock()
 
-	tokenBytes := make([]byte, connectorTokenSize)
-	if _, err := rand.Read(tokenBytes); err != nil {
-		return "", "", nil, err
-	}
-	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
-	if err != nil {
-		return "", "", nil, err
-	}
-	serialLimit := new(big.Int).Lsh(big.NewInt(1), 128)
-	serialNumber, err := rand.Int(rand.Reader, serialLimit)
-	if err != nil {
-		return "", "", nil, err
-	}
-	serialNumber.SetBit(serialNumber, 0, 1)
-	now := time.Now()
-	certificateTemplate := &x509.Certificate{
-		SerialNumber:          serialNumber,
-		Subject:               pkix.Name{CommonName: "kite connector loopback"},
-		NotBefore:             now.Add(-time.Minute),
-		NotAfter:              now.AddDate(10, 0, 0),
-		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
-		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
-		BasicConstraintsValid: true,
-		IsCA:                  true,
-		IPAddresses:           []net.IP{net.ParseIP("127.0.0.1")},
-	}
-	certificateDER, err := x509.CreateCertificate(rand.Reader, certificateTemplate, certificateTemplate, publicKey, privateKey)
-	if err != nil {
-		return "", "", nil, err
-	}
-	token := base64.RawURLEncoding.EncodeToString(tokenBytes)
-	caData := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certificateDER})
-	expectedAuthorization := []byte("Bearer " + token)
-	target := &url.URL{Scheme: "http", Host: kubernetesAPITarget}
-	transport := &http.Transport{DialContext: m.Dialer(clusterID)}
-	reverseProxy := &httputil.ReverseProxy{
-		Rewrite: func(req *httputil.ProxyRequest) {
-			req.SetURL(target)
-			req.Out.Host = target.Host
-			req.Out.Header.Del("Authorization")
-		},
-		Transport:     transport,
-		FlushInterval: -1,
-	}
-	server := &http.Server{
-		Handler: http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-			if subtle.ConstantTimeCompare([]byte(req.Header.Get("Authorization")), expectedAuthorization) != 1 {
-				rw.Header().Set("WWW-Authenticate", "Bearer")
-				http.Error(rw, "unauthorized", http.StatusUnauthorized)
-				return
-			}
-			reverseProxy.ServeHTTP(rw, req)
-		}),
-		ReadHeaderTimeout: 10 * time.Second,
-		TLSConfig: &tls.Config{
-			Certificates: []tls.Certificate{{
-				Certificate: [][]byte{certificateDER},
-				PrivateKey:  privateKey,
-			}},
-			MinVersion: tls.VersionTLS13,
-		},
-	}
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
-		return "", "", nil, err
+		return "", err
 	}
-	m.proxies[clientKey] = &localProxy{
-		listener:  listener,
-		server:    server,
-		transport: transport,
-		token:     token,
-		caData:    caData,
+	address := listener.Addr().String()
+
+	dialer := m.Dialer(clusterID)
+	transport := &http.Transport{
+		DialContext: dialer,
+		Proxy:       func(*http.Request) (*url.URL, error) { return nil, nil },
 	}
-	go func() {
-		if err := server.ServeTLS(listener, "", ""); err != nil && !errors.Is(err, http.ErrServerClosed) {
-			klog.Errorf("Connector proxy for cluster %s stopped: %v", clientKey, err)
-		}
-	}()
-	return listener.Addr().String(), token, caData, nil
+
+	targetURL := &url.URL{Scheme: "http", Host: KubernetesAPITarget}
+	handler := proxy.NewUpgradeAwareHandler(targetURL, transport, false, false, &connectorResponder{})
+	handler.UpgradeTransport = proxy.NewUpgradeRequestRoundTripper(transport, proxy.MirrorRequest)
+	handler.UseRequestLocation = true
+	handler.FlushInterval = 200 * time.Millisecond
+
+	server := &http.Server{
+		Handler:           handler,
+		ReadHeaderTimeout: 30 * time.Second,
+	}
+	go func() { _ = server.Serve(listener) }()
+
+	m.mu.Lock()
+	m.proxies[clusterID] = &localProxy{address: address, server: server}
+	m.mu.Unlock()
+
+	return address, nil
 }
 
+// Remove closes the local proxy for the given cluster and cleans up.
+// Called when a connector cluster is disabled or deleted.
 func (m *Manager) Remove(clusterID uint) {
-	clientKey := strconv.FormatUint(uint64(clusterID), 10)
 	m.mu.Lock()
-	proxy := m.proxies[clientKey]
-	delete(m.proxies, clientKey)
-	m.mu.Unlock()
-	if proxy != nil {
-		_ = proxy.server.Close()
-		proxy.transport.CloseIdleConnections()
+	defer m.mu.Unlock()
+	if lp, ok := m.proxies[clusterID]; ok {
+		_ = lp.server.Close()
+		delete(m.proxies, clusterID)
 	}
+}
+
+// connectorResponder implements proxy.ErrorResponder for the server-side
+// local proxy UpgradeAwareHandler.
+type connectorResponder struct{}
+
+func (r *connectorResponder) Error(w http.ResponseWriter, req *http.Request, err error) {
+	klog.Errorf("connector proxy error: method=%s, path=%s, err=%v", req.Method, req.URL.Path, err)
+	http.Error(w, fmt.Sprintf("proxy error: %s", err), http.StatusBadGateway)
 }

--- a/pkg/connector/manager.go
+++ b/pkg/connector/manager.go
@@ -10,11 +10,9 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io"
 	"net"
 	"net/http"
-	"net/url"
 	"strconv"
 	"strings"
 	"sync"
@@ -25,7 +23,6 @@ import (
 	"github.com/zxh326/kite/pkg/model"
 	"golang.org/x/crypto/hkdf"
 	"gorm.io/gorm"
-	"k8s.io/apimachinery/pkg/util/proxy"
 	"k8s.io/klog/v2"
 )
 
@@ -34,6 +31,9 @@ const (
 	connectorTokenSize   = 32
 	manifestGrantTimeout = 10 * time.Minute
 	manifestGrantAAD     = "kite:connector-manifest-grant:v1"
+	// connectorVersionHeader is the HTTP header sent by the Agent during
+	// WebSocket handshake to report its build version.
+	connectorVersionHeader = "X-Kite-Connector-Version"
 )
 
 var ErrInvalidManifestGrant = errors.New("invalid manifest grant")
@@ -49,24 +49,21 @@ type manifestGrant struct {
 	ExpiresAt      int64  `json:"exp"`
 }
 
-type localProxy struct {
-	address string
-	server  *http.Server
-}
-
 type Manager struct {
 	server    *remotedialer.Server
 	onChange  func()
 	jwtSecret string
-	proxies   map[uint]*localProxy
-	mu        sync.Mutex
+	creds     map[uint]*K8sCredentials
+	versions  map[uint]string
+	mu        sync.RWMutex
 }
 
 func NewManager(onChange func()) *Manager {
 	m := &Manager{
 		onChange:  onChange,
 		jwtSecret: common.JwtSecret,
-		proxies:   make(map[uint]*localProxy),
+		creds:     make(map[uint]*K8sCredentials),
+		versions:  make(map[uint]string),
 	}
 	m.server = remotedialer.New(m.authorize, remotedialer.DefaultErrorWriter)
 	return m
@@ -191,6 +188,27 @@ func (m *Manager) authorize(req *http.Request) (string, bool, error) {
 	if cluster == nil {
 		return "", false, nil
 	}
+
+	// Extract Kubernetes API credentials sent by the Agent. These are used
+	// by the Server to perform TLS + auth directly (TCP forwarding mode).
+	if credHeader := req.Header.Get(credentialsHeaderName()); credHeader != "" {
+		creds, err := UnmarshalHeader(credHeader)
+		if err != nil {
+			klog.Errorf("Failed to parse credentials from connector: %v", err)
+			return "", false, errors.New("invalid credentials header")
+		}
+		m.mu.Lock()
+		m.creds[cluster.ID] = creds
+		m.mu.Unlock()
+	}
+
+	// Store the connector version for display in the cluster list.
+	if ver := req.Header.Get(connectorVersionHeader); ver != "" {
+		m.mu.Lock()
+		m.versions[cluster.ID] = ver
+		m.mu.Unlock()
+	}
+
 	if state, ok := req.Context().Value(requestStateKey{}).(*requestState); ok {
 		state.authenticated = true
 	}
@@ -234,69 +252,25 @@ func (m *Manager) Dialer(clusterID uint) func(context.Context, string, string) (
 	}
 }
 
-// Listen creates (or returns an existing) local HTTP proxy on 127.0.0.1 that
-// forwards all requests through the connector tunnel to the agent. The SPDY
-// and WebSocket executors used by terminal/exec/files ignore config.Transport
-// and create their own transports with net.Dialer, which would fail to resolve
-// the "kubernetes-api" hostname. By providing a local listener on a real IP,
-// those executors connect to 127.0.0.1:<port> (no DNS) and the local
-// UpgradeAwareHandler handles SPDY/WebSocket upgrades and forwards through
-// the tunnel to the agent's own UpgradeAwareHandler → kube-apiserver.
-func (m *Manager) Listen(clusterID uint) (string, error) {
-	m.mu.Lock()
-	if lp, ok := m.proxies[clusterID]; ok {
-		m.mu.Unlock()
-		return lp.address, nil
-	}
-	m.mu.Unlock()
-
-	listener, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		return "", err
-	}
-	address := listener.Addr().String()
-
-	dialer := m.Dialer(clusterID)
-	transport := &http.Transport{
-		DialContext: dialer,
-		Proxy:       func(*http.Request) (*url.URL, error) { return nil, nil },
-	}
-
-	targetURL := &url.URL{Scheme: "http", Host: KubernetesAPITarget}
-	handler := proxy.NewUpgradeAwareHandler(targetURL, transport, false, false, &connectorResponder{})
-	handler.UpgradeTransport = proxy.NewUpgradeRequestRoundTripper(transport, proxy.MirrorRequest)
-	handler.UseRequestLocation = true
-	handler.FlushInterval = 200 * time.Millisecond
-
-	server := &http.Server{
-		Handler:           handler,
-		ReadHeaderTimeout: 30 * time.Second,
-	}
-	go func() { _ = server.Serve(listener) }()
-
-	m.mu.Lock()
-	m.proxies[clusterID] = &localProxy{address: address, server: server}
-	m.mu.Unlock()
-
-	return address, nil
+// GetCredentials returns the Kubernetes API credentials for a connector cluster.
+func (m *Manager) GetCredentials(clusterID uint) *K8sCredentials {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.creds[clusterID]
 }
 
-// Remove closes the local proxy for the given cluster and cleans up.
+// GetVersion returns the connector agent version for a connector cluster.
+func (m *Manager) GetVersion(clusterID uint) string {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.versions[clusterID]
+}
+
+// Remove cleans up credentials and version for a connector cluster.
 // Called when a connector cluster is disabled or deleted.
 func (m *Manager) Remove(clusterID uint) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	if lp, ok := m.proxies[clusterID]; ok {
-		_ = lp.server.Close()
-		delete(m.proxies, clusterID)
-	}
-}
-
-// connectorResponder implements proxy.ErrorResponder for the server-side
-// local proxy UpgradeAwareHandler.
-type connectorResponder struct{}
-
-func (r *connectorResponder) Error(w http.ResponseWriter, req *http.Request, err error) {
-	klog.Errorf("connector proxy error: method=%s, path=%s, err=%v", req.Method, req.URL.Path, err)
-	http.Error(w, fmt.Sprintf("proxy error: %s", err), http.StatusBadGateway)
+	delete(m.creds, clusterID)
+	delete(m.versions, clusterID)
 }

--- a/pkg/connector/manager_test.go
+++ b/pkg/connector/manager_test.go
@@ -1,0 +1,433 @@
+package connector
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/glebarez/sqlite"
+	"github.com/zxh326/kite/pkg/common"
+	"github.com/zxh326/kite/pkg/model"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+func setupManagerTestDB(t *testing.T) {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	if err != nil {
+		t.Fatalf("failed to open test db: %v", err)
+	}
+	if err := db.AutoMigrate(&model.Cluster{}, &model.User{}, &model.Role{}, &model.RoleAssignment{}); err != nil {
+		t.Fatalf("failed to migrate: %v", err)
+	}
+	model.DB = db
+}
+
+// --- Token validation tests ---
+
+func TestNewToken(t *testing.T) {
+	token, hash, err := NewToken()
+	if err != nil {
+		t.Fatalf("NewToken() error: %v", err)
+	}
+	if token == "" || hash == "" {
+		t.Fatal("NewToken() returned empty token or hash")
+	}
+	if token == hash {
+		t.Fatal("token and hash should differ")
+	}
+	if !validToken(token) {
+		t.Fatal("NewToken() token should pass validToken()")
+	}
+}
+
+func TestNewToken_Uniqueness(t *testing.T) {
+	tokens := make(map[string]bool)
+	for i := 0; i < 100; i++ {
+		token, _, err := NewToken()
+		if err != nil {
+			t.Fatalf("NewToken() error on iteration %d: %v", i, err)
+		}
+		if tokens[token] {
+			t.Fatalf("duplicate token generated on iteration %d", i)
+		}
+		tokens[token] = true
+	}
+}
+
+func TestTokenHash_Deterministic(t *testing.T) {
+	token := "abc123"
+	h1 := tokenHash(token)
+	h2 := tokenHash(token)
+	if h1 != h2 {
+		t.Fatal("tokenHash should be deterministic")
+	}
+	if tokenHash("different") == h1 {
+		t.Fatal("different tokens should produce different hashes")
+	}
+}
+
+func TestValidToken(t *testing.T) {
+	tests := []struct {
+		name  string
+		token string
+		want  bool
+	}{
+		{"valid token from NewToken", mustNewToken(t), true},
+		{"empty string", "", false},
+		{"short string", "abc", false},
+		{"non-base64", "!!!!!!!!!notbase64!!!!!!!invalid_chars", false},
+		{"valid base64 but wrong length", base64.RawURLEncoding.EncodeToString([]byte("short")), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := validToken(tt.token); got != tt.want {
+				t.Errorf("validToken(%q) = %v, want %v", tt.token, got, tt.want)
+			}
+		})
+	}
+}
+
+func mustNewToken(t *testing.T) string {
+	t.Helper()
+	token, _, err := NewToken()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return token
+}
+
+// --- resolveToken tests ---
+
+func TestResolveToken(t *testing.T) {
+	setupManagerTestDB(t)
+
+	token, hash, err := NewToken()
+	if err != nil {
+		t.Fatalf("NewToken() error: %v", err)
+	}
+
+	// Create a connector cluster with this token hash
+	cluster := &model.Cluster{
+		Name:               "test-connector",
+		Connector:          true,
+		Enable:             true,
+		ConnectorTokenHash: hash,
+	}
+	if err := model.AddCluster(cluster); err != nil {
+		t.Fatalf("AddCluster() error: %v", err)
+	}
+
+	// Valid token → returns cluster
+	got, err := resolveToken(token)
+	if err != nil {
+		t.Fatalf("resolveToken() error: %v", err)
+	}
+	if got == nil {
+		t.Fatal("resolveToken() returned nil for valid token")
+	}
+	if got.Name != "test-connector" {
+		t.Errorf("resolveToken() returned cluster %q, want %q", got.Name, "test-connector")
+	}
+
+	// Invalid token → returns nil, nil
+	got, err = resolveToken("invalid-token")
+	if err != nil {
+		t.Fatalf("resolveToken() error for invalid: %v", err)
+	}
+	if got != nil {
+		t.Fatal("resolveToken() should return nil for invalid token")
+	}
+}
+
+func TestResolveToken_DisabledCluster(t *testing.T) {
+	setupManagerTestDB(t)
+
+	token, hash, _ := NewToken()
+	cluster := &model.Cluster{
+		Name:               "disabled-connector",
+		Connector:          true,
+		Enable:             true,
+		ConnectorTokenHash: hash,
+	}
+	if err := model.AddCluster(cluster); err != nil {
+		t.Fatalf("AddCluster() error: %v", err)
+	}
+	// Use map to override GORM's default:true on the Enable column.
+	if err := model.DB.Model(&model.Cluster{}).Where("id = ?", cluster.ID).Updates(map[string]interface{}{"enable": false}).Error; err != nil {
+		t.Fatalf("failed to disable cluster: %v", err)
+	}
+
+	got, err := resolveToken(token)
+	if err != nil {
+		t.Fatalf("resolveToken() error: %v", err)
+	}
+	if got != nil {
+		t.Fatal("resolveToken() should return nil for disabled cluster")
+	}
+}
+
+func TestResolveToken_NonConnectorCluster(t *testing.T) {
+	setupManagerTestDB(t)
+
+	token, hash, _ := NewToken()
+	cluster := &model.Cluster{
+		Name:               "not-connector",
+		Connector:          false, // not a connector cluster
+		Enable:             true,
+		ConnectorTokenHash: hash,
+	}
+	if err := model.AddCluster(cluster); err != nil {
+		t.Fatalf("AddCluster() error: %v", err)
+	}
+
+	got, err := resolveToken(token)
+	if err != nil {
+		t.Fatalf("resolveToken() error: %v", err)
+	}
+	if got != nil {
+		t.Fatal("resolveToken() should return nil for non-connector cluster")
+	}
+}
+
+// --- Manifest grant round-trip tests ---
+
+func TestManifestGrant_RoundTrip(t *testing.T) {
+	setupManagerTestDB(t)
+	common.JwtSecret = "test-secret-key"
+	m := NewManager(func() {})
+
+	// ResolveManifestGrant calls resolveToken which checks the DB, so we
+	// need a real cluster with a valid token.
+	token, hash, _ := NewToken()
+	cluster := &model.Cluster{
+		Name:               "grant-test-cluster",
+		Connector:          true,
+		Enable:             true,
+		ConnectorTokenHash: hash,
+	}
+	if err := model.AddCluster(cluster); err != nil {
+		t.Fatalf("AddCluster() error: %v", err)
+	}
+
+	grant, err := m.CreateManifestGrant(token)
+	if err != nil {
+		t.Fatalf("CreateManifestGrant() error: %v", err)
+	}
+	if grant == "" {
+		t.Fatal("CreateManifestGrant() returned empty grant")
+	}
+
+	resolved, err := m.ResolveManifestGrant(grant)
+	if err != nil {
+		t.Fatalf("ResolveManifestGrant() error: %v", err)
+	}
+	if resolved != token {
+		t.Errorf("ResolveManifestGrant() = %q, want %q", resolved, token)
+	}
+}
+
+func TestManifestGrant_DifferentSecrets(t *testing.T) {
+	common.JwtSecret = "secret-a"
+	m1 := NewManager(func() {})
+
+	common.JwtSecret = "secret-b"
+	m2 := NewManager(func() {})
+
+	grant, err := m1.CreateManifestGrant("my-token")
+	if err != nil {
+		t.Fatalf("CreateManifestGrant() error: %v", err)
+	}
+
+	// Decrypting with a different secret should fail
+	_, err = m2.ResolveManifestGrant(grant)
+	if !errors.Is(err, ErrInvalidManifestGrant) {
+		t.Errorf("ResolveManifestGrant() with wrong secret: error = %v, want ErrInvalidManifestGrant", err)
+	}
+}
+
+func TestResolveManifestGrant_InvalidInput(t *testing.T) {
+	common.JwtSecret = "test-secret"
+	m := NewManager(func() {})
+
+	tests := []struct {
+		name  string
+		grant string
+	}{
+		{"empty string", ""},
+		{"not base64", "!!!not-base64!!!"},
+		{"too short", "ab"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := m.ResolveManifestGrant(tt.grant)
+			// Should not return a generic error; either nil or ErrInvalidManifestGrant
+			if err != nil && !errors.Is(err, ErrInvalidManifestGrant) {
+				t.Errorf("ResolveManifestGrant(%q) error = %v, want nil or ErrInvalidManifestGrant", tt.grant, err)
+			}
+		})
+	}
+}
+
+func TestResolveManifestGrant_TamperedCiphertext(t *testing.T) {
+	common.JwtSecret = "test-secret"
+	m := NewManager(func() {})
+
+	grant, err := m.CreateManifestGrant("my-token")
+	if err != nil {
+		t.Fatalf("CreateManifestGrant() error: %v", err)
+	}
+
+	// Tamper with the grant by flipping the last character
+	tampered := grant[:len(grant)-1]
+	if grant[len(grant)-1] == 'A' {
+		tampered += "B"
+	} else {
+		tampered += "A"
+	}
+
+	_, err = m.ResolveManifestGrant(tampered)
+	if !errors.Is(err, ErrInvalidManifestGrant) {
+		t.Errorf("ResolveManifestGrant(tampered) error = %v, want ErrInvalidManifestGrant", err)
+	}
+}
+
+// --- Listen / Remove caching tests ---
+
+func TestListen_CachesAddress(t *testing.T) {
+	m := NewManager(func() {})
+
+	addr1, err := m.Listen(1)
+	if err != nil {
+		t.Fatalf("first Listen() error: %v", err)
+	}
+	if addr1 == "" {
+		t.Fatal("first Listen() returned empty address")
+	}
+
+	// Second call should return the same cached address
+	addr2, err := m.Listen(1)
+	if err != nil {
+		t.Fatalf("second Listen() error: %v", err)
+	}
+	if addr1 != addr2 {
+		t.Errorf("Listen() caching failed: addr1=%q, addr2=%q", addr1, addr2)
+	}
+}
+
+func TestListen_DifferentClusters(t *testing.T) {
+	m := NewManager(func() {})
+
+	addr1, err := m.Listen(1)
+	if err != nil {
+		t.Fatalf("Listen(1) error: %v", err)
+	}
+	addr2, err := m.Listen(2)
+	if err != nil {
+		t.Fatalf("Listen(2) error: %v", err)
+	}
+	if addr1 == addr2 {
+		t.Fatal("different clusters should get different addresses")
+	}
+}
+
+func TestListen_ReturnsValidLocalAddress(t *testing.T) {
+	m := NewManager(func() {})
+
+	addr, err := m.Listen(42)
+	if err != nil {
+		t.Fatalf("Listen() error: %v", err)
+	}
+
+	// Address should be 127.0.0.1:<port>
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		t.Fatalf("invalid address format %q: %v", addr, err)
+	}
+	if host != "127.0.0.1" {
+		t.Errorf("expected host 127.0.0.1, got %q", host)
+	}
+	if port == "" {
+		t.Error("expected non-empty port")
+	}
+}
+
+func TestRemove_CleansUpProxy(t *testing.T) {
+	m := NewManager(func() {})
+
+	addr1, err := m.Listen(1)
+	if err != nil {
+		t.Fatalf("first Listen() error: %v", err)
+	}
+
+	// Remove should close the server and clean up the map entry
+	m.Remove(1)
+
+	// After Remove, Listen should create a new proxy with a different address
+	addr2, err := m.Listen(1)
+	if err != nil {
+		t.Fatalf("Listen() after Remove() error: %v", err)
+	}
+	if addr1 == addr2 {
+		t.Fatal("Listen() after Remove() should return a new address")
+	}
+}
+
+func TestRemove_NeverListened_NoPanic(t *testing.T) {
+	m := NewManager(func() {})
+	// Should not panic
+	m.Remove(999)
+}
+
+func TestRemove_MultipleCalls(t *testing.T) {
+	m := NewManager(func() {})
+	_, _ = m.Listen(1)
+	m.Remove(1)
+	// Second Remove should not panic
+	m.Remove(1)
+}
+
+// --- connectorResponder tests ---
+
+func TestConnectorResponder_Error(t *testing.T) {
+	responder := &connectorResponder{}
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/v1/pods", nil)
+	testErr := context.DeadlineExceeded
+
+	responder.Error(w, req, testErr)
+
+	if w.Code != http.StatusBadGateway {
+		t.Errorf("expected status %d, got %d", http.StatusBadGateway, w.Code)
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, "proxy error") {
+		t.Errorf("response body should contain 'proxy error', got: %s", body)
+	}
+}
+
+// --- Manager.ServeHTTP basic smoke test ---
+
+func TestServeHTTP_UnauthorizedRequest(t *testing.T) {
+	setupManagerTestDB(t)
+	m := NewManager(func() {})
+
+	// A request without auth should not crash but be rejected by remotedialer
+	req := httptest.NewRequest("GET", "/", nil)
+	w := httptest.NewRecorder()
+	m.ServeHTTP(w, req)
+
+	// remotedialer returns 403 for unauthorized connections
+	if w.Code != http.StatusForbidden && w.Code != http.StatusUnauthorized {
+		// remotedialer may return different codes depending on version
+		t.Logf("ServeHTTP returned status %d (expected 401 or 403)", w.Code)
+	}
+}

--- a/pkg/connector/manager_test.go
+++ b/pkg/connector/manager_test.go
@@ -7,7 +7,6 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
 
 	"github.com/glebarez/sqlite"
@@ -300,117 +299,129 @@ func TestResolveManifestGrant_TamperedCiphertext(t *testing.T) {
 	}
 }
 
-// --- Listen / Remove caching tests ---
+// --- GetCredentials / Remove tests ---
 
-func TestListen_CachesAddress(t *testing.T) {
+func TestGetCredentials_NotSet(t *testing.T) {
 	m := NewManager(func() {})
-
-	addr1, err := m.Listen(1)
-	if err != nil {
-		t.Fatalf("first Listen() error: %v", err)
-	}
-	if addr1 == "" {
-		t.Fatal("first Listen() returned empty address")
-	}
-
-	// Second call should return the same cached address
-	addr2, err := m.Listen(1)
-	if err != nil {
-		t.Fatalf("second Listen() error: %v", err)
-	}
-	if addr1 != addr2 {
-		t.Errorf("Listen() caching failed: addr1=%q, addr2=%q", addr1, addr2)
+	if creds := m.GetCredentials(1); creds != nil {
+		t.Errorf("expected nil for unconnected cluster, got %+v", creds)
 	}
 }
 
-func TestListen_DifferentClusters(t *testing.T) {
+func TestGetCredentials_AfterManualSet(t *testing.T) {
 	m := NewManager(func() {})
+	creds := &K8sCredentials{Host: "https://10.0.0.1:443", BearerToken: "abc"}
+	m.creds[1] = creds
 
-	addr1, err := m.Listen(1)
-	if err != nil {
-		t.Fatalf("Listen(1) error: %v", err)
-	}
-	addr2, err := m.Listen(2)
-	if err != nil {
-		t.Fatalf("Listen(2) error: %v", err)
-	}
-	if addr1 == addr2 {
-		t.Fatal("different clusters should get different addresses")
+	got := m.GetCredentials(1)
+	if got == nil || got.Host != "https://10.0.0.1:443" || got.BearerToken != "abc" {
+		t.Errorf("unexpected credentials: %+v", got)
 	}
 }
 
-func TestListen_ReturnsValidLocalAddress(t *testing.T) {
+func TestRemove_CleansUpCredentials(t *testing.T) {
 	m := NewManager(func() {})
+	m.creds[1] = &K8sCredentials{Host: "https://10.0.0.1:443"}
 
-	addr, err := m.Listen(42)
-	if err != nil {
-		t.Fatalf("Listen() error: %v", err)
-	}
-
-	// Address should be 127.0.0.1:<port>
-	host, port, err := net.SplitHostPort(addr)
-	if err != nil {
-		t.Fatalf("invalid address format %q: %v", addr, err)
-	}
-	if host != "127.0.0.1" {
-		t.Errorf("expected host 127.0.0.1, got %q", host)
-	}
-	if port == "" {
-		t.Error("expected non-empty port")
-	}
-}
-
-func TestRemove_CleansUpProxy(t *testing.T) {
-	m := NewManager(func() {})
-
-	addr1, err := m.Listen(1)
-	if err != nil {
-		t.Fatalf("first Listen() error: %v", err)
-	}
-
-	// Remove should close the server and clean up the map entry
 	m.Remove(1)
 
-	// After Remove, Listen should create a new proxy with a different address
-	addr2, err := m.Listen(1)
-	if err != nil {
-		t.Fatalf("Listen() after Remove() error: %v", err)
-	}
-	if addr1 == addr2 {
-		t.Fatal("Listen() after Remove() should return a new address")
+	if creds := m.GetCredentials(1); creds != nil {
+		t.Errorf("expected nil after Remove(), got %+v", creds)
 	}
 }
 
-func TestRemove_NeverListened_NoPanic(t *testing.T) {
+func TestRemove_NonExistent_NoPanic(t *testing.T) {
 	m := NewManager(func() {})
-	// Should not panic
-	m.Remove(999)
+	m.Remove(999) // should not panic
 }
 
 func TestRemove_MultipleCalls(t *testing.T) {
 	m := NewManager(func() {})
-	_, _ = m.Listen(1)
+	m.creds[1] = &K8sCredentials{Host: "https://10.0.0.1:443"}
 	m.Remove(1)
-	// Second Remove should not panic
-	m.Remove(1)
+	m.Remove(1) // second call should not panic
 }
 
-// --- connectorResponder tests ---
+// --- Connector version tests ---
 
-func TestConnectorResponder_Error(t *testing.T) {
-	responder := &connectorResponder{}
-	w := httptest.NewRecorder()
-	req := httptest.NewRequest("GET", "/api/v1/pods", nil)
-	testErr := context.DeadlineExceeded
-
-	responder.Error(w, req, testErr)
-
-	if w.Code != http.StatusBadGateway {
-		t.Errorf("expected status %d, got %d", http.StatusBadGateway, w.Code)
+func TestGetVersion_NotSet(t *testing.T) {
+	m := NewManager(func() {})
+	if v := m.GetVersion(1); v != "" {
+		t.Errorf("expected empty version for unconnected cluster, got %q", v)
 	}
-	body := w.Body.String()
-	if !strings.Contains(body, "proxy error") {
-		t.Errorf("response body should contain 'proxy error', got: %s", body)
+}
+
+func TestGetVersion_AfterManualSet(t *testing.T) {
+	m := NewManager(func() {})
+	m.versions[1] = "v1.2.3"
+
+	if v := m.GetVersion(1); v != "v1.2.3" {
+		t.Errorf("expected version v1.2.3, got %q", v)
+	}
+}
+
+func TestRemove_CleansUpVersion(t *testing.T) {
+	m := NewManager(func() {})
+	m.versions[1] = "v1.2.3"
+
+	m.Remove(1)
+
+	if v := m.GetVersion(1); v != "" {
+		t.Errorf("expected empty after Remove(), got %q", v)
+	}
+}
+
+// --- Credentials serialization tests ---
+
+func TestK8sCredentials_MarshalUnmarshalHeader(t *testing.T) {
+	original := &K8sCredentials{
+		Host:        "https://10.0.0.1:443",
+		BearerToken: "secret-token",
+		CAData:      []byte("-----BEGIN CERTIFICATE-----\nfake\n-----END CERTIFICATE-----"),
+		Insecure:    false,
+	}
+
+	header, err := original.MarshalHeader()
+	if err != nil {
+		t.Fatalf("MarshalHeader() error: %v", err)
+	}
+
+	decoded, err := UnmarshalHeader(header)
+	if err != nil {
+		t.Fatalf("UnmarshalHeader() error: %v", err)
+	}
+
+	if decoded.Host != original.Host {
+		t.Errorf("Host mismatch: %q vs %q", decoded.Host, original.Host)
+	}
+	if decoded.BearerToken != original.BearerToken {
+		t.Errorf("BearerToken mismatch: %q vs %q", decoded.BearerToken, original.BearerToken)
+	}
+	if string(decoded.CAData) != string(original.CAData) {
+		t.Errorf("CAData mismatch")
+	}
+}
+
+func TestK8sCredentials_ToRestConfig(t *testing.T) {
+	creds := &K8sCredentials{
+		Host:        "https://kubernetes.default.svc:443",
+		BearerToken: "my-token",
+		CAData:      []byte("fake-ca"),
+	}
+
+	dialer := func(ctx context.Context, network, addr string) (net.Conn, error) {
+		return nil, nil // not actually used in test
+	}
+
+	cfg := creds.ToRestConfig(dialer)
+	if cfg.Host != creds.Host {
+		t.Errorf("Host mismatch: %q vs %q", cfg.Host, creds.Host)
+	}
+	if cfg.BearerToken != creds.BearerToken {
+		t.Errorf("BearerToken mismatch")
+	}
+	if cfg.Dial == nil {
+		t.Error("Dial should not be nil")
 	}
 }
 

--- a/pkg/connector/run.go
+++ b/pkg/connector/run.go
@@ -9,14 +9,14 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/rancher/remotedialer"
-	"k8s.io/apimachinery/pkg/util/proxy"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog/v2"
+
+	"github.com/zxh326/kite/pkg/version"
 )
 
 func Run(ctx context.Context, args []string) error {
@@ -68,76 +68,43 @@ func Run(ctx context.Context, args []string) error {
 			return fmt.Errorf("load kubeconfig: %w", err)
 		}
 	}
-	target, err := url.Parse(config.Host)
+
+	// Extract credentials from kubeconfig to send to the Server. The Server
+	// needs these to perform TLS + auth directly, since the Agent is now a
+	// pure TCP forwarder (no HTTP proxy layer).
+	creds, err := extractCredentials(config)
 	if err != nil {
-		return fmt.Errorf("parse Kubernetes API URL: %w", err)
+		return fmt.Errorf("extract Kubernetes credentials: %w", err)
 	}
-	target.Path = "/"
 
-	// Regular transport for non-upgrade requests. Allows HTTP/2 for better
-	// multiplexing on regular API calls (List, Get, Watch, etc.).
-	regularTransport, err := rest.TransportFor(config)
+	// Parse the real kube-apiserver address for TCP dialing.
+	apiServerAddr, err := parseHostPort(config.Host)
 	if err != nil {
-		return fmt.Errorf("create transport: %w", err)
+		return fmt.Errorf("parse kube-apiserver address: %w", err)
 	}
 
-	// HTTP/1.1-only transport for upgrade requests. HTTP/2 does not allow
-	// Upgrade headers, so SPDY/WebSocket upgrade requests (kubectl exec,
-	// attach, port-forward) must use HTTP/1.1.
-	upgradeConfig := rest.CopyConfig(config)
-	upgradeConfig.NextProtos = []string{"http/1.1"}
-	upgradeTransport, err := rest.TransportFor(upgradeConfig)
-	if err != nil {
-		return fmt.Errorf("create upgrade transport: %w", err)
-	}
-
-	// authTransport captures auth headers (bearer token, exec provider, etc.)
-	// from the kubeconfig via MirrorRequest without actually sending a
-	// request. The captured headers are injected into upgrade requests by
-	// UpgradeAwareHandler.WrapRequest.
-	authConfig := rest.CopyConfig(config)
-	authConfig.WrapTransport = func(http.RoundTripper) http.RoundTripper {
-		return proxy.MirrorRequest
-	}
-	authTransport, err := rest.TransportFor(authConfig)
-	if err != nil {
-		return fmt.Errorf("create auth transport: %w", err)
-	}
-
-	// Create a single UpgradeAwareHandler that all tunnel connections share.
-	// The regular transport handles non-upgrade requests (HTTP/2 allowed),
-	// while the upgrade transport handles SPDY/WebSocket upgrades (HTTP/1.1).
-	handler := proxy.NewUpgradeAwareHandler(target, regularTransport, false, false, &agentResponder{})
-	handler.UpgradeTransport = proxy.NewUpgradeRequestRoundTripper(upgradeTransport, authTransport)
-	handler.UseRequestLocation = true
-	handler.FlushInterval = 200 * time.Millisecond
-
-	// localDialer is called by remotedialer when the server requests a new
-	// tunnel connection to the K8s API. It creates a net.Pipe and serves
-	// HTTP on one end through the UpgradeAwareHandler. This properly handles
-	// SPDY/WebSocket upgrades (including Content-Length: 0 on POST) by using
-	// Go's standard HTTP server and UpgradeAwareHandler, instead of raw byte
-	// forwarding which could break SPDY upgrade requests.
+	// localDialer is called by remotedialer when the Server requests a new
+	// tunnel connection to the Kubernetes API. It creates a raw TCP connection
+	// to kube-apiserver — no HTTP parsing, no transport management, no auth
+	// injection. TLS and auth are handled end-to-end by the Server's transport.
 	localDialer := func(ctx context.Context, network, address string) (net.Conn, error) {
 		if network != "tcp" || address != KubernetesAPITarget {
 			return nil, fmt.Errorf("unsupported tunnel target %s/%s", network, address)
 		}
-		serverConn, clientConn := net.Pipe()
-		go func() {
-			listener := &singleConnListener{conn: serverConn}
-			server := &http.Server{
-				Handler:           handler,
-				ReadHeaderTimeout: 30 * time.Second,
-			}
-			_ = server.Serve(listener)
-		}()
-		return clientConn, nil
+		var d net.Dialer
+		return d.DialContext(ctx, "tcp", apiServerAddr)
 	}
 
 	authorizer := func(network, address string) bool {
 		return network == "tcp" && address == KubernetesAPITarget
 	}
-	headers := http.Header{"Authorization": []string{"Bearer " + *token}}
+	headers := http.Header{
+		"Authorization":        []string{"Bearer " + *token},
+		connectorVersionHeader: []string{version.Version},
+	}
+	if err := SetCredentialHeader(headers, creds); err != nil {
+		return fmt.Errorf("set credentials header: %w", err)
+	}
 
 	klog.Info("Kite connector started")
 	retryCount := 0
@@ -157,36 +124,4 @@ func Run(ctx context.Context, args []string) error {
 		case <-time.After(5 * time.Second):
 		}
 	}
-}
-
-// singleConnListener is a net.Listener that returns one connection on the
-// first Accept call and an error on subsequent calls. This allows serving
-// a single HTTP connection via http.Server.Serve for each tunnel connection.
-type singleConnListener struct {
-	conn net.Conn
-	once sync.Once
-}
-
-func (l *singleConnListener) Accept() (net.Conn, error) {
-	accepted := false
-	l.once.Do(func() {
-		accepted = true
-	})
-	if !accepted {
-		return nil, errors.New("single-connection listener exhausted")
-	}
-	return l.conn, nil
-}
-
-func (l *singleConnListener) Close() error { return nil }
-
-func (l *singleConnListener) Addr() net.Addr { return l.conn.LocalAddr() }
-
-// agentResponder implements proxy.ErrorResponder for the agent-side
-// UpgradeAwareHandler.
-type agentResponder struct{}
-
-func (r *agentResponder) Error(w http.ResponseWriter, req *http.Request, err error) {
-	klog.Errorf("agent proxy error: method=%s, path=%s, err=%v", req.Method, req.URL.Path, err)
-	http.Error(w, fmt.Sprintf("proxy error: %s", err), http.StatusBadGateway)
 }

--- a/pkg/connector/run.go
+++ b/pkg/connector/run.go
@@ -7,54 +7,17 @@ import (
 	"fmt"
 	"net"
 	"net/http"
-	"net/http/httputil"
 	"net/url"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/rancher/remotedialer"
+	"k8s.io/apimachinery/pkg/util/proxy"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog/v2"
 )
-
-type singleConnListener struct {
-	conn net.Conn
-	addr net.Addr
-}
-
-// upgradeAwareTransport routes upgrade requests (SPDY/WebSocket) through an
-// HTTP/1.1-only transport, while letting regular requests use the standard
-// transport which may negotiate HTTP/2.  HTTP/2 rejects Upgrade headers, so
-// kubectl exec/attach/port-forward requests must go over HTTP/1.1.
-type upgradeAwareTransport struct {
-	normal    http.RoundTripper
-	http1Only http.RoundTripper
-}
-
-func (t *upgradeAwareTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	if req.Header.Get("Upgrade") != "" {
-		return t.http1Only.RoundTrip(req)
-	}
-	return t.normal.RoundTrip(req)
-}
-
-func (l *singleConnListener) Accept() (net.Conn, error) {
-	if l.conn == nil {
-		return nil, net.ErrClosed
-	}
-	conn := l.conn
-	l.conn = nil
-	return conn, nil
-}
-
-func (l *singleConnListener) Close() error {
-	return nil
-}
-
-func (l *singleConnListener) Addr() net.Addr {
-	return l.addr
-}
 
 func Run(ctx context.Context, args []string) error {
 	flags := flag.NewFlagSet("kite connector", flag.ContinueOnError)
@@ -109,58 +72,72 @@ func Run(ctx context.Context, args []string) error {
 	if err != nil {
 		return fmt.Errorf("parse Kubernetes API URL: %w", err)
 	}
+	target.Path = "/"
 
-	// Create two transports so we can conditionally force HTTP/1.1 only for
-	// upgrade requests (SPDY/WebSocket used by kubectl exec, attach,
-	// port-forward).  HTTP/2 does not allow Upgrade headers and would reject
-	// those requests, but regular requests benefit from HTTP/2 multiplexing.
-	normalTransport, err := rest.TransportFor(config)
+	// Regular transport for non-upgrade requests. Allows HTTP/2 for better
+	// multiplexing on regular API calls (List, Get, Watch, etc.).
+	regularTransport, err := rest.TransportFor(config)
 	if err != nil {
-		return fmt.Errorf("create Kubernetes API transport: %w", err)
-	}
-	h1Config := rest.CopyConfig(config)
-	h1Config.NextProtos = []string{"http/1.1"}
-	h1Transport, err := rest.TransportFor(h1Config)
-	if err != nil {
-		return fmt.Errorf("create HTTP/1.1 transport: %w", err)
-	}
-	transport := &upgradeAwareTransport{
-		normal:    normalTransport,
-		http1Only: h1Transport,
+		return fmt.Errorf("create transport: %w", err)
 	}
 
-	proxy := &httputil.ReverseProxy{
-		Rewrite: func(req *httputil.ProxyRequest) {
-			req.SetURL(target)
-			req.Out.Host = target.Host
-			req.Out.Header.Del("Authorization")
-			for name := range req.Out.Header {
-				if strings.HasPrefix(strings.ToLower(name), "impersonate-") {
-					req.Out.Header.Del(name)
-				}
-			}
-		},
-		Transport:     transport,
-		FlushInterval: -1,
+	// HTTP/1.1-only transport for upgrade requests. HTTP/2 does not allow
+	// Upgrade headers, so SPDY/WebSocket upgrade requests (kubectl exec,
+	// attach, port-forward) must use HTTP/1.1.
+	upgradeConfig := rest.CopyConfig(config)
+	upgradeConfig.NextProtos = []string{"http/1.1"}
+	upgradeTransport, err := rest.TransportFor(upgradeConfig)
+	if err != nil {
+		return fmt.Errorf("create upgrade transport: %w", err)
 	}
-	headers := http.Header{"Authorization": []string{"Bearer " + *token}}
-	localDialer := func(_ context.Context, network, address string) (net.Conn, error) {
-		if network != "tcp" || address != kubernetesAPITarget {
+
+	// authTransport captures auth headers (bearer token, exec provider, etc.)
+	// from the kubeconfig via MirrorRequest without actually sending a
+	// request. The captured headers are injected into upgrade requests by
+	// UpgradeAwareHandler.WrapRequest.
+	authConfig := rest.CopyConfig(config)
+	authConfig.WrapTransport = func(http.RoundTripper) http.RoundTripper {
+		return proxy.MirrorRequest
+	}
+	authTransport, err := rest.TransportFor(authConfig)
+	if err != nil {
+		return fmt.Errorf("create auth transport: %w", err)
+	}
+
+	// Create a single UpgradeAwareHandler that all tunnel connections share.
+	// The regular transport handles non-upgrade requests (HTTP/2 allowed),
+	// while the upgrade transport handles SPDY/WebSocket upgrades (HTTP/1.1).
+	handler := proxy.NewUpgradeAwareHandler(target, regularTransport, false, false, &agentResponder{})
+	handler.UpgradeTransport = proxy.NewUpgradeRequestRoundTripper(upgradeTransport, authTransport)
+	handler.UseRequestLocation = true
+	handler.FlushInterval = 200 * time.Millisecond
+
+	// localDialer is called by remotedialer when the server requests a new
+	// tunnel connection to the K8s API. It creates a net.Pipe and serves
+	// HTTP on one end through the UpgradeAwareHandler. This properly handles
+	// SPDY/WebSocket upgrades (including Content-Length: 0 on POST) by using
+	// Go's standard HTTP server and UpgradeAwareHandler, instead of raw byte
+	// forwarding which could break SPDY upgrade requests.
+	localDialer := func(ctx context.Context, network, address string) (net.Conn, error) {
+		if network != "tcp" || address != KubernetesAPITarget {
 			return nil, fmt.Errorf("unsupported tunnel target %s/%s", network, address)
 		}
-		proxyConn, tunnelConn := net.Pipe()
-		proxyServer := &http.Server{
-			Handler:           proxy,
-			ReadHeaderTimeout: 10 * time.Second,
-		}
+		serverConn, clientConn := net.Pipe()
 		go func() {
-			_ = proxyServer.Serve(&singleConnListener{conn: proxyConn, addr: proxyConn.LocalAddr()})
+			listener := &singleConnListener{conn: serverConn}
+			server := &http.Server{
+				Handler:           handler,
+				ReadHeaderTimeout: 30 * time.Second,
+			}
+			_ = server.Serve(listener)
 		}()
-		return tunnelConn, nil
+		return clientConn, nil
 	}
+
 	authorizer := func(network, address string) bool {
-		return network == "tcp" && address == kubernetesAPITarget
+		return network == "tcp" && address == KubernetesAPITarget
 	}
+	headers := http.Header{"Authorization": []string{"Bearer " + *token}}
 
 	klog.Info("Kite connector started")
 	retryCount := 0
@@ -180,4 +157,36 @@ func Run(ctx context.Context, args []string) error {
 		case <-time.After(5 * time.Second):
 		}
 	}
+}
+
+// singleConnListener is a net.Listener that returns one connection on the
+// first Accept call and an error on subsequent calls. This allows serving
+// a single HTTP connection via http.Server.Serve for each tunnel connection.
+type singleConnListener struct {
+	conn net.Conn
+	once sync.Once
+}
+
+func (l *singleConnListener) Accept() (net.Conn, error) {
+	accepted := false
+	l.once.Do(func() {
+		accepted = true
+	})
+	if !accepted {
+		return nil, errors.New("single-connection listener exhausted")
+	}
+	return l.conn, nil
+}
+
+func (l *singleConnListener) Close() error { return nil }
+
+func (l *singleConnListener) Addr() net.Addr { return l.conn.LocalAddr() }
+
+// agentResponder implements proxy.ErrorResponder for the agent-side
+// UpgradeAwareHandler.
+type agentResponder struct{}
+
+func (r *agentResponder) Error(w http.ResponseWriter, req *http.Request, err error) {
+	klog.Errorf("agent proxy error: method=%s, path=%s, err=%v", req.Method, req.URL.Path, err)
+	http.Error(w, fmt.Sprintf("proxy error: %s", err), http.StatusBadGateway)
 }

--- a/pkg/connector/run_test.go
+++ b/pkg/connector/run_test.go
@@ -2,151 +2,189 @@ package connector
 
 import (
 	"errors"
-	"io"
+	"net"
 	"net/http"
+	"strings"
+	"sync"
 	"testing"
+	"time"
 )
 
-// recordingRoundTripper records whether it was called and returns a fixed
-// response. It is used to verify which transport the upgradeAwareTransport
-// delegates to.
-type recordingRoundTripper struct {
-	name    string
-	calls   int
-	lastReq *http.Request
-	respErr error
-}
+// --- singleConnListener tests ---
 
-func (r *recordingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
-	r.calls++
-	r.lastReq = req
-	if r.respErr != nil {
-		return nil, r.respErr
-	}
-	// Return a minimal non-nil response so ReverseProxy is satisfied when used
-	// in integration-style tests; here we only inspect call counts.
-	return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody}, nil
-}
+func TestSingleConnListener_AcceptOnce(t *testing.T) {
+	conn1, conn2 := net.Pipe()
+	defer func() { _ = conn1.Close() }()
+	defer func() { _ = conn2.Close() }()
 
-func TestUpgradeAwareTransportRouting(t *testing.T) {
-	tests := []struct {
-		name       string
-		method     string
-		upgrade    string
-		setEmpty   bool // explicitly set Upgrade: "" (empty value header)
-		wantNormal int
-		wantH1     int
-	}{
-		{name: "no upgrade header - GET", method: http.MethodGet, wantNormal: 1, wantH1: 0},
-		{name: "no upgrade header - POST", method: http.MethodPost, wantNormal: 1, wantH1: 0},
-		{name: "no upgrade header - DELETE", method: http.MethodDelete, wantNormal: 1, wantH1: 0},
-		{name: "websocket upgrade", method: http.MethodGet, upgrade: "websocket", wantNormal: 0, wantH1: 1},
-		{name: "spdy/3.1 upgrade", method: http.MethodGet, upgrade: "SPDY/3.1", wantNormal: 0, wantH1: 1},
-		{name: "spdy/4 upgrade", method: http.MethodGet, upgrade: "SPDY/4", wantNormal: 0, wantH1: 1},
-		{name: "post exec upgrade", method: http.MethodPost, upgrade: "SPDY/3.1", wantNormal: 0, wantH1: 1},
-		// An empty-valued Upgrade header is treated by http.Header.Get as ""
-		// and should route to the normal transport.
-		{name: "empty upgrade header value", method: http.MethodGet, setEmpty: true, wantNormal: 1, wantH1: 0},
-	}
+	listener := &singleConnListener{conn: conn1}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			normal := &recordingRoundTripper{name: "normal"}
-			http1Only := &recordingRoundTripper{name: "http1Only"}
-			transport := &upgradeAwareTransport{
-				normal:    normal,
-				http1Only: http1Only,
-			}
-
-			req, err := http.NewRequest(tt.method, "https://k8s.example.com/api/v1/namespaces/default/pods", nil)
-			if err != nil {
-				t.Fatalf("create request: %v", err)
-			}
-			if tt.setEmpty {
-				req.Header.Set("Upgrade", "")
-			} else if tt.upgrade != "" {
-				req.Header.Set("Upgrade", tt.upgrade)
-			}
-
-			resp, err := transport.RoundTrip(req)
-			if err != nil {
-				t.Fatalf("RoundTrip error: %v", err)
-			}
-			_, _ = io.Copy(io.Discard, resp.Body)
-			_ = resp.Body.Close()
-
-			if normal.calls != tt.wantNormal {
-				t.Errorf("normal transport calls = %d, want %d", normal.calls, tt.wantNormal)
-			}
-			if http1Only.calls != tt.wantH1 {
-				t.Errorf("http1Only transport calls = %d, want %d", http1Only.calls, tt.wantH1)
-			}
-		})
-	}
-}
-
-// TestUpgradeAwareTransportErrorPropagation verifies that errors from the
-// underlying transport are returned to the caller, not swallowed.
-func TestUpgradeAwareTransportErrorPropagation(t *testing.T) {
-	wantErr := errors.New("transport failure")
-	normal := &recordingRoundTripper{name: "normal", respErr: wantErr}
-	http1Only := &recordingRoundTripper{name: "http1Only"}
-	transport := &upgradeAwareTransport{
-		normal:    normal,
-		http1Only: http1Only,
-	}
-
-	req, err := http.NewRequest(http.MethodGet, "https://k8s.example.com/api/v1", nil)
+	// First Accept should return the connection
+	got, err := listener.Accept()
 	if err != nil {
-		t.Fatalf("create request: %v", err)
+		t.Fatalf("first Accept() error: %v", err)
+	}
+	if got != conn1 {
+		t.Fatal("first Accept() should return the original connection")
 	}
 
-	resp, err := transport.RoundTrip(req)
+	// Second Accept should return an error
+	_, err = listener.Accept()
 	if err == nil {
-		_ = resp.Body.Close()
-		t.Fatal("expected error, got nil")
-	}
-	if !errors.Is(err, wantErr) {
-		t.Errorf("expected error %v, got %v", wantErr, err)
-	}
-	if http1Only.calls != 0 {
-		t.Errorf("http1Only should not be called for non-upgrade request, got %d calls", http1Only.calls)
+		t.Fatal("second Accept() should return an error")
 	}
 }
 
-// TestUpgradeAwareTransportRequestPassthrough verifies that the original
-// request is forwarded to the underlying transport unmodified.
-func TestUpgradeAwareTransportRequestPassthrough(t *testing.T) {
-	normal := &recordingRoundTripper{name: "normal"}
-	http1Only := &recordingRoundTripper{name: "http1Only"}
-	transport := &upgradeAwareTransport{
-		normal:    normal,
-		http1Only: http1Only,
+func TestSingleConnListener_ConcurrentAccept(t *testing.T) {
+	conn1, conn2 := net.Pipe()
+	defer func() { _ = conn1.Close() }()
+	defer func() { _ = conn2.Close() }()
+
+	listener := &singleConnListener{conn: conn1}
+
+	var (
+		wg           sync.WaitGroup
+		successCount int
+		errorCount   int
+		mu           sync.Mutex
+	)
+
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, err := listener.Accept()
+			mu.Lock()
+			if err == nil {
+				successCount++
+			} else {
+				errorCount++
+			}
+			mu.Unlock()
+		}()
+	}
+	wg.Wait()
+
+	if successCount != 1 {
+		t.Errorf("expected exactly 1 successful Accept, got %d", successCount)
+	}
+	if errorCount != 4 {
+		t.Errorf("expected 4 errors, got %d", errorCount)
+	}
+}
+
+func TestSingleConnListener_Close(t *testing.T) {
+	conn1, conn2 := net.Pipe()
+	defer func() { _ = conn1.Close() }()
+	defer func() { _ = conn2.Close() }()
+
+	listener := &singleConnListener{conn: conn1}
+	// Close should be a no-op and never error
+	if err := listener.Close(); err != nil {
+		t.Errorf("Close() returned error: %v", err)
+	}
+	// Can close multiple times
+	if err := listener.Close(); err != nil {
+		t.Errorf("second Close() returned error: %v", err)
+	}
+}
+
+func TestSingleConnListener_Addr(t *testing.T) {
+	conn1, conn2 := net.Pipe()
+	defer func() { _ = conn1.Close() }()
+	defer func() { _ = conn2.Close() }()
+
+	listener := &singleConnListener{conn: conn1}
+	addr := listener.Addr()
+	if addr == nil {
+		t.Fatal("Addr() should not return nil")
+	}
+	// For net.Pipe, LocalAddr() returns a pipeAddr
+	if addr.String() != "pipe" {
+		t.Logf("Addr() = %s (expected 'pipe' for net.Pipe)", addr.String())
+	}
+}
+
+// --- localDialer integration test via UpgradeAwareHandler ---
+
+// TestLocalDialer_RejectsInvalidTarget verifies that the dialer created in
+// Run() rejects connections to addresses other than KubernetesAPITarget.
+// Since localDialer is a closure inside Run(), we test the same logic
+// pattern here.
+func TestLocalDialer_RejectsInvalidTarget(t *testing.T) {
+	checkTarget := func(network, address string) error {
+		if network != "tcp" || address != KubernetesAPITarget {
+			return errors.New("unsupported tunnel target")
+		}
+		return nil
 	}
 
-	req, err := http.NewRequest(http.MethodPost, "https://k8s.example.com/api/v1/namespaces/default/pods/x/exec", nil)
+	// Valid target
+	err := checkTarget("tcp", KubernetesAPITarget)
 	if err != nil {
-		t.Fatalf("create request: %v", err)
+		t.Errorf("expected success for valid target, got: %v", err)
 	}
-	req.Header.Set("Upgrade", "SPDY/3.1")
-	req.Header.Set("X-Custom", "keep-me")
 
-	resp, err := transport.RoundTrip(req)
+	// Invalid address
+	err = checkTarget("tcp", "wrong-target")
+	if err == nil {
+		t.Error("expected error for wrong address")
+	}
+
+	// Invalid network
+	err = checkTarget("udp", KubernetesAPITarget)
+	if err == nil {
+		t.Error("expected error for wrong network")
+	}
+}
+
+// TestLocalDialer_PipeHTTPRoundTrip is an end-to-end test that simulates
+// the localDialer pattern: create a pipe, serve HTTP on one end via
+// singleConnListener, and verify the other end can make an HTTP request.
+func TestLocalDialer_PipeHTTPRoundTrip(t *testing.T) {
+	serverConn, clientConn := net.Pipe()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	})
+
+	serverDone := make(chan struct{})
+	go func() {
+		defer close(serverDone)
+		listener := &singleConnListener{conn: serverConn}
+		server := &http.Server{
+			Handler:           mux,
+			ReadHeaderTimeout: 5 * time.Second,
+		}
+		_ = server.Serve(listener)
+	}()
+
+	// Write the HTTP request to the client end of the pipe.
+	request := "GET /healthz HTTP/1.1\r\nHost: localhost\r\n\r\n"
+	_ = clientConn.SetWriteDeadline(time.Now().Add(5 * time.Second))
+	_, err := clientConn.Write([]byte(request))
 	if err != nil {
-		t.Fatalf("RoundTrip error: %v", err)
+		t.Fatalf("failed to write request: %v", err)
 	}
-	_ = resp.Body.Close()
 
-	if http1Only.lastReq != req {
-		t.Error("http1Only transport did not receive the original request pointer")
+	// Read the response from the server.
+	buf := make([]byte, 4096)
+	_ = clientConn.SetReadDeadline(time.Now().Add(5 * time.Second))
+	n, err := clientConn.Read(buf)
+	if err != nil {
+		t.Fatalf("failed to read response: %v", err)
 	}
-	if got := http1Only.lastReq.Header.Get("X-Custom"); got != "keep-me" {
-		t.Errorf("custom header not preserved, got %q", got)
+
+	_ = clientConn.Close()
+	<-serverDone
+
+	response := string(buf[:n])
+	if !strings.Contains(response, "200 OK") {
+		t.Errorf("response does not contain '200 OK': %s", response)
 	}
-	if got := http1Only.lastReq.Header.Get("Upgrade"); got != "SPDY/3.1" {
-		t.Errorf("Upgrade header not preserved, got %q", got)
-	}
-	if normal.calls != 0 {
-		t.Errorf("normal transport should not be called for upgrade request, got %d calls", normal.calls)
+	if !strings.Contains(response, "ok") {
+		t.Errorf("response body does not contain 'ok': %s", response)
 	}
 }

--- a/pkg/connector/run_test.go
+++ b/pkg/connector/run_test.go
@@ -1,117 +1,59 @@
 package connector
 
 import (
+	"context"
 	"errors"
 	"net"
-	"net/http"
-	"strings"
-	"sync"
 	"testing"
-	"time"
 )
 
-// --- singleConnListener tests ---
+// --- parseHostPort tests ---
 
-func TestSingleConnListener_AcceptOnce(t *testing.T) {
-	conn1, conn2 := net.Pipe()
-	defer func() { _ = conn1.Close() }()
-	defer func() { _ = conn2.Close() }()
-
-	listener := &singleConnListener{conn: conn1}
-
-	// First Accept should return the connection
-	got, err := listener.Accept()
+func TestParseHostPort_HTTPS(t *testing.T) {
+	addr, err := parseHostPort("https://10.0.0.1:443")
 	if err != nil {
-		t.Fatalf("first Accept() error: %v", err)
+		t.Fatalf("unexpected error: %v", err)
 	}
-	if got != conn1 {
-		t.Fatal("first Accept() should return the original connection")
+	if addr != "10.0.0.1:443" {
+		t.Errorf("expected 10.0.0.1:443, got %s", addr)
 	}
+}
 
-	// Second Accept should return an error
-	_, err = listener.Accept()
+func TestParseHostPort_HTTP(t *testing.T) {
+	addr, err := parseHostPort("http://localhost:8080")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if addr != "localhost:8080" {
+		t.Errorf("expected localhost:8080, got %s", addr)
+	}
+}
+
+func TestParseHostPort_NoPort(t *testing.T) {
+	_, err := parseHostPort("https://10.0.0.1")
 	if err == nil {
-		t.Fatal("second Accept() should return an error")
+		t.Error("expected error for URL without port")
 	}
 }
 
-func TestSingleConnListener_ConcurrentAccept(t *testing.T) {
-	conn1, conn2 := net.Pipe()
-	defer func() { _ = conn1.Close() }()
-	defer func() { _ = conn2.Close() }()
-
-	listener := &singleConnListener{conn: conn1}
-
-	var (
-		wg           sync.WaitGroup
-		successCount int
-		errorCount   int
-		mu           sync.Mutex
-	)
-
-	for i := 0; i < 5; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			_, err := listener.Accept()
-			mu.Lock()
-			if err == nil {
-				successCount++
-			} else {
-				errorCount++
-			}
-			mu.Unlock()
-		}()
+func TestParseHostPort_NoScheme(t *testing.T) {
+	// Without a scheme prefix, the string is passed to SplitHostPort directly.
+	// "10.0.0.1:443" (no scheme) should still work.
+	addr, err := parseHostPort("10.0.0.1:443")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
-	wg.Wait()
-
-	if successCount != 1 {
-		t.Errorf("expected exactly 1 successful Accept, got %d", successCount)
-	}
-	if errorCount != 4 {
-		t.Errorf("expected 4 errors, got %d", errorCount)
+	if addr != "10.0.0.1:443" {
+		t.Errorf("expected 10.0.0.1:443, got %s", addr)
 	}
 }
 
-func TestSingleConnListener_Close(t *testing.T) {
-	conn1, conn2 := net.Pipe()
-	defer func() { _ = conn1.Close() }()
-	defer func() { _ = conn2.Close() }()
+// --- localDialer target validation tests ---
+//
+// Since localDialer is a closure inside Run(), we test the same validation
+// pattern that the closure uses.
 
-	listener := &singleConnListener{conn: conn1}
-	// Close should be a no-op and never error
-	if err := listener.Close(); err != nil {
-		t.Errorf("Close() returned error: %v", err)
-	}
-	// Can close multiple times
-	if err := listener.Close(); err != nil {
-		t.Errorf("second Close() returned error: %v", err)
-	}
-}
-
-func TestSingleConnListener_Addr(t *testing.T) {
-	conn1, conn2 := net.Pipe()
-	defer func() { _ = conn1.Close() }()
-	defer func() { _ = conn2.Close() }()
-
-	listener := &singleConnListener{conn: conn1}
-	addr := listener.Addr()
-	if addr == nil {
-		t.Fatal("Addr() should not return nil")
-	}
-	// For net.Pipe, LocalAddr() returns a pipeAddr
-	if addr.String() != "pipe" {
-		t.Logf("Addr() = %s (expected 'pipe' for net.Pipe)", addr.String())
-	}
-}
-
-// --- localDialer integration test via UpgradeAwareHandler ---
-
-// TestLocalDialer_RejectsInvalidTarget verifies that the dialer created in
-// Run() rejects connections to addresses other than KubernetesAPITarget.
-// Since localDialer is a closure inside Run(), we test the same logic
-// pattern here.
-func TestLocalDialer_RejectsInvalidTarget(t *testing.T) {
+func TestLocalDialer_RejectsInvalidNetwork(t *testing.T) {
 	checkTarget := func(network, address string) error {
 		if network != "tcp" || address != KubernetesAPITarget {
 			return errors.New("unsupported tunnel target")
@@ -119,72 +61,76 @@ func TestLocalDialer_RejectsInvalidTarget(t *testing.T) {
 		return nil
 	}
 
-	// Valid target
-	err := checkTarget("tcp", KubernetesAPITarget)
-	if err != nil {
-		t.Errorf("expected success for valid target, got: %v", err)
-	}
-
-	// Invalid address
-	err = checkTarget("tcp", "wrong-target")
-	if err == nil {
-		t.Error("expected error for wrong address")
-	}
-
-	// Invalid network
-	err = checkTarget("udp", KubernetesAPITarget)
-	if err == nil {
-		t.Error("expected error for wrong network")
+	if err := checkTarget("udp", KubernetesAPITarget); err == nil {
+		t.Error("expected error for udp network")
 	}
 }
 
-// TestLocalDialer_PipeHTTPRoundTrip is an end-to-end test that simulates
-// the localDialer pattern: create a pipe, serve HTTP on one end via
-// singleConnListener, and verify the other end can make an HTTP request.
-func TestLocalDialer_PipeHTTPRoundTrip(t *testing.T) {
-	serverConn, clientConn := net.Pipe()
-
-	mux := http.NewServeMux()
-	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte("ok"))
-	})
-
-	serverDone := make(chan struct{})
-	go func() {
-		defer close(serverDone)
-		listener := &singleConnListener{conn: serverConn}
-		server := &http.Server{
-			Handler:           mux,
-			ReadHeaderTimeout: 5 * time.Second,
+func TestLocalDialer_RejectsInvalidAddress(t *testing.T) {
+	checkTarget := func(network, address string) error {
+		if network != "tcp" || address != KubernetesAPITarget {
+			return errors.New("unsupported tunnel target")
 		}
-		_ = server.Serve(listener)
+		return nil
+	}
+
+	if err := checkTarget("tcp", "wrong-target"); err == nil {
+		t.Error("expected error for wrong address")
+	}
+}
+
+func TestLocalDialer_AcceptsValidTarget(t *testing.T) {
+	checkTarget := func(network, address string) error {
+		if network != "tcp" || address != KubernetesAPITarget {
+			return errors.New("unsupported tunnel target")
+		}
+		return nil
+	}
+
+	if err := checkTarget("tcp", KubernetesAPITarget); err != nil {
+		t.Errorf("expected success for valid target, got: %v", err)
+	}
+}
+
+// --- localDialer TCP dial test ---
+//
+// Test that the localDialer pattern actually creates a TCP connection
+// to a real listener. This verifies that net.DialContext works as expected
+// for the TCP forwarding use case.
+
+func TestLocalDialer_TCPDialSuccess(t *testing.T) {
+	// Start a local TCP listener
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to listen: %v", err)
+	}
+	defer func() { _ = listener.Close() }()
+
+	addr := listener.Addr().String()
+
+	// Simulate the localDialer pattern from Run()
+	localDialer := func(ctx context.Context, network, address string) (net.Conn, error) {
+		if network != "tcp" || address != KubernetesAPITarget {
+			return nil, errors.New("unsupported tunnel target")
+		}
+		var d net.Dialer
+		return d.DialContext(ctx, "tcp", addr)
+	}
+
+	// Accept the connection on the listener side
+	accepted := make(chan struct{})
+	go func() {
+		conn, err := listener.Accept()
+		if err == nil {
+			_ = conn.Close()
+		}
+		close(accepted)
 	}()
 
-	// Write the HTTP request to the client end of the pipe.
-	request := "GET /healthz HTTP/1.1\r\nHost: localhost\r\n\r\n"
-	_ = clientConn.SetWriteDeadline(time.Now().Add(5 * time.Second))
-	_, err := clientConn.Write([]byte(request))
+	conn, err := localDialer(context.Background(), "tcp", KubernetesAPITarget)
 	if err != nil {
-		t.Fatalf("failed to write request: %v", err)
+		t.Fatalf("localDialer failed: %v", err)
 	}
-
-	// Read the response from the server.
-	buf := make([]byte, 4096)
-	_ = clientConn.SetReadDeadline(time.Now().Add(5 * time.Second))
-	n, err := clientConn.Read(buf)
-	if err != nil {
-		t.Fatalf("failed to read response: %v", err)
-	}
-
-	_ = clientConn.Close()
-	<-serverDone
-
-	response := string(buf[:n])
-	if !strings.Contains(response, "200 OK") {
-		t.Errorf("response does not contain '200 OK': %s", response)
-	}
-	if !strings.Contains(response, "ok") {
-		t.Errorf("response body does not contain 'ok': %s", response)
-	}
+	defer func() { _ = conn.Close() }()
+	<-accepted
 }

--- a/pkg/email/code_manager.go
+++ b/pkg/email/code_manager.go
@@ -1,0 +1,147 @@
+package email
+
+import (
+	"crypto/rand"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/zxh326/kite/pkg/i18n"
+)
+
+const (
+	codeLength    = 6
+	codeTTL       = 10 * time.Minute
+	sendCooldown  = 60 * time.Second // min interval between sends to same email
+	maxAttempts   = 5
+	attemptWindow = 10 * time.Minute
+)
+
+type codeEntry struct {
+	code      string
+	expiresAt time.Time
+	sentAt    time.Time
+	attempts  []time.Time
+}
+
+type CodeManager struct {
+	mu    sync.Mutex
+	codes map[string]*codeEntry // key: email
+}
+
+var defaultCodeManager = &CodeManager{
+	codes: make(map[string]*codeEntry),
+}
+
+// GetCodeManager returns the singleton CodeManager.
+func GetCodeManager() *CodeManager {
+	return defaultCodeManager
+}
+
+// GenerateAndStore generates a new verification code for the email,
+// stores it, and returns the code. It enforces a send cooldown.
+func (m *CodeManager) GenerateAndStore(email, lang string) (string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	now := time.Now()
+
+	// Check cooldown
+	if entry, ok := m.codes[email]; ok {
+		if now.Sub(entry.sentAt) < sendCooldown {
+			seconds := int(sendCooldown.Seconds()) - int(now.Sub(entry.sentAt).Seconds())
+			return "", fmt.Errorf(i18n.T(lang, "code_cooldown"), seconds)
+		}
+	}
+
+	code, err := generateCode()
+	if err != nil {
+		return "", err
+	}
+
+	m.codes[email] = &codeEntry{
+		code:      code,
+		expiresAt: now.Add(codeTTL),
+		sentAt:    now,
+		attempts:  nil,
+	}
+
+	return code, nil
+}
+
+// Verify checks the code for the email. On success, the code is consumed.
+// On failure, an attempt is recorded; after maxAttempts the code is invalidated.
+func (m *CodeManager) Verify(email, code, lang string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	entry, ok := m.codes[email]
+	if !ok {
+		return errors.New(i18n.T(lang, "code_not_found"))
+	}
+
+	now := time.Now()
+	if now.After(entry.expiresAt) {
+		delete(m.codes, email)
+		return errors.New(i18n.T(lang, "code_expired"))
+	}
+
+	// Clean old attempts outside the window
+	validAttempts := entry.attempts[:0]
+	for _, t := range entry.attempts {
+		if now.Sub(t) < attemptWindow {
+			validAttempts = append(validAttempts, t)
+		}
+	}
+	entry.attempts = validAttempts
+
+	if len(entry.attempts) >= maxAttempts {
+		delete(m.codes, email)
+		return errors.New(i18n.T(lang, "code_too_many_attempts"))
+	}
+
+	if entry.code != code {
+		entry.attempts = append(entry.attempts, now)
+		return errors.New(i18n.T(lang, "code_invalid"))
+	}
+
+	// Success — consume the code
+	delete(m.codes, email)
+	return nil
+}
+
+// cleanupExpired removes expired entries. Called periodically.
+func (m *CodeManager) cleanupExpired() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	now := time.Now()
+	for email, entry := range m.codes {
+		if now.After(entry.expiresAt) {
+			delete(m.codes, email)
+		}
+	}
+}
+
+func generateCode() (string, error) {
+	buf := make([]byte, codeLength)
+	if _, err := rand.Read(buf); err != nil {
+		return "", err
+	}
+	code := make([]byte, codeLength)
+	for i := 0; i < codeLength; i++ {
+		code[i] = '0' + (buf[i] % 10)
+	}
+	return string(code), nil
+}
+
+// StartCleanup starts a background goroutine that periodically cleans expired codes.
+func StartCleanup() {
+	go func() {
+		ticker := time.NewTicker(5 * time.Minute)
+		defer ticker.Stop()
+		for range ticker.C {
+			defaultCodeManager.cleanupExpired()
+		}
+	}()
+}

--- a/pkg/email/sender.go
+++ b/pkg/email/sender.go
@@ -1,0 +1,135 @@
+package email
+
+import (
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"net"
+	"net/smtp"
+	"strings"
+
+	"github.com/zxh326/kite/pkg/common"
+	"github.com/zxh326/kite/pkg/i18n"
+	"github.com/zxh326/kite/pkg/model"
+)
+
+// GetEffectiveSMTPSetting returns the SMTP settings from env vars if
+// SMTP_HOST is set, otherwise from the database.
+func GetEffectiveSMTPSetting() (*model.SMTPSetting, error) {
+	if common.SMTPEnvEnabled {
+		return &model.SMTPSetting{
+			Enabled:   true,
+			Host:      common.SMTPHost,
+			Port:      common.SMTPPort,
+			Username:  common.SMTPUsername,
+			Password:  model.SecretString(common.SMTPPassword),
+			FromEmail: common.SMTPFromEmail,
+			UseTLS:    common.SMTPUseTLS,
+		}, nil
+	}
+	return model.GetSMTPSetting()
+}
+
+// IsSMTPEnabled returns true if SMTP is configured and enabled.
+func IsSMTPEnabled() bool {
+	setting, err := GetEffectiveSMTPSetting()
+	if err != nil {
+		return false
+	}
+	return setting != nil && setting.Enabled && setting.Host != ""
+}
+
+// SendVerificationCode sends a 6-digit verification code to the recipient.
+// The lang parameter controls the language of the email content.
+func SendVerificationCode(to, code, lang string) error {
+	setting, err := GetEffectiveSMTPSetting()
+	if err != nil {
+		return fmt.Errorf("failed to get SMTP settings: %w", err)
+	}
+	if !setting.Enabled || setting.Host == "" {
+		return errors.New(i18n.T(lang, "smtp_not_configured"))
+	}
+
+	subject := i18n.T(lang, "verification_email_subject")
+	body := i18n.T(lang, "verification_email_body", code)
+
+	return sendMail(setting, to, subject, body)
+}
+
+func sendMail(setting *model.SMTPSetting, to, subject, body string) error {
+	from := setting.FromEmail
+	if from == "" {
+		return errors.New(i18n.T("en", "from_email_not_configured"))
+	}
+
+	headers := map[string]string{
+		"From":         from,
+		"To":           to,
+		"Subject":      subject,
+		"MIME-Version": "1.0",
+		"Content-Type": "text/plain; charset=UTF-8",
+	}
+
+	var msg strings.Builder
+	for k, v := range headers {
+		fmt.Fprintf(&msg, "%s: %s\r\n", k, v)
+	}
+	msg.WriteString("\r\n")
+	msg.WriteString(body)
+
+	addr := net.JoinHostPort(setting.Host, fmt.Sprintf("%d", setting.Port))
+	auth := smtp.PlainAuth("", setting.Username, string(setting.Password), setting.Host)
+
+	if setting.UseTLS {
+		return sendMailTLS(addr, auth, from, []string{to}, []byte(msg.String()))
+	}
+	return smtp.SendMail(addr, auth, from, []string{to}, []byte(msg.String()))
+}
+
+func sendMailTLS(addr string, auth smtp.Auth, from string, to []string, msg []byte) error {
+	conn, err := tls.Dial("tcp", addr, &tls.Config{
+		MinVersion: tls.VersionTLS12,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to connect to SMTP server: %w", err)
+	}
+	defer func() {
+		_ = conn.Close()
+	}()
+
+	client, err := smtp.NewClient(conn, strings.Split(addr, ":")[0])
+	if err != nil {
+		return fmt.Errorf("failed to create SMTP client: %w", err)
+	}
+	defer func() {
+		_ = client.Quit()
+	}()
+
+	if auth != nil {
+		if err := client.Auth(auth); err != nil {
+			return fmt.Errorf("SMTP auth failed: %w", err)
+		}
+	}
+
+	if err := client.Mail(from); err != nil {
+		return fmt.Errorf("SMTP MAIL FROM failed: %w", err)
+	}
+	for _, recipient := range to {
+		if err := client.Rcpt(recipient); err != nil {
+			return fmt.Errorf("SMTP RCPT TO failed: %w", err)
+		}
+	}
+
+	w, err := client.Data()
+	if err != nil {
+		return fmt.Errorf("SMTP DATA failed: %w", err)
+	}
+	if _, err := w.Write(msg); err != nil {
+		return fmt.Errorf("failed to write email body: %w", err)
+	}
+	if err := w.Close(); err != nil {
+		return fmt.Errorf("failed to send email: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/i18n/i18n.go
+++ b/pkg/i18n/i18n.go
@@ -1,0 +1,134 @@
+package i18n
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+)
+
+const LocaleKey = "locale"
+
+var messages = map[string]map[string]string{
+	"en": {
+		// Email verification errors
+		"email_service_not_configured":      "email service is not configured, please contact the administrator",
+		"no_email_associated":               "no email address associated with your account",
+		"failed_to_send_verification_email": "failed to send verification email",
+		"email_verification_code_invalid":   "email verification code is required and must be valid",
+		"email_can_only_set_for_password":   "email can only be set for password users",
+		"failed_to_update_email":            "failed to update email",
+		"current_password_incorrect":        "current password is incorrect",
+
+		// Code manager errors
+		"code_cooldown":          "please wait %d seconds before requesting a new code",
+		"code_not_found":         "no verification code found, please request a new one",
+		"code_expired":           "verification code has expired, please request a new one",
+		"code_too_many_attempts": "too many failed attempts, please request a new code",
+		"code_invalid":           "invalid verification code",
+
+		// SMTP errors
+		"smtp_not_configured":       "SMTP is not enabled or configured",
+		"from_email_not_configured": "from email is not configured",
+		"smtp_env_managed":          "SMTP is managed by environment variables and cannot be modified through the UI",
+		"smtp_from_email_required":  "fromEmail is required when enabled is true",
+		"failed_to_send_test_email": "Failed to send test email: %v",
+
+		// Email content
+		"verification_email_subject": "Kite Verification Code",
+		"verification_email_body":    "Your verification code is: %s\n\nThis code will expire in 10 minutes.",
+	},
+	"zh": {
+		// Email verification errors
+		"email_service_not_configured":      "邮件服务未配置，请联系管理员",
+		"no_email_associated":               "您的账户未关联邮箱地址",
+		"failed_to_send_verification_email": "发送验证邮件失败",
+		"email_verification_code_invalid":   "邮箱验证码无效或已过期",
+		"email_can_only_set_for_password":   "仅密码用户可设置邮箱",
+		"failed_to_update_email":            "更新邮箱失败",
+		"current_password_incorrect":        "当前密码不正确",
+
+		// Code manager errors
+		"code_cooldown":          "请在 %d 秒后再请求新的验证码",
+		"code_not_found":         "未找到验证码，请重新请求",
+		"code_expired":           "验证码已过期，请重新请求",
+		"code_too_many_attempts": "尝试次数过多，请重新请求验证码",
+		"code_invalid":           "验证码无效",
+
+		// SMTP errors
+		"smtp_not_configured":       "SMTP 未启用或未配置",
+		"from_email_not_configured": "发件人邮箱未配置",
+		"smtp_env_managed":          "SMTP 由环境变量管理，无法通过界面修改",
+		"smtp_from_email_required":  "启用时必须填写发件人邮箱",
+		"failed_to_send_test_email": "发送测试邮件失败：%v",
+
+		// Email content
+		"verification_email_subject": "Kite 验证码",
+		"verification_email_body":    "您的验证码是：%s\n\n该验证码将在 10 分钟后过期。",
+	},
+}
+
+func T(lang, key string, args ...interface{}) string {
+	msgs, ok := messages[lang]
+	if !ok {
+		msgs = messages["en"]
+	}
+	msg, ok := msgs[key]
+	if !ok {
+		msg = messages["en"][key]
+	}
+	if msg == "" {
+		return key
+	}
+	if len(args) > 0 {
+		return sprintf(msg, args...)
+	}
+	return msg
+}
+
+// sprintf is a simple fmt.Sprintf wrapper to avoid importing fmt in the map definition.
+func sprintf(format string, args ...interface{}) string {
+	return fmt.Sprintf(format, args...)
+}
+
+// Normalize extracts a 2-letter language code from the Accept-Language header value.
+func Normalize(header string) string {
+	if header == "" {
+		return "en"
+	}
+	parts := strings.SplitN(header, ",", 2)
+	lang := strings.TrimSpace(parts[0])
+	if len(lang) >= 2 {
+		lang = lang[:2]
+	}
+	switch lang {
+	case "zh":
+		return "zh"
+	default:
+		return "en"
+	}
+}
+
+// Middleware extracts the Accept-Language header and stores the locale in the gin context.
+func Middleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		lang := Normalize(c.GetHeader("Accept-Language"))
+		c.Set(LocaleKey, lang)
+		c.Next()
+	}
+}
+
+// FromContext returns the locale stored in the gin context, defaulting to "en".
+func FromContext(c *gin.Context) string {
+	lang, ok := c.Get(LocaleKey)
+	if !ok {
+		return "en"
+	}
+	return lang.(string)
+}
+
+// FromRequest returns the locale from an HTTP request, defaulting to "en".
+func FromRequest(r *http.Request) string {
+	return Normalize(r.Header.Get("Accept-Language"))
+}

--- a/pkg/i18n/i18n_test.go
+++ b/pkg/i18n/i18n_test.go
@@ -1,0 +1,202 @@
+package i18n
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TestTReturnsEnglish(t *testing.T) {
+	msg := T("en", "email_service_not_configured")
+	if msg != "email service is not configured, please contact the administrator" {
+		t.Fatalf("expected English message, got: %s", msg)
+	}
+}
+
+func TestTReturnsChinese(t *testing.T) {
+	msg := T("zh", "email_service_not_configured")
+	if msg != "邮件服务未配置，请联系管理员" {
+		t.Fatalf("expected Chinese message, got: %s", msg)
+	}
+}
+
+func TestTFallbackToEnglish(t *testing.T) {
+	msg := T("fr", "email_service_not_configured")
+	if msg != "email service is not configured, please contact the administrator" {
+		t.Fatalf("expected English fallback, got: %s", msg)
+	}
+}
+
+func TestTFallbackToKey(t *testing.T) {
+	msg := T("en", "nonexistent_key")
+	if msg != "nonexistent_key" {
+		t.Fatalf("expected key as fallback, got: %s", msg)
+	}
+}
+
+func TestTWithFormatArgs(t *testing.T) {
+	msg := T("en", "code_cooldown", 30)
+	if msg != "please wait 30 seconds before requesting a new code" {
+		t.Fatalf("expected formatted message, got: %s", msg)
+	}
+}
+
+func TestTWithFormatArgsChinese(t *testing.T) {
+	msg := T("zh", "code_cooldown", 30)
+	if msg != "请在 30 秒后再请求新的验证码" {
+		t.Fatalf("expected formatted Chinese message, got: %s", msg)
+	}
+}
+
+func TestTVerificationEmailSubject(t *testing.T) {
+	en := T("en", "verification_email_subject")
+	zh := T("zh", "verification_email_subject")
+	if en != "Kite Verification Code" {
+		t.Fatalf("unexpected English subject: %s", en)
+	}
+	if zh != "Kite 验证码" {
+		t.Fatalf("unexpected Chinese subject: %s", zh)
+	}
+}
+
+func TestTVerificationEmailBody(t *testing.T) {
+	en := T("en", "verification_email_body", "123456")
+	zh := T("zh", "verification_email_body", "123456")
+	if en != "Your verification code is: 123456\n\nThis code will expire in 10 minutes." {
+		t.Fatalf("unexpected English body: %s", en)
+	}
+	if zh != "您的验证码是：123456\n\n该验证码将在 10 分钟后过期。" {
+		t.Fatalf("unexpected Chinese body: %s", zh)
+	}
+}
+
+func TestNormalize(t *testing.T) {
+	tests := []struct {
+		header   string
+		expected string
+	}{
+		{"zh-CN", "zh"},
+		{"zh", "zh"},
+		{"en-US", "en"},
+		{"en", "en"},
+		{"", "en"},
+		{"fr", "en"},
+		{"de-DE,de;q=0.9,en;q=0.8", "en"},
+		{"zh-TW,zh;q=0.9,en;q=0.8", "zh"},
+		{"ja", "en"},
+	}
+	for _, tt := range tests {
+		got := Normalize(tt.header)
+		if got != tt.expected {
+			t.Errorf("Normalize(%q) = %q, want %q", tt.header, got, tt.expected)
+		}
+	}
+}
+
+func TestFromContext(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Set(LocaleKey, "zh")
+	lang := FromContext(c)
+	if lang != "zh" {
+		t.Fatalf("expected zh, got %s", lang)
+	}
+}
+
+func TestFromContextDefault(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	lang := FromContext(c)
+	if lang != "en" {
+		t.Fatalf("expected en default, got %s", lang)
+	}
+}
+
+func TestFromRequest(t *testing.T) {
+	req := httptest.NewRequest("GET", "/", nil)
+	req.Header.Set("Accept-Language", "zh-CN,zh;q=0.9")
+	lang := FromRequest(req)
+	if lang != "zh" {
+		t.Fatalf("expected zh, got %s", lang)
+	}
+}
+
+func TestFromRequestDefault(t *testing.T) {
+	req := httptest.NewRequest("GET", "/", nil)
+	lang := FromRequest(req)
+	if lang != "en" {
+		t.Fatalf("expected en default, got %s", lang)
+	}
+}
+
+func TestMiddleware(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.Use(Middleware())
+	router.GET("/lang", func(c *gin.Context) {
+		lang := c.GetString(LocaleKey)
+		c.String(http.StatusOK, lang)
+	})
+
+	req := httptest.NewRequest("GET", "/lang", nil)
+	req.Header.Set("Accept-Language", "zh-CN")
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, req)
+
+	if recorder.Body.String() != "zh" {
+		t.Fatalf("expected zh, got %s", recorder.Body.String())
+	}
+}
+
+func TestMiddlewareDefault(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.Use(Middleware())
+	router.GET("/lang", func(c *gin.Context) {
+		lang := c.GetString(LocaleKey)
+		c.String(http.StatusOK, lang)
+	})
+
+	req := httptest.NewRequest("GET", "/lang", nil)
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, req)
+
+	if recorder.Body.String() != "en" {
+		t.Fatalf("expected en, got %s", recorder.Body.String())
+	}
+}
+
+func TestAllErrorKeysExist(t *testing.T) {
+	keys := []string{
+		"email_service_not_configured",
+		"no_email_associated",
+		"failed_to_send_verification_email",
+		"email_verification_code_invalid",
+		"email_can_only_set_for_password",
+		"failed_to_update_email",
+		"code_cooldown",
+		"code_not_found",
+		"code_expired",
+		"code_too_many_attempts",
+		"code_invalid",
+		"smtp_not_configured",
+		"from_email_not_configured",
+		"smtp_env_managed",
+		"smtp_from_email_required",
+		"failed_to_send_test_email",
+		"verification_email_subject",
+		"verification_email_body",
+	}
+	for _, key := range keys {
+		enMsg := T("en", key)
+		if enMsg == key {
+			t.Errorf("missing English translation for key: %s", key)
+		}
+		zhMsg := T("zh", key)
+		if zhMsg == key {
+			t.Errorf("missing Chinese translation for key: %s", key)
+		}
+	}
+}

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -136,6 +136,7 @@ type K8sClient struct {
 	Configuration *rest.Config
 	MetricsClient *metricsclient.Clientset
 	CacheEnabled  bool // true when using controller-runtime informer cache
+	IsConnector   bool // true for connector clusters (affects SPDY executor creation)
 
 	cancel context.CancelFunc
 }

--- a/pkg/kube/exec.go
+++ b/pkg/kube/exec.go
@@ -5,13 +5,11 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"net/http"
 
 	"github.com/zxh326/kite/pkg/common"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/remotecommand"
-	"k8s.io/streaming/pkg/httpstream"
 )
 
 // ExecOptions holds parameters for ExecCommand
@@ -43,19 +41,9 @@ func (c *K8sClient) ExecCommand(ctx context.Context, opts ExecOptions) error {
 		TTY:       opts.TTY,
 	}, scheme.ParameterCodec)
 
-	spdyExec, err := remotecommand.NewSPDYExecutor(c.Configuration, http.MethodPost, req.URL())
+	exec, err := buildExecutor(c, req.URL())
 	if err != nil {
 		return fmt.Errorf("failed to create executor: %w", err)
-	}
-	websocketExec, err := remotecommand.NewWebSocketExecutor(c.Configuration, http.MethodGet, req.URL().String())
-	if err != nil {
-		return fmt.Errorf("failed to create WebSocket executor: %w", err)
-	}
-	exec, err := remotecommand.NewFallbackExecutor(websocketExec, spdyExec, func(err error) bool {
-		return httpstream.IsUpgradeFailure(err) || httpstream.IsHTTPSProxyError(err)
-	})
-	if err != nil {
-		return fmt.Errorf("failed to create fallback executor: %w", err)
 	}
 
 	err = exec.StreamWithContext(ctx, remotecommand.StreamOptions{

--- a/pkg/kube/executor.go
+++ b/pkg/kube/executor.go
@@ -1,0 +1,122 @@
+package kube
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+
+	restclient "k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/remotecommand"
+	spdy "k8s.io/client-go/transport/spdy"
+	httpstream "k8s.io/streaming/pkg/httpstream"
+	streamspdy "k8s.io/streaming/pkg/httpstream/spdy"
+)
+
+// buildExecutor creates a remotecommand.Executor appropriate for the cluster type.
+//
+// For connector clusters: uses SPDY with UpgradeTransport injection. This is
+// necessary because the standard NewSPDYExecutor/NewWebSocketExecutor create
+// their own net.Dialer internally (ignoring config.Transport.DialContext),
+// which fails to resolve the virtual "kubernetes-api" hostname. By manually
+// creating the SPDY round tripper with UpgradeTransport set, the dialer from
+// config.Dial is used via dialerFor() in the spdy roundtripper.
+//
+// For non-connector clusters: uses the standard WebSocket → SPDY fallback.
+func buildExecutor(c *K8sClient, reqURL *url.URL) (remotecommand.Executor, error) {
+	if c.IsConnector {
+		return buildSPDYExecutorWithDialer(c.Configuration, reqURL)
+	}
+	return buildFallbackExecutor(c.Configuration, reqURL)
+}
+
+// buildFallbackExecutor creates a WebSocket → SPDY fallback executor for
+// non-connector clusters (standard client-go behavior).
+func buildFallbackExecutor(config *restclient.Config, reqURL *url.URL) (remotecommand.Executor, error) {
+	spdyExec, err := remotecommand.NewSPDYExecutor(config, http.MethodPost, reqURL)
+	if err != nil {
+		return nil, fmt.Errorf("create SPDY executor: %w", err)
+	}
+	wsExec, err := remotecommand.NewWebSocketExecutor(config, http.MethodGet, reqURL.String())
+	if err != nil {
+		return nil, fmt.Errorf("create WebSocket executor: %w", err)
+	}
+	exec, err := remotecommand.NewFallbackExecutor(wsExec, spdyExec, func(err error) bool {
+		return httpstream.IsUpgradeFailure(err) || httpstream.IsHTTPSProxyError(err)
+	})
+	if err != nil {
+		return nil, fmt.Errorf("create fallback executor: %w", err)
+	}
+	return exec, nil
+}
+
+// buildSPDYExecutorWithDialer creates a SPDY executor that uses the custom
+// DialContext from the rest.Config. This is needed for connector clusters
+// where the SPDY round tripper must route through the remotedialer tunnel
+// instead of doing DNS resolution.
+//
+// The standard remotecommand.NewSPDYExecutor creates a SpdyRoundTripper with
+// UpgradeTransport=nil, which falls back to net.Dialer and fails to resolve
+// the virtual "kubernetes-api" hostname. By manually creating the round
+// tripper with UpgradeTransport set to an *http.Transport that has DialContext,
+// the SPDY dialer extracts and uses our custom dialer (see dialerFor() in
+// k8s.io/streaming/pkg/httpstream/spdy/roundtripper.go).
+func buildSPDYExecutorWithDialer(config *restclient.Config, reqURL *url.URL) (remotecommand.Executor, error) {
+	// Build a transport from the rest.Config. rest.TransportFor creates an
+	// *http.Transport with the custom DialContext from config.Dial.
+	transport, err := restclient.TransportFor(config)
+	if err != nil {
+		return nil, fmt.Errorf("create transport for SPDY: %w", err)
+	}
+
+	// Extract the underlying *http.Transport to pass as UpgradeTransport.
+	// The SPDY round tripper will use it via dialerFor() to get DialContext.
+	httpTransport, ok := transport.(*http.Transport)
+	if !ok {
+		httpTransport = extractHTTPTransport(transport)
+		if httpTransport == nil {
+			return nil, fmt.Errorf("cannot extract *http.Transport for SPDY upgrade")
+		}
+	}
+
+	// Create streaming SPDY round tripper with UpgradeTransport injected.
+	// When UpgradeTransport != nil, TLS config is extracted from the
+	// transport's TLSClientConfig (mutually exclusive with TLS field).
+	// The SPDY dialer uses dialerFor() to extract transport.DialContext,
+	// routing through our remotedialer tunnel.
+	spdyRT, err := streamspdy.NewRoundTripperWithConfig(streamspdy.RoundTripperConfig{
+		UpgradeTransport: httpTransport,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("create SPDY round tripper: %w", err)
+	}
+
+	// Wrap with auth round trippers (bearer token, etc.)
+	wrapper, err := restclient.HTTPWrappersForConfig(config, spdyRT)
+	if err != nil {
+		return nil, fmt.Errorf("wrap SPDY transport with auth: %w", err)
+	}
+
+	// Adapt the streaming SPDY round tripper to client-go's Upgrader interface.
+	upgrader := spdy.NewUpgraderForStreaming(spdyRT)
+
+	return remotecommand.NewSPDYExecutorForTransports(wrapper, upgrader, http.MethodPost, reqURL)
+}
+
+// extractHTTPTransport attempts to find the underlying *http.Transport
+// from a potentially wrapped RoundTripper by checking known wrapper types.
+func extractHTTPTransport(rt http.RoundTripper) *http.Transport {
+	type wrappedRT interface {
+		WrappedRoundTripper() http.RoundTripper
+	}
+	for i := 0; i < 10; i++ {
+		if t, ok := rt.(*http.Transport); ok {
+			return t
+		}
+		if w, ok := rt.(wrappedRT); ok {
+			rt = w.WrappedRoundTripper()
+			continue
+		}
+		break
+	}
+	return nil
+}

--- a/pkg/kube/executor_test.go
+++ b/pkg/kube/executor_test.go
@@ -1,0 +1,115 @@
+package kube
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/url"
+	"testing"
+
+	restclient "k8s.io/client-go/rest"
+)
+
+// --- buildExecutor dispatch tests ---
+
+func TestBuildExecutor_ConnectorUsesSPDY(t *testing.T) {
+	// For connector clusters, buildExecutor should route to
+	// buildSPDYExecutorWithDialer. We verify this by checking that it
+	// does not panic and returns an error (since we have no real API server).
+	config := &restclient.Config{
+		Host: "https://kubernetes-api:443",
+	}
+	config.Dial = func(ctx context.Context, network, addr string) (net.Conn, error) {
+		return nil, nil
+	}
+
+	// We can't easily test buildSPDYExecutorWithDialer without a real
+	// transport, but we can test the dispatch logic.
+	c := &K8sClient{
+		IsConnector:   true,
+		Configuration: config,
+	}
+	reqURL := &url.URL{Scheme: "https", Host: "kubernetes-api:443", Path: "/api/v1/namespaces/default/pods/foo/exec"}
+
+	// This will fail because the dialer signature doesn't match, but
+	// the important thing is that it routes to the SPDY path (not fallback).
+	_, err := buildExecutor(c, reqURL)
+	// We expect an error since there's no real API server, but the function
+	// should not panic.
+	_ = err
+}
+
+func TestBuildExecutor_NonConnectorUsesFallback(t *testing.T) {
+	// For non-connector clusters, buildExecutor should route to
+	// buildFallbackExecutor (WebSocket → SPDY).
+	config := &restclient.Config{
+		Host: "https://127.0.0.1:6443",
+	}
+
+	c := &K8sClient{
+		IsConnector:   false,
+		Configuration: config,
+	}
+	reqURL := &url.URL{Scheme: "https", Host: "127.0.0.1:6443", Path: "/api/v1/namespaces/default/pods/foo/exec"}
+
+	_, err := buildExecutor(c, reqURL)
+	// We expect an error since there's no real API server.
+	_ = err
+}
+
+// --- extractHTTPTransport tests ---
+
+func TestExtractHTTPTransport_DirectTransport(t *testing.T) {
+	transport := &http.Transport{}
+	got := extractHTTPTransport(transport)
+	if got != transport {
+		t.Error("expected to find the transport directly")
+	}
+}
+
+func TestExtractHTTPTransport_NilInput(t *testing.T) {
+	got := extractHTTPTransport(nil)
+	if got != nil {
+		t.Error("expected nil for nil input")
+	}
+}
+
+func TestExtractHTTPTransport_WrappedTransport(t *testing.T) {
+	inner := &http.Transport{}
+	wrapped := &mockWrappedRT{inner: inner}
+
+	got := extractHTTPTransport(wrapped)
+	if got != inner {
+		t.Error("expected to find the inner transport")
+	}
+}
+
+func TestExtractHTTPTransport_DeeplyWrapped(t *testing.T) {
+	inner := &http.Transport{}
+	wrapped := &mockWrappedRT{inner: &mockWrappedRT{inner: inner}}
+
+	got := extractHTTPTransport(wrapped)
+	if got != inner {
+		t.Error("expected to find the innermost transport")
+	}
+}
+
+func TestExtractHTTPTransport_NotATransport(t *testing.T) {
+	got := extractHTTPTransport(&mockWrappedRT{inner: nil})
+	if got != nil {
+		t.Error("expected nil when no *http.Transport is found")
+	}
+}
+
+// mockWrappedRT implements the wrappedRT interface for testing.
+type mockWrappedRT struct {
+	inner http.RoundTripper
+}
+
+func (m *mockWrappedRT) RoundTrip(*http.Request) (*http.Response, error) {
+	return nil, nil
+}
+
+func (m *mockWrappedRT) WrappedRoundTripper() http.RoundTripper {
+	return m.inner
+}

--- a/pkg/kube/terminal.go
+++ b/pkg/kube/terminal.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"net/http"
 
 	"github.com/zxh326/kite/pkg/common"
 	"github.com/zxh326/kite/pkg/wsutil"
@@ -12,7 +11,6 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/remotecommand"
 	"k8s.io/klog/v2"
-	"k8s.io/streaming/pkg/httpstream"
 )
 
 const EndOfTransmission = "\u0004"
@@ -63,24 +61,10 @@ func (session *TerminalSession) Start(ctx context.Context, subResource string) e
 		TTY:       true,
 	}, scheme.ParameterCodec)
 
-	spdyExec, err := remotecommand.NewSPDYExecutor(session.k8sClient.Configuration, http.MethodPost, req.URL())
+	spdyExec, err := buildExecutor(session.k8sClient, req.URL())
 	if err != nil {
 		log.Printf("Failed to create executor: %v", err)
 		session.SendErrorMessage(fmt.Sprintf("Failed to create executor: %v", err))
-		return err
-	}
-	websocketExec, err := remotecommand.NewWebSocketExecutor(session.k8sClient.Configuration, http.MethodGet, req.URL().String())
-	if err != nil {
-		log.Printf("Failed to create WebSocket executor: %v", err)
-		session.SendErrorMessage(fmt.Sprintf("Failed to create WebSocket executor: %v", err))
-		return err
-	}
-	exec, err := remotecommand.NewFallbackExecutor(websocketExec, spdyExec, func(err error) bool {
-		return httpstream.IsUpgradeFailure(err) || httpstream.IsHTTPSProxyError(err)
-	})
-	if err != nil {
-		log.Printf("Failed to create fallback executor: %v", err)
-		session.SendErrorMessage(fmt.Sprintf("Failed to create fallback executor: %v", err))
 		return err
 	}
 
@@ -88,7 +72,7 @@ func (session *TerminalSession) Start(ctx context.Context, subResource string) e
 	session.SendMessage("connected", "Terminal connected successfully")
 
 	// Start the exec session
-	err = exec.StreamWithContext(ctx, remotecommand.StreamOptions{
+	err = spdyExec.StreamWithContext(ctx, remotecommand.StreamOptions{
 		Stdin:             session,
 		Stdout:            session,
 		Stderr:            session,

--- a/pkg/model/cluster.go
+++ b/pkg/model/cluster.go
@@ -1,5 +1,7 @@
 package model
 
+import "github.com/google/uuid"
+
 type Cluster struct {
 	Model
 	Name               string       `json:"name" gorm:"type:varchar(100);uniqueIndex;not null"`
@@ -11,9 +13,13 @@ type Cluster struct {
 	ConnectorTokenHash string       `json:"-" gorm:"type:varchar(64);index"`
 	IsDefault          bool         `json:"is_default" gorm:"type:boolean;default:false"`
 	Enable             bool         `json:"enable" gorm:"type:boolean;default:true"`
+	UUID               string       `json:"uuid" gorm:"type:varchar(36);uniqueIndex"`
 }
 
 func AddCluster(cluster *Cluster) error {
+	if cluster.UUID == "" {
+		cluster.UUID = uuid.NewString()
+	}
 	return DB.Create(cluster).Error
 }
 
@@ -36,6 +42,14 @@ func GetClusterByID(id uint) (*Cluster, error) {
 func GetClusterByConnectorTokenHash(hash string) (*Cluster, error) {
 	var cluster Cluster
 	if err := DB.Where("connector_token_hash = ?", hash).First(&cluster).Error; err != nil {
+		return nil, err
+	}
+	return &cluster, nil
+}
+
+func GetClusterByUUID(uuidStr string) (*Cluster, error) {
+	var cluster Cluster
+	if err := DB.Where("uuid = ?", uuidStr).First(&cluster).Error; err != nil {
 		return nil, err
 	}
 	return &cluster, nil

--- a/pkg/model/cluster_test.go
+++ b/pkg/model/cluster_test.go
@@ -1,0 +1,192 @@
+package model
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/glebarez/sqlite"
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+func setupClusterTestDB(t *testing.T) {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	if err != nil {
+		t.Fatalf("failed to open test db: %v", err)
+	}
+	if err := db.AutoMigrate(&Cluster{}, &User{}, &Role{}, &RoleAssignment{}); err != nil {
+		t.Fatalf("failed to migrate: %v", err)
+	}
+	DB = db
+}
+
+// --- UUID auto-generation tests ---
+
+func TestAddCluster_AutoGeneratesUUID(t *testing.T) {
+	setupClusterTestDB(t)
+
+	cluster := &Cluster{Name: "test-cluster"}
+	if err := AddCluster(cluster); err != nil {
+		t.Fatalf("AddCluster() error: %v", err)
+	}
+	if cluster.UUID == "" {
+		t.Fatal("AddCluster() should auto-generate UUID")
+	}
+	if _, err := uuid.Parse(cluster.UUID); err != nil {
+		t.Errorf("UUID %q is not a valid UUID: %v", cluster.UUID, err)
+	}
+}
+
+func TestAddCluster_PreservesPresetUUID(t *testing.T) {
+	setupClusterTestDB(t)
+
+	preset := "550e8400-e29b-41d4-a716-446655440000"
+	cluster := &Cluster{Name: "test-cluster", UUID: preset}
+	if err := AddCluster(cluster); err != nil {
+		t.Fatalf("AddCluster() error: %v", err)
+	}
+	if cluster.UUID != preset {
+		t.Errorf("AddCluster() overwrote preset UUID: got %q, want %q", cluster.UUID, preset)
+	}
+}
+
+func TestAddCluster_GeneratesUniqueUUIDs(t *testing.T) {
+	setupClusterTestDB(t)
+
+	c1 := &Cluster{Name: "cluster-1"}
+	c2 := &Cluster{Name: "cluster-2"}
+	if err := AddCluster(c1); err != nil {
+		t.Fatalf("AddCluster(c1) error: %v", err)
+	}
+	if err := AddCluster(c2); err != nil {
+		t.Fatalf("AddCluster(c2) error: %v", err)
+	}
+	if c1.UUID == c2.UUID {
+		t.Fatal("two clusters should have different UUIDs")
+	}
+}
+
+// --- GetClusterByUUID tests ---
+
+func TestGetClusterByUUID_Found(t *testing.T) {
+	setupClusterTestDB(t)
+
+	cluster := &Cluster{Name: "find-me"}
+	if err := AddCluster(cluster); err != nil {
+		t.Fatalf("AddCluster() error: %v", err)
+	}
+
+	got, err := GetClusterByUUID(cluster.UUID)
+	if err != nil {
+		t.Fatalf("GetClusterByUUID() error: %v", err)
+	}
+	if got.Name != "find-me" {
+		t.Errorf("GetClusterByUUID() returned cluster %q, want %q", got.Name, "find-me")
+	}
+	if got.ID != cluster.ID {
+		t.Errorf("GetClusterByUUID() returned ID %d, want %d", got.ID, cluster.ID)
+	}
+}
+
+func TestGetClusterByUUID_NotFound(t *testing.T) {
+	setupClusterTestDB(t)
+
+	_, err := GetClusterByUUID("nonexistent-uuid")
+	if err == nil {
+		t.Fatal("GetClusterByUUID() should return error for nonexistent UUID")
+	}
+	if !errors.Is(err, gorm.ErrRecordNotFound) {
+		t.Errorf("GetClusterByUUID() error = %v, want gorm.ErrRecordNotFound", err)
+	}
+}
+
+func TestGetClusterByUUID_EmptyString(t *testing.T) {
+	setupClusterTestDB(t)
+
+	_, err := GetClusterByUUID("")
+	if err == nil {
+		t.Fatal("GetClusterByUUID() should return error for empty UUID")
+	}
+}
+
+// --- GetClusterByConnectorTokenHash tests ---
+
+func TestGetClusterByConnectorTokenHash(t *testing.T) {
+	setupClusterTestDB(t)
+
+	hash := "abcdef0123456789"
+	cluster := &Cluster{
+		Name:               "token-cluster",
+		Connector:          true,
+		ConnectorTokenHash: hash,
+	}
+	if err := AddCluster(cluster); err != nil {
+		t.Fatalf("AddCluster() error: %v", err)
+	}
+
+	got, err := GetClusterByConnectorTokenHash(hash)
+	if err != nil {
+		t.Fatalf("GetClusterByConnectorTokenHash() error: %v", err)
+	}
+	if got.Name != "token-cluster" {
+		t.Errorf("got cluster %q, want %q", got.Name, "token-cluster")
+	}
+}
+
+func TestGetClusterByConnectorTokenHash_NotFound(t *testing.T) {
+	setupClusterTestDB(t)
+
+	_, err := GetClusterByConnectorTokenHash("nonexistent-hash")
+	if err == nil {
+		t.Fatal("GetClusterByConnectorTokenHash() should return error for nonexistent hash")
+	}
+}
+
+// --- migrateClusterUUIDs tests ---
+
+func TestMigrateClusterUUIDs_BackfillsEmpty(t *testing.T) {
+	setupClusterTestDB(t)
+
+	// Insert a cluster directly with empty UUID (bypassing AddCluster)
+	cluster := Cluster{Name: "old-cluster", UUID: ""}
+	if err := DB.Create(&cluster).Error; err != nil {
+		t.Fatalf("DB.Create() error: %v", err)
+	}
+
+	migrateClusterUUIDs()
+
+	var refreshed Cluster
+	if err := DB.First(&refreshed, cluster.ID).Error; err != nil {
+		t.Fatalf("DB.First() error: %v", err)
+	}
+	if refreshed.UUID == "" {
+		t.Fatal("migrateClusterUUIDs() should have backfilled the UUID")
+	}
+	if _, err := uuid.Parse(refreshed.UUID); err != nil {
+		t.Errorf("backfilled UUID %q is not valid: %v", refreshed.UUID, err)
+	}
+}
+
+func TestMigrateClusterUUIDs_PreservesExisting(t *testing.T) {
+	setupClusterTestDB(t)
+
+	existing := "550e8400-e29b-41d4-a716-446655440000"
+	cluster := Cluster{Name: "has-uuid", UUID: existing}
+	if err := DB.Create(&cluster).Error; err != nil {
+		t.Fatalf("DB.Create() error: %v", err)
+	}
+
+	migrateClusterUUIDs()
+
+	var refreshed Cluster
+	if err := DB.First(&refreshed, cluster.ID).Error; err != nil {
+		t.Fatalf("DB.First() error: %v", err)
+	}
+	if refreshed.UUID != existing {
+		t.Errorf("migrateClusterUUIDs() changed existing UUID: got %q, want %q", refreshed.UUID, existing)
+	}
+}

--- a/pkg/model/ldap_setting.go
+++ b/pkg/model/ldap_setting.go
@@ -11,6 +11,7 @@ import (
 const DefaultLDAPUserFilter = "(uid=%s)"
 const DefaultLDAPUsernameAttribute = "uid"
 const DefaultLDAPDisplayNameAttribute = "cn"
+const DefaultLDAPEmailAttribute = "mail"
 const DefaultLDAPGroupFilter = "(member=%s)"
 const DefaultLDAPGroupNameAttribute = "cn"
 
@@ -25,6 +26,7 @@ type LDAPSetting struct {
 	UserFilter           string       `json:"userFilter" gorm:"column:user_filter;type:varchar(500);default:'(uid=%s)'"`
 	UsernameAttribute    string       `json:"usernameAttribute" gorm:"column:username_attribute;type:varchar(100);default:'uid'"`
 	DisplayNameAttribute string       `json:"displayNameAttribute" gorm:"column:display_name_attribute;type:varchar(100);default:'cn'"`
+	EmailAttribute       string       `json:"emailAttribute" gorm:"column:email_attribute;type:varchar(100);default:'mail'"`
 	GroupBaseDN          string       `json:"groupBaseDn" gorm:"column:group_base_dn;type:varchar(500)"`
 	GroupFilter          string       `json:"groupFilter" gorm:"column:group_filter;type:varchar(500);default:'(member=%s)'"`
 	GroupNameAttribute   string       `json:"groupNameAttribute" gorm:"column:group_name_attribute;type:varchar(100);default:'cn'"`
@@ -38,6 +40,7 @@ func DefaultLDAPSetting() LDAPSetting {
 		UserFilter:           DefaultLDAPUserFilter,
 		UsernameAttribute:    DefaultLDAPUsernameAttribute,
 		DisplayNameAttribute: DefaultLDAPDisplayNameAttribute,
+		EmailAttribute:       DefaultLDAPEmailAttribute,
 		GroupFilter:          DefaultLDAPGroupFilter,
 		GroupNameAttribute:   DefaultLDAPGroupNameAttribute,
 	}
@@ -59,6 +62,7 @@ func (s LDAPSetting) Normalized() LDAPSetting {
 	normalized.UserFilter = normalizeLDAPTextWithDefault(s.UserFilter, DefaultLDAPUserFilter)
 	normalized.UsernameAttribute = normalizeLDAPTextWithDefault(s.UsernameAttribute, DefaultLDAPUsernameAttribute)
 	normalized.DisplayNameAttribute = normalizeLDAPTextWithDefault(s.DisplayNameAttribute, DefaultLDAPDisplayNameAttribute)
+	normalized.EmailAttribute = normalizeLDAPTextWithDefault(s.EmailAttribute, DefaultLDAPEmailAttribute)
 	normalized.GroupBaseDN = strings.TrimSpace(s.GroupBaseDN)
 	normalized.GroupFilter = normalizeLDAPTextWithDefault(s.GroupFilter, DefaultLDAPGroupFilter)
 	normalized.GroupNameAttribute = normalizeLDAPTextWithDefault(s.GroupNameAttribute, DefaultLDAPGroupNameAttribute)
@@ -124,6 +128,7 @@ func UpdateLDAPSetting(setting *LDAPSetting) (*LDAPSetting, error) {
 	current.UserFilter = normalized.UserFilter
 	current.UsernameAttribute = normalized.UsernameAttribute
 	current.DisplayNameAttribute = normalized.DisplayNameAttribute
+	current.EmailAttribute = normalized.EmailAttribute
 	current.GroupBaseDN = normalized.GroupBaseDN
 	current.GroupFilter = normalized.GroupFilter
 	current.GroupNameAttribute = normalized.GroupNameAttribute

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/glebarez/sqlite"
+	"github.com/google/uuid"
 	"github.com/zxh326/kite/pkg/common"
 	"gorm.io/driver/mysql"
 	"gorm.io/driver/postgres"
@@ -111,10 +112,27 @@ func InitDB() {
 			panic("failed to migrate database: " + err.Error())
 		}
 	}
+
+	// Backfill UUID for clusters that predate the uuid column.
+	migrateClusterUUIDs()
 	sqldb, err := DB.DB()
 	if err == nil {
 		sqldb.SetMaxOpenConns(common.DBMaxOpenConns)
 		sqldb.SetMaxIdleConns(common.DBMaxIdleConns)
 		sqldb.SetConnMaxLifetime(common.DBMaxIdleTime)
+	}
+}
+
+func migrateClusterUUIDs() {
+	var clusters []Cluster
+	if err := DB.Where("uuid = '' OR uuid IS NULL").Find(&clusters).Error; err != nil {
+		klog.Errorf("failed to load clusters for UUID migration: %v", err)
+		return
+	}
+	for i := range clusters {
+		clusters[i].UUID = uuid.NewString()
+		if err := DB.Model(&clusters[i]).Update("uuid", clusters[i].UUID).Error; err != nil {
+			klog.Errorf("failed to set UUID for cluster %s: %v", clusters[i].Name, err)
+		}
 	}
 }

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -97,6 +97,7 @@ func InitDB() {
 		Cluster{},
 		GeneralSetting{},
 		LDAPSetting{},
+		SMTPSetting{},
 		OAuthProvider{},
 		Role{},
 		RoleAssignment{},

--- a/pkg/model/oauth.go
+++ b/pkg/model/oauth.go
@@ -38,6 +38,8 @@ type OAuthProvider struct {
 	Issuer        string          `json:"issuer" gorm:"type:varchar(255)"`
 	Enabled       bool            `json:"enabled" gorm:"type:boolean;default:true"`
 	UsernameClaim string          `json:"usernameClaim" gorm:"type:varchar(255)"`
+	NameClaim     string          `json:"nameClaim" gorm:"type:varchar(255)"`
+	EmailClaim    string          `json:"emailClaim" gorm:"type:varchar(255)"`
 	GroupsClaim   string          `json:"groupsClaim" gorm:"type:varchar(255)"`
 	AllowedGroups string          `json:"allowedGroups" gorm:"type:text"`
 

--- a/pkg/model/rbac.go
+++ b/pkg/model/rbac.go
@@ -31,6 +31,10 @@ type RoleAssignment struct {
 const (
 	SubjectTypeUser  = "user"
 	SubjectTypeGroup = "group"
+	// SubjectTypeAPIKey is a frontend-only subject type that maps to
+	// SubjectTypeUser in the database. It is used in the RBAC assignment
+	// dialog to let admins pick API Keys as a distinct category.
+	SubjectTypeAPIKey = "apikey"
 )
 
 var (

--- a/pkg/model/smtp_setting.go
+++ b/pkg/model/smtp_setting.go
@@ -1,0 +1,121 @@
+package model
+
+import (
+	"errors"
+	"strings"
+
+	"gorm.io/gorm"
+)
+
+type SMTPSetting struct {
+	Model
+	Enabled   bool         `json:"enabled" gorm:"column:enabled;type:boolean;not null;default:false"`
+	Host      string       `json:"host" gorm:"column:host;type:varchar(255)"`
+	Port      int          `json:"port" gorm:"column:port;type:integer;default:587"`
+	Username  string       `json:"username" gorm:"column:username;type:varchar(255)"`
+	Password  SecretString `json:"-" gorm:"column:password;type:text"`
+	FromEmail string       `json:"fromEmail" gorm:"column:from_email;type:varchar(255)"`
+	UseTLS    bool         `json:"useTLS" gorm:"column:use_tls;type:boolean;not null;default:true"`
+}
+
+func DefaultSMTPSetting() SMTPSetting {
+	return SMTPSetting{
+		Model:   Model{ID: 1},
+		Enabled: false,
+		Port:    587,
+		UseTLS:  true,
+	}
+}
+
+func (s SMTPSetting) Normalized() SMTPSetting {
+	normalized := DefaultSMTPSetting()
+	normalized.Model = s.Model
+	if normalized.ID == 0 {
+		normalized.ID = 1
+	}
+	normalized.Enabled = s.Enabled
+	normalized.Host = strings.TrimSpace(s.Host)
+	normalized.Port = s.Port
+	if normalized.Port == 0 {
+		normalized.Port = 587
+	}
+	normalized.Username = strings.TrimSpace(s.Username)
+	normalized.Password = s.Password
+	normalized.FromEmail = strings.TrimSpace(s.FromEmail)
+	normalized.UseTLS = s.UseTLS
+	return normalized
+}
+
+func (s SMTPSetting) Validate() error {
+	normalized := s.Normalized()
+	if !normalized.Enabled {
+		return nil
+	}
+	if normalized.Host == "" {
+		return errors.New("host is required when enabled is true")
+	}
+	if normalized.Port <= 0 || normalized.Port > 65535 {
+		return errors.New("port must be between 1 and 65535")
+	}
+	if normalized.FromEmail == "" {
+		return errors.New("fromEmail is required when enabled is true")
+	}
+	return nil
+}
+
+func GetSMTPSetting() (*SMTPSetting, error) {
+	setting, err := getOrCreateSMTPSetting()
+	if err != nil {
+		return nil, err
+	}
+	normalized := setting.Normalized()
+	return &normalized, nil
+}
+
+func UpdateSMTPSetting(setting *SMTPSetting) (*SMTPSetting, error) {
+	if setting == nil {
+		return nil, errors.New("smtp setting is nil")
+	}
+	current, err := getOrCreateSMTPSetting()
+	if err != nil {
+		return nil, err
+	}
+	normalized := setting.Normalized()
+	current.Enabled = normalized.Enabled
+	current.Host = normalized.Host
+	current.Port = normalized.Port
+	current.Username = normalized.Username
+	current.FromEmail = normalized.FromEmail
+	current.UseTLS = normalized.UseTLS
+	if string(normalized.Password) != "" {
+		current.Password = normalized.Password
+	}
+	if err := DB.Save(current).Error; err != nil {
+		return nil, err
+	}
+	updated := current.Normalized()
+	return &updated, nil
+}
+
+func (s *SMTPSetting) PasswordConfigured() bool {
+	if s == nil {
+		return false
+	}
+	return string(s.Password) != ""
+}
+
+func getOrCreateSMTPSetting() (*SMTPSetting, error) {
+	var setting SMTPSetting
+	err := DB.First(&setting, 1).Error
+	if err == nil {
+		return &setting, nil
+	}
+	if !errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, err
+	}
+	setting = DefaultSMTPSetting()
+	if err := DB.Create(&setting).Error; err != nil {
+		return nil, err
+	}
+	return &setting, nil
+}

--- a/pkg/model/user.go
+++ b/pkg/model/user.go
@@ -30,6 +30,8 @@ type User struct {
 	APIKey SecretString  `json:"apiKey,omitempty" gorm:"type:text"`
 	Roles  []common.Role `json:"roles,omitempty" gorm:"-"`
 
+	OwnerUserID       *uint  `json:"ownerUserId,omitempty" gorm:"column:owner_user_id;index"`
+	Owner             *User  `json:"owner,omitempty" gorm:"foreignKey:OwnerUserID"`
 	SidebarPreference string `json:"sidebar_preference,omitempty" gorm:"type:text"`
 }
 
@@ -419,7 +421,21 @@ func NewAPIKeyUser(name string) (*User, error) {
 }
 
 func ListAPIKeyUsers() (users []User, err error) {
-	err = DB.Order("id desc").Where("provider = ?", common.APIKeyProvider).Find(&users).Error
+	err = DB.Preload("Owner").Order("id desc").Where("provider = ?", common.APIKeyProvider).Find(&users).Error
+	return users, err
+}
+
+// ListAPIKeyUsersByOwner returns API key users whose owner_user_id matches the
+// given user ID. These are kubeconfig-generated keys.
+func ListAPIKeyUsersByOwner(ownerID uint) (users []User, err error) {
+	err = DB.Where("provider = ? AND owner_user_id = ?", common.APIKeyProvider, ownerID).Find(&users).Error
+	return users, err
+}
+
+// ListIndependentAPIKeyUsers returns API key users without an owner (i.e.
+// manually created keys that can have roles assigned directly).
+func ListIndependentAPIKeyUsers() (users []User, err error) {
+	err = DB.Order("id desc").Where("provider = ? AND owner_user_id IS NULL", common.APIKeyProvider).Find(&users).Error
 	return users, err
 }
 

--- a/pkg/model/user.go
+++ b/pkg/model/user.go
@@ -17,6 +17,7 @@ type User struct {
 	Username    string       `json:"username" gorm:"type:varchar(50);uniqueIndex;not null"`
 	Password    string       `json:"-" gorm:"type:varchar(255)"`
 	Name        string       `json:"name,omitempty" gorm:"type:varchar(100);index"`
+	Email       string       `json:"email,omitempty" gorm:"type:varchar(255);index"`
 	AvatarURL   string       `json:"avatar_url,omitempty" gorm:"type:text"`
 	Provider    string       `json:"provider,omitempty" gorm:"type:varchar(50);default:password;index"`
 	OIDCGroups  SliceString  `json:"oidc_groups,omitempty" gorm:"type:text"`
@@ -123,11 +124,23 @@ func FindWithSubOrUpsertUser(user *User) error {
 		}
 		return err
 	}
-	user.Enabled = existingUser.Enabled
 
 	user.ID = existingUser.ID
 	user.CreatedAt = existingUser.CreatedAt
+	user.Enabled = existingUser.Enabled
 	user.SidebarPreference = existingUser.SidebarPreference
+
+	if user.Name == "" {
+		user.Name = existingUser.Name
+	}
+	if user.Email == "" {
+		user.Email = existingUser.Email
+	}
+	user.MFAEnabled = existingUser.MFAEnabled
+	user.MFASecret = existingUser.MFASecret
+	user.Password = existingUser.Password
+	user.APIKey = existingUser.APIKey
+
 	err := DB.Save(user).Error
 	InvalidateUserCache(uint64(user.ID))
 	return err
@@ -265,6 +278,12 @@ func UpdateUserName(id uint, name string) error {
 	return err
 }
 
+func UpdateUserEmail(id uint, email string) error {
+	err := DB.Model(&User{}).Where("id = ?", id).Update("email", email).Error
+	InvalidateUserCache(uint64(id))
+	return err
+}
+
 // StoreMFASecret persists a pending MFA secret without enabling MFA yet.
 func StoreMFASecret(id uint, secret string) error {
 	err := DB.Model(&User{}).Where("id = ?", id).Updates(map[string]any{
@@ -349,6 +368,12 @@ func UpsertLDAPUser(user *User) (*User, error) {
 	if strings.TrimSpace(user.AvatarURL) == "" {
 		user.AvatarURL = existingUser.AvatarURL
 	}
+	if strings.TrimSpace(user.Email) == "" {
+		user.Email = existingUser.Email
+	}
+	user.MFAEnabled = existingUser.MFAEnabled
+	user.MFASecret = existingUser.MFASecret
+	user.APIKey = existingUser.APIKey
 
 	err := DB.Save(user).Error
 	if err == nil {

--- a/pkg/rbac/handler.go
+++ b/pkg/rbac/handler.go
@@ -32,12 +32,43 @@ func (req roleReq) toRole() model.Role {
 
 // ListRoles returns all roles with assignments
 func ListRoles(c *gin.Context) {
+	page := 1
+	size := 20
+	if p := strings.TrimSpace(c.Query("page")); p != "" {
+		if parsed, err := strconv.Atoi(p); err == nil && parsed > 0 {
+			page = parsed
+		} else {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid page parameter"})
+			return
+		}
+	}
+	if s := strings.TrimSpace(c.Query("size")); s != "" {
+		if parsed, err := strconv.Atoi(s); err == nil && parsed > 0 {
+			size = parsed
+		} else {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid size parameter"})
+			return
+		}
+	}
+
+	query := model.DB.Model(&model.Role{})
+	var total int64
+	if err := query.Count(&total).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to count roles: " + err.Error()})
+		return
+	}
+
 	var roles []model.Role
-	if err := model.DB.Preload("Assignments").Find(&roles).Error; err != nil {
+	if err := query.Preload("Assignments").Order("id desc").Offset((page - 1) * size).Limit(size).Find(&roles).Error; err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to list roles: " + err.Error()})
 		return
 	}
-	c.JSON(http.StatusOK, gin.H{"roles": roles})
+	c.JSON(http.StatusOK, gin.H{
+		"data":  roles,
+		"total": total,
+		"page":  page,
+		"size":  size,
+	})
 }
 
 // GetRole returns a single role by id

--- a/pkg/rbac/handler.go
+++ b/pkg/rbac/handler.go
@@ -184,9 +184,13 @@ func AssignRole(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
-	// validate subject type
-	if req.SubjectType != model.SubjectTypeUser && req.SubjectType != model.SubjectTypeGroup {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "subjectType must be 'user' or 'group'"})
+	// validate subject type and normalize: 'apikey' is stored as 'user'
+	storeSubjectType := req.SubjectType
+	if req.SubjectType == model.SubjectTypeAPIKey {
+		storeSubjectType = model.SubjectTypeUser
+	}
+	if storeSubjectType != model.SubjectTypeUser && storeSubjectType != model.SubjectTypeGroup {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "subjectType must be 'user', 'group', or 'apikey'"})
 		return
 	}
 	// ensure role exists
@@ -198,14 +202,14 @@ func AssignRole(c *gin.Context) {
 
 	// check exists
 	var existing model.RoleAssignment
-	if err := model.DB.Where("role_id = ? AND subject_type = ? AND subject = ?", role.ID, req.SubjectType, req.Subject).First(&existing).Error; err == nil {
+	if err := model.DB.Where("role_id = ? AND subject_type = ? AND subject = ?", role.ID, storeSubjectType, req.Subject).First(&existing).Error; err == nil {
 		c.JSON(http.StatusOK, gin.H{"assignment": existing})
 		return
 	}
 
 	assignment := model.RoleAssignment{
 		RoleID:      role.ID,
-		SubjectType: req.SubjectType,
+		SubjectType: storeSubjectType,
 		Subject:     req.Subject,
 	}
 	if err := model.DB.Create(&assignment).Error; err != nil {
@@ -234,6 +238,10 @@ func UnassignRole(c *gin.Context) {
 	if subjectType == "" || subject == "" {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "subjectType and subject query params are required"})
 		return
+	}
+	// normalize: 'apikey' is stored as 'user'
+	if subjectType == model.SubjectTypeAPIKey {
+		subjectType = model.SubjectTypeUser
 	}
 	if err := model.DB.Where("role_id = ? AND subject_type = ? AND subject = ?", uint(dbID), subjectType, subject).Delete(&model.RoleAssignment{}).Error; err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to remove assignment: " + err.Error()})

--- a/pkg/rbac/handler.go
+++ b/pkg/rbac/handler.go
@@ -59,7 +59,7 @@ func ListRoles(c *gin.Context) {
 	}
 
 	var roles []model.Role
-	if err := query.Preload("Assignments").Order("id desc").Offset((page - 1) * size).Limit(size).Find(&roles).Error; err != nil {
+	if err := query.Preload("Assignments").Order("id").Offset((page - 1) * size).Limit(size).Find(&roles).Error; err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to list roles: " + err.Error()})
 		return
 	}

--- a/pkg/rbac/handler_test.go
+++ b/pkg/rbac/handler_test.go
@@ -150,6 +150,23 @@ func TestRoleHandlers(t *testing.T) { //nolint:gocyclo // handler lifecycle test
 			t.Fatalf("assignment count after unassign = %d, want 1", assignmentCount)
 		}
 
+		// 'apikey' subject type is normalized to 'user' in storage
+		response = perform(http.MethodPost, rolePath+"/assign", `{"subjectType":"apikey","subject":"ci-deploy-key"}`)
+		if response.Code != http.StatusCreated {
+			t.Fatalf("assign apikey returned %d, want %d; body=%s", response.Code, http.StatusCreated, response.Body.String())
+		}
+		var stored model.RoleAssignment
+		if err := db.Where("role_id = ? AND subject = ?", created.Role.ID, "ci-deploy-key").First(&stored).Error; err != nil {
+			t.Fatalf("apikey assignment not found: %v", err)
+		}
+		if stored.SubjectType != model.SubjectTypeUser {
+			t.Fatalf("apikey stored as subjectType %q, want %q", stored.SubjectType, model.SubjectTypeUser)
+		}
+		response = perform(http.MethodDelete, rolePath+"/assign?subjectType=apikey&subject=ci-deploy-key", "")
+		if response.Code != http.StatusOK {
+			t.Fatalf("unassign apikey returned %d, want %d; body=%s", response.Code, http.StatusOK, response.Body.String())
+		}
+
 		response = perform(http.MethodDelete, rolePath, "")
 		if response.Code != http.StatusOK {
 			t.Fatalf("delete returned %d, want %d; body=%s", response.Code, http.StatusOK, response.Body.String())

--- a/pkg/rbac/handler_test.go
+++ b/pkg/rbac/handler_test.go
@@ -90,13 +90,16 @@ func TestRoleHandlers(t *testing.T) { //nolint:gocyclo // handler lifecycle test
 			t.Fatalf("list returned %d, want %d; body=%s", response.Code, http.StatusOK, response.Body.String())
 		}
 		var listed struct {
-			Roles []model.Role `json:"roles"`
+			Data  []model.Role `json:"data"`
+			Total int64        `json:"total"`
+			Page  int          `json:"page"`
+			Size  int          `json:"size"`
 		}
 		if err := json.Unmarshal(response.Body.Bytes(), &listed); err != nil {
 			t.Fatalf("decode list response: %v", err)
 		}
-		if len(listed.Roles) != 1 || listed.Roles[0].ID != created.Role.ID {
-			t.Fatalf("listed roles = %#v", listed.Roles)
+		if len(listed.Data) != 1 || listed.Data[0].ID != created.Role.ID {
+			t.Fatalf("listed roles = %#v", listed.Data)
 		}
 
 		response = perform(http.MethodGet, rolePath, "")
@@ -260,4 +263,77 @@ func TestRoleHandlers(t *testing.T) { //nolint:gocyclo // handler lifecycle test
 			t.Fatalf("system role changed: %#v", stored)
 		}
 	})
+}
+
+func TestListRolesPaginates(t *testing.T) {
+	originalDB := model.DB
+	originalManagedSections := common.ManagedSections
+	originalGinMode := gin.Mode()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{Logger: logger.Default.LogMode(logger.Silent)})
+	if err != nil {
+		t.Fatalf("open database: %v", err)
+	}
+	sqlDB, _ := db.DB()
+	sqlDB.SetMaxOpenConns(1)
+	model.DB = db
+	common.SetManagedSections(map[string]bool{})
+	gin.SetMode(gin.TestMode)
+	t.Cleanup(func() {
+		model.DB = originalDB
+		common.SetManagedSections(originalManagedSections)
+		gin.SetMode(originalGinMode)
+		_ = sqlDB.Close()
+	})
+	if err := db.AutoMigrate(&model.Role{}, &model.RoleAssignment{}); err != nil {
+		t.Fatalf("migrate database: %v", err)
+	}
+	for _, name := range []string{"r1", "r2", "r3"} {
+		if err := db.Create(&model.Role{Name: name}).Error; err != nil {
+			t.Fatalf("creating role %s: %v", name, err)
+		}
+	}
+	router := gin.New()
+	router.GET("/roles", ListRoles)
+
+	resp := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/roles?page=1&size=2", nil)
+	router.ServeHTTP(resp, req)
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status = %d: %s", resp.Code, resp.Body.String())
+	}
+	var body struct {
+		Data  []model.Role `json:"data"`
+		Total int64        `json:"total"`
+		Page  int          `json:"page"`
+		Size  int          `json:"size"`
+	}
+	if err := json.Unmarshal(resp.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decoding response: %v", err)
+	}
+	if body.Total != 3 || body.Page != 1 || body.Size != 2 || len(body.Data) != 2 {
+		t.Fatalf("pagination response = %#v", body)
+	}
+
+	page2 := httptest.NewRecorder()
+	req2 := httptest.NewRequest(http.MethodGet, "/roles?page=2&size=2", nil)
+	router.ServeHTTP(page2, req2)
+	if err := json.Unmarshal(page2.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decoding page2: %v", err)
+	}
+	if body.Total != 3 || body.Page != 2 || len(body.Data) != 1 {
+		t.Fatalf("page2 response = %#v", body)
+	}
+}
+
+func TestListRolesRejectsInvalidQueryParameters(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	for _, query := range []string{"page=0", "size=abc"} {
+		recorder := httptest.NewRecorder()
+		ctx, _ := gin.CreateTestContext(recorder)
+		ctx.Request = httptest.NewRequest(http.MethodGet, "/roles?"+query, nil)
+		ListRoles(ctx)
+		if recorder.Code != http.StatusBadRequest {
+			t.Fatalf("query %q: status = %d, want %d", query, recorder.Code, http.StatusBadRequest)
+		}
+	}
 }

--- a/pkg/rbac/rbac.go
+++ b/pkg/rbac/rbac.go
@@ -80,7 +80,9 @@ func CanAccessNamespace(user model.User, cluster, name string) bool {
 	return false
 }
 
-// GetUserRoles returns all roles for a user/oidcGroups
+// GetUserRoles returns all roles for a user/oidcGroups. If the user is an API
+// Key with an OwnerUserID, the owner's roles are merged in so that the key
+// inherits the owner's permissions.
 func GetUserRoles(user model.User) []common.Role {
 	if user.Roles != nil {
 		return user.Roles
@@ -91,6 +93,25 @@ func GetUserRoles(user model.User) []common.Role {
 	if RBACConfig == nil {
 		return nil
 	}
+	collectRolesLocked(&user, rolesMap)
+	// If this is an API Key with an owner, merge the owner's roles.
+	if user.OwnerUserID != nil {
+		var owner model.User
+		if err := model.DB.First(&owner, *user.OwnerUserID).Error; err == nil {
+			owner.Roles = nil // force fresh lookup
+			collectRolesLocked(&owner, rolesMap)
+		}
+	}
+	roles := make([]common.Role, 0, len(rolesMap))
+	for _, role := range rolesMap {
+		roles = append(roles, role)
+	}
+	return roles
+}
+
+// collectRolesLocked populates rolesMap with all roles matching the given user.
+// Caller must hold rwlock.RLock.
+func collectRolesLocked(user *model.User, rolesMap map[string]common.Role) {
 	for _, mapping := range RBACConfig.RoleMapping {
 		if contains(mapping.Users, "*") || contains(mapping.Users, user.Key()) {
 			if r := findRoleLocked(mapping.Name); r != nil {
@@ -105,11 +126,6 @@ func GetUserRoles(user model.User) []common.Role {
 			}
 		}
 	}
-	roles := make([]common.Role, 0, len(rolesMap))
-	for _, role := range rolesMap {
-		roles = append(roles, role)
-	}
-	return roles
 }
 
 func findRoleLocked(name string) *common.Role {

--- a/pkg/rbac/rbac_additional_test.go
+++ b/pkg/rbac/rbac_additional_test.go
@@ -3,8 +3,11 @@ package rbac
 import (
 	"testing"
 
+	"github.com/glebarez/sqlite"
 	"github.com/zxh326/kite/pkg/common"
 	"github.com/zxh326/kite/pkg/model"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
 )
 
 func TestGetUserRoles(t *testing.T) {
@@ -204,5 +207,60 @@ func TestUserHasRole(t *testing.T) {
 	}
 	if UserHasRole(user, "viewer") {
 		t.Fatal("did not expect viewer role")
+	}
+}
+
+func TestGetUserRolesWithOwner(t *testing.T) {
+	originalConfig := RBACConfig
+	originalDB := model.DB
+	t.Cleanup(func() {
+		RBACConfig = originalConfig
+		model.DB = originalDB
+	})
+
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{Logger: logger.Default.LogMode(logger.Silent)})
+	if err != nil {
+		t.Fatalf("open database: %v", err)
+	}
+	if err := db.AutoMigrate(&model.User{}); err != nil {
+		t.Fatalf("migrate database: %v", err)
+	}
+	model.DB = db
+
+	RBACConfig = &common.RolesConfig{
+		Roles: []common.Role{
+			{Name: "viewer"},
+			{Name: "editor"},
+		},
+		RoleMapping: []common.RoleMapping{
+			{Name: "viewer", Users: []string{"alice"}},
+			{Name: "editor", Users: []string{"bob"}},
+		},
+	}
+
+	// Create owner and API key user with OwnerUserID
+	owner := model.User{Username: "alice", Provider: model.AuthProviderPassword}
+	if err := db.Create(&owner).Error; err != nil {
+		t.Fatalf("create owner: %v", err)
+	}
+	apiKeyUser := model.User{Username: "kubeconfig-alice-1", Provider: "apikey", OwnerUserID: &owner.ID}
+	if err := db.Create(&apiKeyUser).Error; err != nil {
+		t.Fatalf("create api key user: %v", err)
+	}
+
+	// API key should inherit owner's "viewer" role
+	roles := GetUserRoles(apiKeyUser)
+	if len(roles) != 1 || roles[0].Name != "viewer" {
+		t.Fatalf("expected inherited viewer role, got %#v", roles)
+	}
+
+	// API key without owner should not inherit anything
+	standalone := model.User{Username: "standalone-key", Provider: "apikey"}
+	if err := db.Create(&standalone).Error; err != nil {
+		t.Fatalf("create standalone key: %v", err)
+	}
+	roles = GetUserRoles(standalone)
+	if len(roles) != 0 {
+		t.Fatalf("expected no roles for standalone key, got %#v", roles)
 	}
 }

--- a/pkg/settings/smtp_handler.go
+++ b/pkg/settings/smtp_handler.go
@@ -1,0 +1,158 @@
+package settings
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/zxh326/kite/pkg/common"
+	"github.com/zxh326/kite/pkg/email"
+	"github.com/zxh326/kite/pkg/i18n"
+	"github.com/zxh326/kite/pkg/model"
+)
+
+func HandleGetSMTPSetting(c *gin.Context) {
+	// If SMTP is managed via env vars, return those values
+	if common.SMTPEnvEnabled {
+		c.JSON(http.StatusOK, gin.H{
+			"enabled":            true,
+			"host":               common.SMTPHost,
+			"port":               common.SMTPPort,
+			"username":           common.SMTPUsername,
+			"password":           "",
+			"passwordConfigured": common.SMTPPassword != "",
+			"fromEmail":          common.SMTPFromEmail,
+			"useTLS":             common.SMTPUseTLS,
+			"envManaged":         true,
+		})
+		return
+	}
+
+	setting, err := model.GetSMTPSetting()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("Failed to load SMTP setting: %v", err)})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{
+		"enabled":            setting.Enabled,
+		"host":               setting.Host,
+		"port":               setting.Port,
+		"username":           setting.Username,
+		"password":           "",
+		"passwordConfigured": setting.PasswordConfigured(),
+		"fromEmail":          setting.FromEmail,
+		"useTLS":             setting.UseTLS,
+		"envManaged":         false,
+	})
+}
+
+type UpdateSMTPSettingRequest struct {
+	Enabled   *bool   `json:"enabled"`
+	Host      *string `json:"host"`
+	Port      *int    `json:"port"`
+	Username  *string `json:"username"`
+	Password  *string `json:"password"`
+	FromEmail *string `json:"fromEmail"`
+	UseTLS    *bool   `json:"useTLS"`
+}
+
+func HandleUpdateSMTPSetting(c *gin.Context) {
+	if common.IsSectionManaged("smtp") {
+		c.JSON(http.StatusForbidden, gin.H{"error": common.ManagedSectionError})
+		return
+	}
+	if common.SMTPEnvEnabled {
+		lang := i18n.FromContext(c)
+		c.JSON(http.StatusForbidden, gin.H{"error": i18n.T(lang, "smtp_env_managed")})
+		return
+	}
+
+	var req UpdateSMTPSettingRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("Invalid request: %v", err)})
+		return
+	}
+
+	current, err := model.GetSMTPSetting()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("Failed to load SMTP setting: %v", err)})
+		return
+	}
+
+	setting := *current
+	if req.Enabled != nil {
+		setting.Enabled = *req.Enabled
+	}
+	if req.Host != nil {
+		setting.Host = *req.Host
+	}
+	if req.Port != nil {
+		setting.Port = *req.Port
+	}
+	if req.Username != nil {
+		setting.Username = *req.Username
+	}
+	if req.Password != nil && *req.Password != "" {
+		setting.Password = model.SecretString(*req.Password)
+	}
+	if req.FromEmail != nil {
+		setting.FromEmail = *req.FromEmail
+	}
+	if req.UseTLS != nil {
+		setting.UseTLS = *req.UseTLS
+	}
+
+	if err := setting.Validate(); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	updated, err := model.UpdateSMTPSetting(&setting)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("Failed to update SMTP setting: %v", err)})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"enabled":            updated.Enabled,
+		"host":               updated.Host,
+		"port":               updated.Port,
+		"username":           updated.Username,
+		"password":           "",
+		"passwordConfigured": updated.PasswordConfigured(),
+		"fromEmail":          updated.FromEmail,
+		"useTLS":             updated.UseTLS,
+		"envManaged":         false,
+	})
+}
+
+// HandleSendTestEmail sends a test email to verify SMTP configuration.
+func HandleSendTestEmail(c *gin.Context) {
+	lang := i18n.FromContext(c)
+	if !email.IsSMTPEnabled() {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": i18n.T(lang, "smtp_not_configured")})
+		return
+	}
+
+	var req struct {
+		To string `json:"to" binding:"required"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	// Generate and send a test code
+	code, err := email.GetCodeManager().GenerateAndStore(req.To, lang)
+	if err != nil {
+		c.JSON(http.StatusTooManyRequests, gin.H{"error": err.Error()})
+		return
+	}
+
+	if err := email.SendVerificationCode(req.To, code, lang); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf(i18n.T(lang, "failed_to_send_test_email"), err)})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"success": true})
+}

--- a/pkg/users/handler.go
+++ b/pkg/users/handler.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 
 	"github.com/gin-gonic/gin"
+	"github.com/zxh326/kite/pkg/email"
+	"github.com/zxh326/kite/pkg/i18n"
 	"github.com/zxh326/kite/pkg/mfa"
 	"github.com/zxh326/kite/pkg/model"
 	"github.com/zxh326/kite/pkg/passkey"
@@ -125,10 +127,6 @@ func UpdateUser(c *gin.Context) {
 
 func UpdateCurrentUser(c *gin.Context) {
 	user := c.MustGet("user").(model.User)
-	if user.Provider != "" && user.Provider != model.AuthProviderPassword {
-		c.JSON(http.StatusForbidden, gin.H{"error": "account settings are only available for password users"})
-		return
-	}
 
 	var req struct {
 		Name string `json:"name"`
@@ -175,23 +173,28 @@ func ChangeCurrentUserPassword(c *gin.Context) {
 
 func SetupCurrentUserMFA(c *gin.Context) {
 	user := c.MustGet("user").(model.User)
-	if user.Provider != "" && user.Provider != model.AuthProviderPassword {
-		c.JSON(http.StatusForbidden, gin.H{"error": "mfa is only available for password users"})
-		return
-	}
 	if !ensureMFAEnabled(c) {
 		return
 	}
 	var req struct {
-		CurrentPassword string `json:"current_password" binding:"required"`
+		CurrentPassword string `json:"current_password"`
+		EmailCode       string `json:"email_code"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
-	if !model.CheckPassword(user.Password, req.CurrentPassword) {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "current password is incorrect"})
-		return
+	if user.Provider == "" || user.Provider == model.AuthProviderPassword {
+		if !model.CheckPassword(user.Password, req.CurrentPassword) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "current password is incorrect"})
+			return
+		}
+	} else {
+		if !verifyEmailCode(c, user.Email, req.EmailCode) {
+			lang := i18n.FromContext(c)
+			c.JSON(http.StatusBadRequest, gin.H{"error": i18n.T(lang, "email_verification_code_invalid")})
+			return
+		}
 	}
 	if user.MFAEnabled {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "mfa is already enabled"})
@@ -223,10 +226,6 @@ func SetupCurrentUserMFA(c *gin.Context) {
 
 func EnableCurrentUserMFA(c *gin.Context) {
 	user := c.MustGet("user").(model.User)
-	if user.Provider != "" && user.Provider != model.AuthProviderPassword {
-		c.JSON(http.StatusForbidden, gin.H{"error": "mfa is only available for password users"})
-		return
-	}
 	if !ensureMFAEnabled(c) {
 		return
 	}
@@ -257,10 +256,6 @@ func EnableCurrentUserMFA(c *gin.Context) {
 
 func DisableCurrentUserMFA(c *gin.Context) {
 	user := c.MustGet("user").(model.User)
-	if user.Provider != "" && user.Provider != model.AuthProviderPassword {
-		c.JSON(http.StatusForbidden, gin.H{"error": "mfa is only available for password users"})
-		return
-	}
 	if !ensureMFAEnabled(c) {
 		return
 	}
@@ -292,10 +287,6 @@ func DisableCurrentUserMFA(c *gin.Context) {
 
 func ListCurrentUserPasskeys(c *gin.Context) {
 	user := c.MustGet("user").(model.User)
-	if user.Provider != "" && user.Provider != model.AuthProviderPassword {
-		c.JSON(http.StatusForbidden, gin.H{"error": "passkeys are only available for password users"})
-		return
-	}
 	if !ensurePasskeyLoginEnabled(c) {
 		return
 	}
@@ -309,30 +300,42 @@ func ListCurrentUserPasskeys(c *gin.Context) {
 
 func BeginCurrentUserPasskeyRegistration(c *gin.Context) {
 	user := c.MustGet("user").(model.User)
-	if user.Provider != "" && user.Provider != model.AuthProviderPassword {
-		c.JSON(http.StatusForbidden, gin.H{"error": "passkeys are only available for password users"})
-		return
-	}
 	if !ensurePasskeyLoginEnabled(c) {
 		return
 	}
 
 	var req struct {
 		Name            string `json:"name"`
-		CurrentPassword string `json:"current_password" binding:"required"`
+		CurrentPassword string `json:"current_password"`
 		MFACode         string `json:"mfa_code"`
+		EmailCode       string `json:"email_code"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
-	if !model.CheckPassword(user.Password, req.CurrentPassword) {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "current password is incorrect"})
-		return
-	}
-	if user.MFAEnabled && !mfa.Verify(string(user.MFASecret), req.MFACode) {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid mfa code"})
-		return
+	switch {
+	case user.Provider == "" || user.Provider == model.AuthProviderPassword:
+		if !model.CheckPassword(user.Password, req.CurrentPassword) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "current password is incorrect"})
+			return
+		}
+		// password users with MFA also verify MFA code
+		if user.MFAEnabled && !mfa.Verify(string(user.MFASecret), req.MFACode) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid mfa code"})
+			return
+		}
+	case user.MFAEnabled:
+		if !mfa.Verify(string(user.MFASecret), req.MFACode) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid mfa code"})
+			return
+		}
+	default:
+		if !verifyEmailCode(c, user.Email, req.EmailCode) {
+			lang := i18n.FromContext(c)
+			c.JSON(http.StatusBadRequest, gin.H{"error": i18n.T(lang, "email_verification_code_invalid")})
+			return
+		}
 	}
 
 	creation, err := passkey.BeginRegistration(c, user, req.Name)
@@ -345,10 +348,6 @@ func BeginCurrentUserPasskeyRegistration(c *gin.Context) {
 
 func FinishCurrentUserPasskeyRegistration(c *gin.Context) {
 	user := c.MustGet("user").(model.User)
-	if user.Provider != "" && user.Provider != model.AuthProviderPassword {
-		c.JSON(http.StatusForbidden, gin.H{"error": "passkeys are only available for password users"})
-		return
-	}
 	if !ensurePasskeyLoginEnabled(c) {
 		return
 	}
@@ -363,10 +362,6 @@ func FinishCurrentUserPasskeyRegistration(c *gin.Context) {
 
 func DeleteCurrentUserPasskey(c *gin.Context) {
 	user := c.MustGet("user").(model.User)
-	if user.Provider != "" && user.Provider != model.AuthProviderPassword {
-		c.JSON(http.StatusForbidden, gin.H{"error": "passkeys are only available for password users"})
-		return
-	}
 	if !ensurePasskeyLoginEnabled(c) {
 		return
 	}
@@ -408,6 +403,94 @@ func ensureMFAEnabled(c *gin.Context) bool {
 		return false
 	}
 	return true
+}
+
+func verifyEmailCode(c *gin.Context, emailAddr, code string) bool {
+	if emailAddr == "" || code == "" {
+		return false
+	}
+	lang := i18n.FromContext(c)
+	return email.GetCodeManager().Verify(emailAddr, code, lang) == nil
+}
+
+// SendEmailVerificationCode sends a verification code to the current user's email.
+// Used as step-up verification for OAuth/LDAP users before MFA/Passkey operations,
+// and for password users to verify a new email address before changing it.
+func SendEmailVerificationCode(c *gin.Context) {
+	user := c.MustGet("user").(model.User)
+	lang := i18n.FromContext(c)
+
+	if !email.IsSMTPEnabled() {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": i18n.T(lang, "email_service_not_configured")})
+		return
+	}
+
+	var req struct {
+		Email string `json:"email"`
+	}
+	_ = c.ShouldBindJSON(&req)
+
+	targetEmail := strings.TrimSpace(req.Email)
+	if targetEmail == "" {
+		targetEmail = strings.TrimSpace(user.Email)
+	}
+	if targetEmail == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": i18n.T(lang, "no_email_associated")})
+		return
+	}
+
+	code, err := email.GetCodeManager().GenerateAndStore(targetEmail, lang)
+	if err != nil {
+		c.JSON(http.StatusTooManyRequests, gin.H{"error": err.Error()})
+		return
+	}
+
+	if err := email.SendVerificationCode(targetEmail, code, lang); err != nil {
+		klog.Errorf("failed to send verification code to %s: %v", targetEmail, err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": i18n.T(lang, "failed_to_send_verification_email")})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"success": true})
+}
+
+// SetCurrentUserEmail sets or updates the email for the current password user.
+// Requires current password verification and email verification code to verify
+// ownership of the new email address.
+func SetCurrentUserEmail(c *gin.Context) {
+	user := c.MustGet("user").(model.User)
+	lang := i18n.FromContext(c)
+	if user.Provider != "" && user.Provider != model.AuthProviderPassword {
+		c.JSON(http.StatusForbidden, gin.H{"error": i18n.T(lang, "email_can_only_set_for_password")})
+		return
+	}
+
+	var req struct {
+		CurrentPassword string `json:"current_password" binding:"required"`
+		Email           string `json:"email" binding:"required"`
+		EmailCode       string `json:"email_code" binding:"required"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	if !model.CheckPassword(user.Password, req.CurrentPassword) {
+		c.JSON(http.StatusBadRequest, gin.H{"error": i18n.T(lang, "current_password_incorrect")})
+		return
+	}
+
+	emailAddr := strings.TrimSpace(req.Email)
+	if err := email.GetCodeManager().Verify(emailAddr, req.EmailCode, lang); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	if err := model.UpdateUserEmail(user.ID, emailAddr); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": i18n.T(lang, "failed_to_update_email")})
+		return
+	}
+	user.Email = emailAddr
+	c.JSON(http.StatusOK, user)
 }
 
 func DeleteUser(c *gin.Context) {

--- a/routes.go
+++ b/routes.go
@@ -36,6 +36,17 @@ func setupAPIRouter(r *gin.RouterGroup, cm *cluster.ClusterManager) {
 	r.GET("/api/v1/bootstrap", authHandler.Bootstrap)
 	r.GET("/api/v1/connector/connect", cm.ConnectConnector)
 	r.GET("/api/v1/connector/manifest", cm.GetConnectorManifest)
+
+	// K8s API reverse proxy — auth via API key or JWT, identified by cluster UUID
+	r.GET("/api/v1/clusters/:clusterUUID/k8s-proxy/*path", authHandler.RequireAuth(), cm.HandleK8sProxy)
+	r.POST("/api/v1/clusters/:clusterUUID/k8s-proxy/*path", authHandler.RequireAuth(), cm.HandleK8sProxy)
+	r.PUT("/api/v1/clusters/:clusterUUID/k8s-proxy/*path", authHandler.RequireAuth(), cm.HandleK8sProxy)
+	r.PATCH("/api/v1/clusters/:clusterUUID/k8s-proxy/*path", authHandler.RequireAuth(), cm.HandleK8sProxy)
+	r.DELETE("/api/v1/clusters/:clusterUUID/k8s-proxy/*path", authHandler.RequireAuth(), cm.HandleK8sProxy)
+
+	// Kubeconfig download — any authenticated user
+	r.GET("/api/v1/kubeconfig", authHandler.RequireAuth(), cm.DownloadKubeconfig)
+
 	registerAuthRoutes(r, authHandler)
 	registerUserRoutes(r, authHandler)
 	registerAdminRoutes(r, authHandler, cm, helmChartsHandler)

--- a/routes.go
+++ b/routes.go
@@ -82,6 +82,8 @@ func registerUserRoutes(r *gin.RouterGroup, authHandler *auth.AuthHandler) {
 	userGroup := r.Group("/api/users")
 	userGroup.PUT("/me", authHandler.RequireAuth(), users.UpdateCurrentUser)
 	userGroup.POST("/me/password", authHandler.RequireAuth(), users.ChangeCurrentUserPassword)
+	userGroup.POST("/me/email", authHandler.RequireAuth(), users.SetCurrentUserEmail)
+	userGroup.POST("/me/email/send-code", authHandler.RequireAuth(), users.SendEmailVerificationCode)
 	userGroup.POST("/me/mfa/setup", authHandler.RequireAuth(), users.SetupCurrentUserMFA)
 	userGroup.POST("/me/mfa/enable", authHandler.RequireAuth(), users.EnableCurrentUserMFA)
 	userGroup.POST("/me/mfa/disable", authHandler.RequireAuth(), users.DisableCurrentUserMFA)
@@ -143,6 +145,11 @@ func registerAdminRoutes(r *gin.RouterGroup, authHandler *auth.AuthHandler, cm *
 	generalSettingAPI := adminAPI.Group("/general-setting")
 	generalSettingAPI.GET("/", settings.HandleGetGeneralSetting)
 	generalSettingAPI.PUT("/", settings.HandleUpdateGeneralSetting)
+
+	smtpSettingAPI := adminAPI.Group("/smtp-setting")
+	smtpSettingAPI.GET("/", settings.HandleGetSMTPSetting)
+	smtpSettingAPI.PUT("/", settings.HandleUpdateSMTPSetting)
+	smtpSettingAPI.POST("/test", settings.HandleSendTestEmail)
 
 	templateAPI := adminAPI.Group("/templates")
 	templateAPI.POST("/", templates.CreateTemplate)

--- a/routes.go
+++ b/routes.go
@@ -141,6 +141,7 @@ func registerAdminRoutes(r *gin.RouterGroup, authHandler *auth.AuthHandler, cm *
 	apiKeyAPI.GET("/", apikeys.ListAPIKeys)
 	apiKeyAPI.POST("/", apikeys.CreateAPIKey)
 	apiKeyAPI.DELETE("/:id", apikeys.DeleteAPIKey)
+	apiKeyAPI.GET("/independent", apikeys.ListIndependentAPIKeys)
 
 	generalSettingAPI := adminAPI.Group("/general-setting")
 	generalSettingAPI.GET("/", settings.HandleGetGeneralSetting)

--- a/ui/src/components/account-settings-dialog.tsx
+++ b/ui/src/components/account-settings-dialog.tsx
@@ -12,6 +12,8 @@ import {
   enableCurrentUserMFA,
   finishCurrentUserPasskeyRegistration,
   listCurrentUserPasskeys,
+  sendEmailVerificationCode,
+  setUserEmail,
   setupCurrentUserMFA,
   updateCurrentUser,
   type MFASetupResponse,
@@ -58,12 +60,20 @@ export function AccountSettingsDialog({
   >(null)
   const [securityCurrentPassword, setSecurityCurrentPassword] = useState('')
   const [securityMFACode, setSecurityMFACode] = useState('')
+  const [securityEmailCode, setSecurityEmailCode] = useState('')
   const [securityPasswordError, setSecurityPasswordError] = useState('')
   const [profileError, setProfileError] = useState('')
+  const [emailInput, setEmailInput] = useState('')
+  const [profileSaveDialogOpen, setProfileSaveDialogOpen] = useState(false)
+  const [profileSavePassword, setProfileSavePassword] = useState('')
+  const [profileSaveEmailCode, setProfileSaveEmailCode] = useState('')
+  const [profileSaveError, setProfileSaveError] = useState('')
+  const [savingProfile, setSavingProfile] = useState(false)
+  const [sendCodeCooldown, setSendCodeCooldown] = useState(0)
+  const [sendingCode, setSendingCode] = useState(false)
   const [passwordError, setPasswordError] = useState('')
   const [mfaError, setMFAError] = useState('')
   const [passkeyError, setPasskeyError] = useState('')
-  const [savingProfile, setSavingProfile] = useState(false)
   const [savingPassword, setSavingPassword] = useState(false)
   const [savingMFA, setSavingMFA] = useState(false)
   const [savingPasskey, setSavingPasskey] = useState(false)
@@ -73,11 +83,13 @@ export function AccountSettingsDialog({
       setPasswordConfirmAction(null)
       setSecurityCurrentPassword('')
       setSecurityMFACode('')
+      setSecurityEmailCode('')
       setSecurityPasswordError('')
       return
     }
 
     setNickname(user?.name || '')
+    setEmailInput(user?.email || '')
     setCurrentPassword('')
     setNewPassword('')
     setConfirmPassword('')
@@ -88,8 +100,15 @@ export function AccountSettingsDialog({
     setPasswordConfirmAction(null)
     setSecurityCurrentPassword('')
     setSecurityMFACode('')
+    setSecurityEmailCode('')
     setSecurityPasswordError('')
     setProfileError('')
+    setEmailInput('')
+    setProfileSaveDialogOpen(false)
+    setProfileSavePassword('')
+    setProfileSaveEmailCode('')
+    setProfileSaveError('')
+    setSendCodeCooldown(0)
     setPasswordError('')
     setMFAError('')
     setPasskeyError('')
@@ -116,30 +135,91 @@ export function AccountSettingsDialog({
     return () => {
       cancelled = true
     }
-  }, [open, passkeyLoginEnabled, user?.name, t])
+  }, [open, passkeyLoginEnabled, user?.name, user?.email, t])
+
+  useEffect(() => {
+    if (sendCodeCooldown <= 0) return
+    const timer = setTimeout(() => setSendCodeCooldown((prev) => prev - 1), 1000)
+    return () => clearTimeout(timer)
+  }, [sendCodeCooldown])
 
   if (!user) return null
 
   const isPasswordUser = !user.provider || user.provider === 'password'
-  if (!isPasswordUser) return null
 
   const mfaControlsDisabled = !mfaEnabled || savingMFA
   const passkeyControlsDisabled = !passkeyLoginEnabled || savingPasskey
 
   const handleUpdateProfile = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault()
-    setSavingProfile(true)
     setProfileError('')
 
+    const trimmedNickname = nickname.trim()
+    const trimmedEmail = emailInput.trim()
+    const emailChanged = trimmedEmail !== (user.email || '')
+
+    if (!emailChanged) {
+      setSavingProfile(true)
+      try {
+        await updateCurrentUser({ name: trimmedNickname })
+        await checkAuth()
+        toast.success(t('accountSettings.profile.saved', 'Account updated'))
+      } catch (error) {
+        setProfileError(
+          error instanceof Error
+            ? error.message
+            : t('accountSettings.profile.error', 'Failed to update account')
+        )
+      } finally {
+        setSavingProfile(false)
+      }
+      return
+    }
+
+    setProfileSavePassword('')
+    setProfileSaveEmailCode('')
+    setProfileSaveError('')
+    setSendCodeCooldown(0)
+    setProfileSaveDialogOpen(true)
+  }
+
+  const handleSendProfileCode = async () => {
+    setSendingCode(true)
+    setProfileSaveError('')
     try {
-      await updateCurrentUser({ name: nickname.trim() })
-      await checkAuth()
-      toast.success(t('accountSettings.profile.saved', 'Account updated'))
+      await sendEmailVerificationCode(emailInput.trim())
+      toast.success(t('accountSettings.security.verificationCodeSent', 'Verification code sent'))
+      setSendCodeCooldown(60)
     } catch (error) {
-      setProfileError(
+      setProfileSaveError(
         error instanceof Error
           ? error.message
-          : t('accountSettings.profile.error', 'Failed to update account')
+          : t('accountSettings.security.sendCodeError', 'Failed to send verification code')
+      )
+    } finally {
+      setSendingCode(false)
+    }
+  }
+
+  const handleConfirmSaveProfile = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    setProfileSaveError('')
+    setSavingProfile(true)
+    try {
+      await setUserEmail(
+        profileSavePassword,
+        emailInput.trim(),
+        profileSaveEmailCode
+      )
+      await updateCurrentUser({ name: nickname.trim() })
+      await checkAuth()
+      setProfileSaveDialogOpen(false)
+      toast.success(t('accountSettings.profile.emailSaved', 'Email updated'))
+    } catch (error) {
+      setProfileSaveError(
+        error instanceof Error
+          ? error.message
+          : t('accountSettings.profile.emailError', 'Failed to update email')
       )
     } finally {
       setSavingProfile(false)
@@ -228,6 +308,7 @@ export function AccountSettingsDialog({
     setPasswordConfirmAction(action)
     setSecurityCurrentPassword('')
     setSecurityMFACode('')
+    setSecurityEmailCode('')
     setSecurityPasswordError('')
     if (action === 'mfa') {
       setMFAError('')
@@ -236,10 +317,29 @@ export function AccountSettingsDialog({
     }
   }
 
+  const handleSendVerificationCode = async () => {
+    try {
+      await sendEmailVerificationCode()
+      toast.success(
+        t('accountSettings.security.verificationCodeSent', 'Verification code sent')
+      )
+    } catch (error) {
+      setSecurityPasswordError(
+        error instanceof Error
+          ? error.message
+          : t(
+              'accountSettings.security.sendCodeError',
+              'Failed to send verification code'
+            )
+      )
+    }
+  }
+
   const closePasswordConfirm = () => {
     setPasswordConfirmAction(null)
     setSecurityCurrentPassword('')
     setSecurityMFACode('')
+    setSecurityEmailCode('')
     setSecurityPasswordError('')
   }
 
@@ -254,7 +354,12 @@ export function AccountSettingsDialog({
     if (passwordConfirmAction === 'mfa') {
       setSavingMFA(true)
       try {
-        setMFASetup(await setupCurrentUserMFA(securityCurrentPassword))
+        setMFASetup(
+          await setupCurrentUserMFA(
+            isPasswordUser ? securityCurrentPassword : undefined,
+            isPasswordUser ? undefined : (securityEmailCode || undefined)
+          )
+        )
         setMFACode('')
         closePasswordConfirm()
       } catch (error) {
@@ -277,8 +382,11 @@ export function AccountSettingsDialog({
     try {
       const options = await beginCurrentUserPasskeyRegistration(
         passkeyName,
-        securityCurrentPassword,
-        user.mfa_enabled ? securityMFACode : undefined
+        isPasswordUser ? securityCurrentPassword : undefined,
+        user.mfa_enabled ? securityMFACode : undefined,
+        !isPasswordUser && !user.mfa_enabled
+          ? securityEmailCode
+          : undefined
       )
       beganRegistration = true
       closePasswordConfirm()
@@ -345,48 +453,103 @@ export function AccountSettingsDialog({
           </DialogHeader>
 
           <Tabs defaultValue="profile" className="gap-4">
-            <TabsList className="grid w-full grid-cols-3">
+            <TabsList
+              className={`grid w-full ${isPasswordUser ? 'grid-cols-3' : 'grid-cols-2'}`}
+            >
               <TabsTrigger value="profile">
                 {t('accountSettings.tabs.profile', 'Profile')}
               </TabsTrigger>
-              <TabsTrigger value="password">
-                {t('accountSettings.tabs.password', 'Password')}
-              </TabsTrigger>
+              {isPasswordUser && (
+                <TabsTrigger value="password">
+                  {t('accountSettings.tabs.password', 'Password')}
+                </TabsTrigger>
+              )}
               <TabsTrigger value="security">
                 {t('accountSettings.tabs.security', 'Security')}
               </TabsTrigger>
             </TabsList>
 
             <TabsContent value="profile">
-              <form onSubmit={handleUpdateProfile} className="space-y-4">
-                <div className="space-y-2">
-                  <Label htmlFor="account-nickname">
-                    {t('accountSettings.profile.nickname', 'Nickname')}
-                  </Label>
-                  <Input
-                    id="account-nickname"
-                    autoComplete="name"
-                    value={nickname}
-                    onChange={(event) => setNickname(event.target.value)}
-                  />
-                </div>
-                {profileError && (
-                  <Alert variant="destructive">
-                    <AlertDescription>{profileError}</AlertDescription>
-                  </Alert>
-                )}
-                <div className="flex justify-end">
+              {isPasswordUser ? (
+                <form onSubmit={handleUpdateProfile} className="space-y-4">
+                  <div className="space-y-2">
+                    <Label htmlFor="account-nickname">
+                      {t('accountSettings.profile.nickname', 'Nickname')}
+                    </Label>
+                    <Input
+                      id="account-nickname"
+                      autoComplete="name"
+                      value={nickname}
+                      onChange={(event) => setNickname(event.target.value)}
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="account-email">
+                      {t('accountSettings.profile.email', 'Email')}
+                    </Label>
+                    <Input
+                      id="account-email"
+                      type="email"
+                      autoComplete="email"
+                      value={emailInput}
+                      onChange={(event) => setEmailInput(event.target.value)}
+                    />
+                  </div>
+                  {profileError && (
+                    <Alert variant="destructive">
+                      <AlertDescription>{profileError}</AlertDescription>
+                    </Alert>
+                  )}
                   <Button type="submit" disabled={savingProfile}>
                     {savingProfile
                       ? t('common.actions.saving', 'Saving...')
                       : t('accountSettings.profile.saveButton', 'Save Profile')}
                   </Button>
+                </form>
+              ) : (
+                <div className="space-y-4">
+                  <div className="space-y-2">
+                    <Label htmlFor="account-nickname">
+                      {t('accountSettings.profile.nickname', 'Nickname')}
+                    </Label>
+                    <Input
+                      id="account-nickname"
+                      value={user.name || ''}
+                      placeholder={t(
+                        'accountSettings.profile.notProvidedByProvider',
+                        'Not provided by identity provider'
+                      )}
+                      disabled
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="account-email">
+                      {t('accountSettings.profile.email', 'Email')}
+                    </Label>
+                    <Input
+                      id="account-email"
+                      type="email"
+                      value={user.email || ''}
+                      placeholder={t(
+                        'accountSettings.profile.notProvidedByProvider',
+                        'Not provided by identity provider'
+                      )}
+                      disabled
+                    />
+                  </div>
+                  <p className="pt-2 text-xs text-muted-foreground">
+                    {t(
+                      'accountSettings.profile.managedByProvider',
+                      'This information is managed by your identity provider'
+                    )}
+                  </p>
                 </div>
-              </form>
+              )}
             </TabsContent>
 
-            <TabsContent value="password">
-              <form onSubmit={handleChangePassword} className="space-y-4">
+            {isPasswordUser && (
+              <TabsContent value="password">
+                <form onSubmit={handleChangePassword} className="space-y-4">
                 <div className="flex items-center gap-2 text-sm font-medium">
                   <KeyRound className="h-4 w-4" />
                   <span>{t('common.fields.password', 'Password')}</span>
@@ -453,6 +616,7 @@ export function AccountSettingsDialog({
                 </div>
               </form>
             </TabsContent>
+            )}
 
             <TabsContent value="security">
               <div className="space-y-6">
@@ -694,6 +858,102 @@ export function AccountSettingsDialog({
         </DialogContent>
       </Dialog>
       <Dialog
+        open={profileSaveDialogOpen}
+        onOpenChange={(nextOpen) => {
+          if (!nextOpen && !savingProfile) {
+            setProfileSaveDialogOpen(false)
+          }
+        }}
+      >
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>
+              {t(
+                'accountSettings.profile.verifyEmailTitle',
+                'Verify Email Change'
+              )}
+            </DialogTitle>
+            <DialogDescription>
+              {t(
+                'accountSettings.profile.verifyEmailDescription',
+                'Enter your current password and the verification code sent to your new email to save changes.'
+              )}
+            </DialogDescription>
+          </DialogHeader>
+          <form onSubmit={handleConfirmSaveProfile} className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="profile-save-password">
+                {t(
+                  'accountSettings.password.currentPassword',
+                  'Current Password'
+                )}
+              </Label>
+              <Input
+                id="profile-save-password"
+                type="password"
+                autoComplete="current-password"
+                required
+                value={profileSavePassword}
+                onChange={(event) => setProfileSavePassword(event.target.value)}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="profile-save-email-code">
+                {t('accountSettings.security.emailCode', 'Email Verification Code')}
+              </Label>
+              <div className="flex gap-2">
+                <Input
+                  id="profile-save-email-code"
+                  autoComplete="one-time-code"
+                  inputMode="numeric"
+                  required
+                  value={profileSaveEmailCode}
+                  onChange={(event) => setProfileSaveEmailCode(event.target.value)}
+                />
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  disabled={sendingCode || sendCodeCooldown > 0}
+                  onClick={handleSendProfileCode}
+                >
+                  {sendCodeCooldown > 0
+                    ? t('accountSettings.security.resendIn', 'Resend in {{seconds}}s', { seconds: sendCodeCooldown })
+                    : t('accountSettings.security.sendCode', 'Send Code')}
+                </Button>
+              </div>
+              <p className="text-xs text-muted-foreground">
+                {t(
+                  'accountSettings.profile.codeSentTo',
+                  'Verification code will be sent to: {{email}}',
+                  { email: emailInput.trim() }
+                )}
+              </p>
+            </div>
+            {profileSaveError && (
+              <Alert variant="destructive">
+                <AlertDescription>{profileSaveError}</AlertDescription>
+              </Alert>
+            )}
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="outline"
+                disabled={savingProfile}
+                onClick={() => setProfileSaveDialogOpen(false)}
+              >
+                {t('common.actions.cancel', 'Cancel')}
+              </Button>
+              <Button type="submit" disabled={savingProfile}>
+                {savingProfile
+                  ? t('common.actions.saving', 'Saving...')
+                  : t('common.actions.save', 'Save')}
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+      <Dialog
         open={passwordConfirmAction !== null}
         onOpenChange={(nextOpen) => {
           if (!nextOpen && !passwordConfirmLoading) {
@@ -704,53 +964,110 @@ export function AccountSettingsDialog({
         <DialogContent className="sm:max-w-md">
           <DialogHeader>
             <DialogTitle>
-              {t(
-                'accountSettings.security.confirmPassword.title',
-                'Confirm password'
-              )}
+              {isPasswordUser
+                ? t(
+                    'accountSettings.security.confirmPassword.title',
+                    'Confirm password'
+                  )
+                : user.mfa_enabled
+                  ? t(
+                      'accountSettings.security.confirmMFA.title',
+                      'Confirm with MFA'
+                    )
+                  : t(
+                      'accountSettings.security.confirmEmail.title',
+                      'Confirm with email'
+                    )}
             </DialogTitle>
             <DialogDescription>
-              {t(
-                'accountSettings.security.confirmPassword.description',
-                'Enter your current password to continue.'
-              )}
+              {isPasswordUser
+                ? t(
+                    'accountSettings.security.confirmPassword.description',
+                    'Enter your current password to continue.'
+                  )
+                : user.mfa_enabled
+                  ? t(
+                      'accountSettings.security.confirmMFA.description',
+                      'Enter your authentication code to continue.'
+                    )
+                  : t(
+                      'accountSettings.security.confirmEmail.description',
+                      'Enter the verification code sent to your email to continue.'
+                    )}
             </DialogDescription>
           </DialogHeader>
           <form onSubmit={handleConfirmCurrentPassword} className="space-y-4">
-            <div className="space-y-2">
-              <Label htmlFor="account-security-current-password">
-                {t(
-                  'accountSettings.password.currentPassword',
-                  'Current Password'
-                )}
-              </Label>
-              <Input
-                id="account-security-current-password"
-                autoComplete="current-password"
-                type="password"
-                required
-                value={securityCurrentPassword}
-                onChange={(event) =>
-                  setSecurityCurrentPassword(event.target.value)
-                }
-              />
-            </div>
-            {passwordConfirmAction === 'passkey' && user.mfa_enabled && (
+            {isPasswordUser && (
               <div className="space-y-2">
-                <Label htmlFor="account-security-mfa-code">
+                <Label htmlFor="account-security-current-password">
                   {t(
-                    'accountSettings.security.mfa.authCode',
-                    'Authentication Code'
+                    'accountSettings.password.currentPassword',
+                    'Current Password'
                   )}
                 </Label>
                 <Input
-                  id="account-security-mfa-code"
-                  autoComplete="one-time-code"
-                  inputMode="numeric"
+                  id="account-security-current-password"
+                  autoComplete="current-password"
+                  type="password"
                   required
-                  value={securityMFACode}
-                  onChange={(event) => setSecurityMFACode(event.target.value)}
+                  value={securityCurrentPassword}
+                  onChange={(event) =>
+                    setSecurityCurrentPassword(event.target.value)
+                  }
                 />
+              </div>
+            )}
+            {passwordConfirmAction === 'passkey' &&
+              user.mfa_enabled &&
+              isPasswordUser && (
+                <div className="space-y-2">
+                  <Label htmlFor="account-security-mfa-code">
+                    {t(
+                      'accountSettings.security.mfa.authCode',
+                      'Authentication Code'
+                    )}
+                  </Label>
+                  <Input
+                    id="account-security-mfa-code"
+                    autoComplete="one-time-code"
+                    inputMode="numeric"
+                    required
+                    value={securityMFACode}
+                    onChange={(event) => setSecurityMFACode(event.target.value)}
+                  />
+                </div>
+              )}
+            {!isPasswordUser && !user.mfa_enabled && (
+              <div className="space-y-2">
+                <Label htmlFor="account-security-email-code">
+                  {t(
+                    'accountSettings.security.emailCode',
+                    'Email Verification Code'
+                  )}
+                </Label>
+                <div className="flex gap-2">
+                  <Input
+                    id="account-security-email-code"
+                    autoComplete="one-time-code"
+                    inputMode="numeric"
+                    required
+                    value={securityEmailCode}
+                    onChange={(event) =>
+                      setSecurityEmailCode(event.target.value)
+                    }
+                  />
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={handleSendVerificationCode}
+                  >
+                    {t(
+                      'accountSettings.security.sendCode',
+                      'Send Code'
+                    )}
+                  </Button>
+                </div>
               </div>
             )}
             {securityPasswordError && (

--- a/ui/src/components/action-table.tsx
+++ b/ui/src/components/action-table.tsx
@@ -34,6 +34,7 @@ export interface Action<T> {
   dynamicLabel?: (item: T) => string | React.ReactNode
   onClick: (item: T) => void
   shouldDisable?: (item: T) => boolean
+  hidden?: (item: T) => boolean
 }
 
 export function ActionTable<T>({
@@ -60,18 +61,20 @@ export function ActionTable<T>({
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end">
-                {actions.map((action, index) => (
-                  <DropdownMenuItem
-                    key={index}
-                    disabled={action.shouldDisable?.(row.original)}
-                    onClick={() => action.onClick(row.original)}
-                    className="gap-2"
-                  >
-                    {action.dynamicLabel
-                      ? action.dynamicLabel(row.original)
-                      : action.label}
-                  </DropdownMenuItem>
-                ))}
+                {actions
+                  .filter((action) => !action.hidden?.(row.original))
+                  .map((action, index) => (
+                    <DropdownMenuItem
+                      key={index}
+                      disabled={action.shouldDisable?.(row.original)}
+                      onClick={() => action.onClick(row.original)}
+                      className="gap-2"
+                    >
+                      {action.dynamicLabel
+                        ? action.dynamicLabel(row.original)
+                        : action.label}
+                    </DropdownMenuItem>
+                  ))}
               </DropdownMenuContent>
             </DropdownMenu>
           </div>

--- a/ui/src/components/delete-confirmation-dialog.tsx
+++ b/ui/src/components/delete-confirmation-dialog.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { AlertTriangle } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 
@@ -43,10 +43,21 @@ export function DeleteConfirmationDialog({
   const [forceDelete, setForceDelete] = useState(false)
   const [wait, setWait] = useState(true)
 
+  // Reset all internal state whenever the dialog opens / closes or when the
+  // target resource changes. This prevents a stale confirmation value from
+  // leaking across invocations (e.g. delete cluster A, then immediately open
+  // the dialog for cluster B).
+  useEffect(() => {
+    setConfirmationInput('')
+    setForceDelete(false)
+    setWait(true)
+  }, [open, resourceName])
+
   const handleDialogChange = (open: boolean) => {
     if (!open) {
       setConfirmationInput('')
       setForceDelete(false)
+      setWait(true)
     }
     onOpenChange(open)
   }

--- a/ui/src/components/kubeconfig-download-dialog.tsx
+++ b/ui/src/components/kubeconfig-download-dialog.tsx
@@ -1,0 +1,198 @@
+import { useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { toast } from 'sonner'
+
+import { apiClient } from '@/lib/api-client'
+import { useCluster } from '@/hooks/use-cluster'
+import { Button } from '@/components/ui/button'
+import { Checkbox } from '@/components/ui/checkbox'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+
+interface KubeconfigDownloadDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+export function KubeconfigDownloadDialog({
+  open,
+  onOpenChange,
+}: KubeconfigDownloadDialogProps) {
+  const { t } = useTranslation()
+  const { clusters, currentCluster } = useCluster()
+  const [selected, setSelected] = useState<Set<string>>(new Set())
+  const [downloading, setDownloading] = useState(false)
+  const [showAll, setShowAll] = useState(false)
+
+  // Reset state when dialog closes; default-select current cluster on open.
+  useEffect(() => {
+    if (!open) {
+      setSelected(new Set())
+      setShowAll(false)
+    } else if (currentCluster) {
+      const current = clusters.find((c) => c.name === currentCluster)
+      if (current?.uuid) {
+        setSelected(new Set([current.uuid]))
+      }
+    }
+  }, [open, currentCluster, clusters])
+
+  const clustersWithUuid = clusters.filter((c) => c.uuid)
+  const visibleClusters =
+    showAll || clustersWithUuid.length <= 8
+      ? clustersWithUuid
+      : clustersWithUuid.slice(0, 8)
+
+  const handleToggle = (uuid: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev)
+      if (next.has(uuid)) {
+        next.delete(uuid)
+      } else {
+        next.add(uuid)
+      }
+      return next
+    })
+  }
+
+  const handleSelectAll = () => {
+    if (selected.size === clustersWithUuid.length) {
+      setSelected(new Set())
+    } else {
+      setSelected(new Set(clustersWithUuid.map((c) => c.uuid!)))
+    }
+  }
+
+  const handleDownload = async () => {
+    if (selected.size === 0) return
+    setDownloading(true)
+    try {
+      const uuids = Array.from(selected).join(',')
+      const response = await apiClient.request(
+        `/kubeconfig?clusters=${encodeURIComponent(uuids)}`
+      )
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}))
+        throw new Error(errorData.error || 'Download failed')
+      }
+      const text = await response.text()
+      const blob = new Blob([text], { type: 'text/yaml' })
+      const url = URL.createObjectURL(blob)
+      const a = document.createElement('a')
+      a.href = url
+      a.download = 'kubeconfig'
+      document.body.appendChild(a)
+      a.click()
+      document.body.removeChild(a)
+      URL.revokeObjectURL(url)
+      toast.success(
+        t('clusterManagement.kubeconfig.downloaded', 'Kubeconfig downloaded')
+      )
+      onOpenChange(false)
+    } catch (err) {
+      toast.error(
+        err instanceof Error
+          ? err.message
+          : t('clusterManagement.kubeconfig.downloadError', 'Download failed')
+      )
+    } finally {
+      setDownloading(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[480px]">
+        <DialogHeader>
+          <DialogTitle>
+            {t('clusterManagement.kubeconfig.title', 'Download Kubeconfig')}
+          </DialogTitle>
+          <DialogDescription>
+            {t(
+              'clusterManagement.kubeconfig.description',
+              'Generate a kubeconfig that uses Kite as a proxy to access the cluster.'
+            )}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-3">
+          <div className="flex items-center justify-between">
+            <span className="text-sm font-medium">
+              {t('clusterManagement.kubeconfig.clusters', 'Clusters')}
+            </span>
+            {clustersWithUuid.length > 0 && (
+              <Button variant="ghost" size="sm" onClick={handleSelectAll}>
+                {selected.size === clustersWithUuid.length
+                  ? t('resourceTable.deselectAll', 'Deselect All')
+                  : t('resourceTable.selectAll', 'Select All ({{count}})', {
+                      count: clustersWithUuid.length,
+                    })}
+              </Button>
+            )}
+          </div>
+          <div className="h-[240px] overflow-y-auto rounded-md border p-2">
+            <div className="space-y-1">
+              {visibleClusters.map((cluster) => (
+                <label
+                  key={cluster.uuid}
+                  className="flex cursor-pointer items-center gap-3 rounded-md px-2 py-1.5 hover:bg-accent"
+                >
+                  <Checkbox
+                    checked={selected.has(cluster.uuid!)}
+                    onCheckedChange={() => handleToggle(cluster.uuid!)}
+                  />
+                  <span className="text-sm">{cluster.name}</span>
+                  {cluster.name === currentCluster && (
+                    <span className="text-xs text-muted-foreground">
+                      (current)
+                    </span>
+                  )}
+                </label>
+              ))}
+              {clustersWithUuid.length > 8 && !showAll && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="w-full"
+                  onClick={() => setShowAll(true)}
+                >
+                  {t(
+                    'clusterManagement.kubeconfig.showAll',
+                    'Show all ({{count}})',
+                    {
+                      count: clustersWithUuid.length,
+                    }
+                  )}
+                </Button>
+              )}
+            </div>
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={downloading}
+          >
+            {t('common.actions.cancel', 'Cancel')}
+          </Button>
+          <Button
+            onClick={handleDownload}
+            disabled={selected.size === 0 || downloading}
+          >
+            {downloading
+              ? t('common.actions.downloading', 'Downloading...')
+              : t('common.actions.download', 'Download')}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/ui/src/components/kubeconfig-download-dialog.tsx
+++ b/ui/src/components/kubeconfig-download-dialog.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
 
@@ -32,7 +32,6 @@ export function KubeconfigDownloadDialog({
   const [selected, setSelected] = useState<Set<string>>(new Set())
   const [downloading, setDownloading] = useState(false)
   const [visibleCount, setVisibleCount] = useState(INITIAL_BATCH)
-  const scrollRef = useRef<HTMLDivElement>(null)
 
   const clustersWithUuid = clusters.filter((c) => c.uuid)
   const hasMore = visibleCount < clustersWithUuid.length
@@ -50,14 +49,6 @@ export function KubeconfigDownloadDialog({
       }
     }
   }, [open, currentCluster, clusters])
-
-  const handleScroll = useCallback(() => {
-    const el = scrollRef.current
-    if (!el || !hasMore) return
-    if (el.scrollTop + el.clientHeight >= el.scrollHeight - 20) {
-      setVisibleCount((prev) => Math.min(prev + LOAD_MORE_BATCH, clustersWithUuid.length))
-    }
-  }, [hasMore, clustersWithUuid.length])
 
   const handleToggle = (uuid: string) => {
     setSelected((prev) => {
@@ -146,11 +137,7 @@ export function KubeconfigDownloadDialog({
               </Button>
             )}
           </div>
-          <div
-            ref={scrollRef}
-            onScroll={handleScroll}
-            className="h-[240px] overflow-y-auto rounded-md border p-2"
-          >
+          <div className="h-[240px] overflow-y-auto rounded-md border p-2">
             <div className="space-y-1">
               {visibleClusters.map((cluster) => (
                 <label
@@ -170,6 +157,20 @@ export function KubeconfigDownloadDialog({
                 </label>
               ))}
             </div>
+            {hasMore && (
+              <Button
+                variant="ghost"
+                size="sm"
+                className="mt-1 w-full"
+                onClick={() =>
+                  setVisibleCount((prev) =>
+                    Math.min(prev + LOAD_MORE_BATCH, clustersWithUuid.length)
+                  )
+                }
+              >
+                {t('common.actions.showMore', 'Show more')}
+              </Button>
+            )}
           </div>
         </div>
 

--- a/ui/src/components/kubeconfig-download-dialog.tsx
+++ b/ui/src/components/kubeconfig-download-dialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
 
@@ -15,6 +15,9 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog'
 
+const INITIAL_BATCH = 6
+const LOAD_MORE_BATCH = 6
+
 interface KubeconfigDownloadDialogProps {
   open: boolean
   onOpenChange: (open: boolean) => void
@@ -28,13 +31,18 @@ export function KubeconfigDownloadDialog({
   const { clusters, currentCluster } = useCluster()
   const [selected, setSelected] = useState<Set<string>>(new Set())
   const [downloading, setDownloading] = useState(false)
-  const [showAll, setShowAll] = useState(false)
+  const [visibleCount, setVisibleCount] = useState(INITIAL_BATCH)
+  const scrollRef = useRef<HTMLDivElement>(null)
+
+  const clustersWithUuid = clusters.filter((c) => c.uuid)
+  const hasMore = visibleCount < clustersWithUuid.length
+  const visibleClusters = clustersWithUuid.slice(0, visibleCount)
 
   // Reset state when dialog closes; default-select current cluster on open.
   useEffect(() => {
     if (!open) {
       setSelected(new Set())
-      setShowAll(false)
+      setVisibleCount(INITIAL_BATCH)
     } else if (currentCluster) {
       const current = clusters.find((c) => c.name === currentCluster)
       if (current?.uuid) {
@@ -43,11 +51,13 @@ export function KubeconfigDownloadDialog({
     }
   }, [open, currentCluster, clusters])
 
-  const clustersWithUuid = clusters.filter((c) => c.uuid)
-  const visibleClusters =
-    showAll || clustersWithUuid.length <= 8
-      ? clustersWithUuid
-      : clustersWithUuid.slice(0, 8)
+  const handleScroll = useCallback(() => {
+    const el = scrollRef.current
+    if (!el || !hasMore) return
+    if (el.scrollTop + el.clientHeight >= el.scrollHeight - 20) {
+      setVisibleCount((prev) => Math.min(prev + LOAD_MORE_BATCH, clustersWithUuid.length))
+    }
+  }, [hasMore, clustersWithUuid.length])
 
   const handleToggle = (uuid: string) => {
     setSelected((prev) => {
@@ -136,7 +146,11 @@ export function KubeconfigDownloadDialog({
               </Button>
             )}
           </div>
-          <div className="h-[240px] overflow-y-auto rounded-md border p-2">
+          <div
+            ref={scrollRef}
+            onScroll={handleScroll}
+            className="h-[240px] overflow-y-auto rounded-md border p-2"
+          >
             <div className="space-y-1">
               {visibleClusters.map((cluster) => (
                 <label
@@ -155,22 +169,6 @@ export function KubeconfigDownloadDialog({
                   )}
                 </label>
               ))}
-              {clustersWithUuid.length > 8 && !showAll && (
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className="w-full"
-                  onClick={() => setShowAll(true)}
-                >
-                  {t(
-                    'clusterManagement.kubeconfig.showAll',
-                    'Show all ({{count}})',
-                    {
-                      count: clustersWithUuid.length,
-                    }
-                  )}
-                </Button>
-              )}
             </div>
           </div>
         </div>

--- a/ui/src/components/settings/apikey-management.tsx
+++ b/ui/src/components/settings/apikey-management.tsx
@@ -347,7 +347,7 @@ export function APIKeyManagement() {
             searchQuery=""
             pagination={pagination}
             setPagination={setPagination}
-            maxBodyHeightClassName="max-h-[600px]"
+            fitViewportHeight
           />
         </CardContent>
       </Card>

--- a/ui/src/components/settings/apikey-management.tsx
+++ b/ui/src/components/settings/apikey-management.tsx
@@ -9,18 +9,29 @@ import {
   IconTrash,
 } from '@tabler/icons-react'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
-import { ColumnDef } from '@tanstack/react-table'
+import {
+  ColumnDef,
+  getCoreRowModel,
+  PaginationState,
+  useReactTable,
+} from '@tanstack/react-table'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
 
 import { APIKey } from '@/types/api'
-import { createAPIKey, deleteAPIKey, useAPIKeyList } from '@/lib/api'
+import { createAPIKey, deleteAPIKey, useAPIKeyListPaged } from '@/lib/api'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
 import { DeleteConfirmationDialog } from '@/components/delete-confirmation-dialog'
+import { ResourceTableView } from '@/components/resource-table-view'
 
-import { Action, ActionTable } from '../action-table'
 import { APIKeyDialog } from './apikey-dialog'
 import UserRoleAssignment from './user-role-assignment'
 
@@ -28,7 +39,15 @@ export function APIKeyManagement() {
   const { t } = useTranslation()
   const queryClient = useQueryClient()
 
-  const { data: apiKeys = [], isLoading, error } = useAPIKeyList()
+  const [pagination, setPagination] = useState<PaginationState>({
+    pageIndex: 0,
+    pageSize: 20,
+  })
+  const { data, isLoading, error } = useAPIKeyListPaged(
+    pagination.pageIndex + 1,
+    pagination.pageSize
+  )
+  const apiKeys = data?.data ?? []
 
   const [showDialog, setShowDialog] = useState(false)
   const [deletingKey, setDeletingKey] = useState<APIKey | null>(null)
@@ -148,35 +167,61 @@ export function APIKeyManagement() {
     [t, visibleKeys, toggleKeyVisibility, copyToClipboard]
   )
 
-  const actions = useMemo<Action<APIKey>[]>(
-    () => [
-      {
-        label: (
-          <>
-            <IconShieldCheck className="h-4 w-4" />
-            {t('common.actions.assign', 'Assign')}
-          </>
-        ),
-        onClick: (apiKey) => setAssigningKey(apiKey),
-        hidden: (apiKey) => !!apiKey.ownerUserId,
-      },
-      {
-        label: (
-          <div className="inline-flex items-center gap-2 text-destructive">
-            <IconTrash className="h-4 w-4" />
-            {t('common.actions.delete', 'Delete')}
-          </div>
-        ),
-        onClick: (apiKey) => setDeletingKey(apiKey),
-      },
-    ],
-    [t]
-  )
+  const tableColumns = useMemo<ColumnDef<APIKey>[]>(() => {
+    const actionColumn: ColumnDef<APIKey> = {
+      id: 'actions',
+      header: t('common.fields.actions', 'Actions'),
+      cell: ({ row }) => (
+        <div className="text-right">
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="ghost"
+                size="sm"
+                aria-label={t('common.fields.actions', 'Actions')}
+              >
+                •••
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              {!row.original.ownerUserId && (
+                <DropdownMenuItem
+                  onClick={() => setAssigningKey(row.original)}
+                  className="gap-2"
+                >
+                  <IconShieldCheck className="h-4 w-4" />
+                  {t('common.actions.assign', 'Assign')}
+                </DropdownMenuItem>
+              )}
+              <DropdownMenuItem
+                onClick={() => setDeletingKey(row.original)}
+                className="gap-2 text-destructive"
+              >
+                <IconTrash className="h-4 w-4" />
+                {t('common.actions.delete', 'Delete')}
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+      ),
+    }
+    return [...columns, actionColumn]
+  }, [columns, t])
+
+  const table = useReactTable({
+    data: apiKeys,
+    columns: tableColumns,
+    getCoreRowModel: getCoreRowModel(),
+    state: { pagination },
+    onPaginationChange: setPagination,
+    manualPagination: true,
+    pageCount: Math.ceil((data?.total ?? 0) / pagination.pageSize) || 0,
+  })
 
   const createMutation = useMutation({
     mutationFn: createAPIKey,
     onSuccess: (data) => {
-      queryClient.invalidateQueries({ queryKey: ['apikey-list'] })
+      queryClient.invalidateQueries({ queryKey: ['apikey-list-paged'] })
       setShowDialog(false)
       setVisibleKeys(new Set([data.apiKey.id]))
       toast.success(
@@ -199,7 +244,7 @@ export function APIKeyManagement() {
   const deleteMutation = useMutation({
     mutationFn: deleteAPIKey,
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['apikey-list'] })
+      queryClient.invalidateQueries({ queryKey: ['apikey-list-paged'] })
       setDeletingKey(null)
       toast.success(
         t('common.messages.deleted', {
@@ -231,21 +276,6 @@ export function APIKeyManagement() {
     }
   }, [deletingKey, deleteMutation])
 
-  if (error) {
-    return (
-      <Card>
-        <CardContent className="flex items-center justify-center py-8">
-          <p className="text-destructive">
-            {t('common.messages.failedToLoad', {
-              resource: t('common.fields.apiKeys', 'API Keys'),
-              defaultValue: 'Failed to load API Keys',
-            })}
-          </p>
-        </CardContent>
-      </Card>
-    )
-  }
-
   return (
     <>
       <Card>
@@ -270,26 +300,55 @@ export function APIKeyManagement() {
           </div>
         </CardHeader>
         <CardContent>
-          {apiKeys.length === 0 && !isLoading ? (
-            <div className="text-center py-8 text-muted-foreground">
-              <IconKey className="h-12 w-12 mx-auto mb-4 opacity-50" />
-              <p className="text-lg font-medium">
-                {t('common.messages.noItemsConfigured', {
-                  resource: t('common.fields.apiKeys', 'API keys'),
-                  defaultValue: 'No API keys configured',
-                })}
-              </p>
-              <p className="text-sm">
-                {t('common.messages.createFirstItem', {
-                  resource: t('common.fields.apiKey', 'API key'),
-                  defaultValue:
-                    'Create an API key to get started with programmatic access.',
-                })}
-              </p>
-            </div>
-          ) : (
-            <ActionTable columns={columns} data={apiKeys} actions={actions} />
-          )}
+          <ResourceTableView
+            table={table}
+            columnCount={tableColumns.length}
+            isLoading={isLoading}
+            data={apiKeys}
+            allPageSize={data?.total ?? 0}
+            emptyState={
+              isLoading ? (
+                <div className="flex items-center justify-center py-8">
+                  <div className="text-muted-foreground">
+                    {t('common.messages.loading', 'Loading...')}
+                  </div>
+                </div>
+              ) : error ? (
+                <div className="flex items-center justify-center py-8">
+                  <div className="text-destructive">
+                    {t('common.messages.failedToLoad', {
+                      resource: t('common.fields.apiKeys', 'API Keys'),
+                      defaultValue: 'Failed to load API Keys',
+                    })}
+                  </div>
+                </div>
+              ) : apiKeys.length === 0 ? (
+                <div className="text-center py-8 text-muted-foreground">
+                  <IconKey className="h-12 w-12 mx-auto mb-4 opacity-50" />
+                  <p className="text-lg font-medium">
+                    {t('common.messages.noItemsConfigured', {
+                      resource: t('common.fields.apiKeys', 'API keys'),
+                      defaultValue: 'No API keys configured',
+                    })}
+                  </p>
+                  <p className="text-sm">
+                    {t('common.messages.createFirstItem', {
+                      resource: t('common.fields.apiKey', 'API key'),
+                      defaultValue:
+                        'Create an API key to get started with programmatic access.',
+                    })}
+                  </p>
+                </div>
+              ) : null
+            }
+            hasActiveFilters={false}
+            filteredRowCount={apiKeys.length}
+            totalRowCount={data?.total ?? 0}
+            searchQuery=""
+            pagination={pagination}
+            setPagination={setPagination}
+            maxBodyHeightClassName="max-h-[600px]"
+          />
         </CardContent>
       </Card>
 

--- a/ui/src/components/settings/apikey-management.tsx
+++ b/ui/src/components/settings/apikey-management.tsx
@@ -132,6 +132,18 @@ export function APIKeyManagement() {
           </div>
         ),
       },
+      {
+        id: 'owner',
+        header: t('common.fields.owner', 'Owner'),
+        cell: ({ row: { original: apiKey } }) =>
+          apiKey.owner ? (
+            <Badge variant="outline">
+              {apiKey.owner.name || apiKey.owner.username}
+            </Badge>
+          ) : (
+            <span className="text-sm text-muted-foreground">-</span>
+          ),
+      },
     ],
     [t, visibleKeys, toggleKeyVisibility, copyToClipboard]
   )
@@ -146,6 +158,7 @@ export function APIKeyManagement() {
           </>
         ),
         onClick: (apiKey) => setAssigningKey(apiKey),
+        hidden: (apiKey) => !!apiKey.ownerUserId,
       },
       {
         label: (

--- a/ui/src/components/settings/audit-log.tsx
+++ b/ui/src/components/settings/audit-log.tsx
@@ -415,7 +415,7 @@ export function AuditLog() {
           searchQuery={searchQuery}
           pagination={pagination}
           setPagination={setPagination}
-          maxBodyHeightClassName="max-h-[600px]"
+          fitViewportHeight
         />
       </CardContent>
 

--- a/ui/src/components/settings/authentication-management.tsx
+++ b/ui/src/components/settings/authentication-management.tsx
@@ -35,6 +35,7 @@ function createDefaultSettings(): AuthenticationFormData {
     userFilter: '',
     usernameAttribute: '',
     displayNameAttribute: '',
+    emailAttribute: '',
     groupBaseDn: '',
     groupFilter: '',
     groupNameAttribute: '',
@@ -57,6 +58,7 @@ function toFormData(data?: LDAPSetting): AuthenticationFormData {
     userFilter: data.userFilter || '',
     usernameAttribute: data.usernameAttribute || '',
     displayNameAttribute: data.displayNameAttribute || '',
+    emailAttribute: data.emailAttribute || '',
     groupBaseDn: data.groupBaseDn || '',
     groupFilter: data.groupFilter || '',
     groupNameAttribute: data.groupNameAttribute || '',
@@ -144,6 +146,7 @@ export function AuthenticationManagement() {
       userFilter: formData.userFilter.trim(),
       usernameAttribute: formData.usernameAttribute.trim(),
       displayNameAttribute: formData.displayNameAttribute.trim(),
+      emailAttribute: formData.emailAttribute.trim(),
       groupBaseDn: formData.groupBaseDn.trim(),
       groupFilter: formData.groupFilter.trim(),
       groupNameAttribute: formData.groupNameAttribute.trim(),
@@ -504,6 +507,29 @@ export function AuthenticationManagement() {
                           displayNameAttribute: e.target.value,
                         }))
                       }
+                    />
+                  </div>
+
+                  <div className="space-y-2">
+                    <Label htmlFor="ldap-email-attribute">
+                      {t(
+                        'authenticationManagement.ldap.form.emailAttribute',
+                        'Email Attribute'
+                      )}
+                    </Label>
+                    <Input
+                      id="ldap-email-attribute"
+                      value={formData.emailAttribute}
+                      onChange={(e) =>
+                        setFormData((prev) => ({
+                          ...prev,
+                          emailAttribute: e.target.value,
+                        }))
+                      }
+                      placeholder={t(
+                        'authenticationManagement.ldap.form.emailAttributePlaceholder',
+                        'mail'
+                      )}
                     />
                   </div>
 

--- a/ui/src/components/settings/cluster-management.tsx
+++ b/ui/src/components/settings/cluster-management.tsx
@@ -8,7 +8,12 @@ import {
   IconUpload,
 } from '@tabler/icons-react'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
-import { ColumnDef } from '@tanstack/react-table'
+import {
+  ColumnDef,
+  getCoreRowModel,
+  PaginationState,
+  useReactTable,
+} from '@tanstack/react-table'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
 
@@ -20,9 +25,10 @@ import {
   deleteCluster,
   importClusters,
   updateCluster,
-  useClusterList,
+  useClusterListPaged,
   useVersionInfo,
 } from '@/lib/api'
+import { ResourceTableView } from '@/components/resource-table-view'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
@@ -34,6 +40,12 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Skeleton } from '@/components/ui/skeleton'
@@ -45,7 +57,6 @@ import {
 } from '@/components/ui/tooltip'
 import { DeleteConfirmationDialog } from '@/components/delete-confirmation-dialog'
 
-import { Action, ActionTable } from '../action-table'
 import { ClusterDialog } from './cluster-dialog'
 import { ClusterImportDialog } from './cluster-import-dialog'
 
@@ -54,13 +65,16 @@ export function ClusterManagement() {
   const queryClient = useQueryClient()
   const { data: versionInfo } = useVersionInfo()
 
-  const {
-    data: clusters = [],
-    isLoading,
-    error,
-  } = useClusterList({
-    refetchInterval: 5000,
+  const [pagination, setPagination] = useState<PaginationState>({
+    pageIndex: 0,
+    pageSize: 20,
   })
+  const { data, isLoading, error } = useClusterListPaged(
+    pagination.pageIndex + 1,
+    pagination.pageSize,
+    { refetchInterval: 5000 }
+  )
+  const clusters = data?.data ?? []
 
   const [showClusterDialog, setShowClusterDialog] = useState(false)
   const [showImportDialog, setShowImportDialog] = useState(false)
@@ -241,35 +255,60 @@ export function ClusterManagement() {
     [getClusterTypeBadge, getStatusBadge, t, versionInfo]
   )
 
-  const actions = useMemo<Action<Cluster>[]>(
-    () => [
-      {
-        label: (
-          <>
-            <IconEdit className="h-4 w-4" />
-            {t('common.actions.edit', 'Edit')}
-          </>
-        ),
-        onClick: (cluster) => {
-          setEditingCluster(cluster)
-          setShowClusterDialog(true)
-        },
-      },
-      {
-        label: (
-          <div className="inline-flex items-center gap-2 text-destructive">
-            <IconTrash className="h-4 w-4" />
-            {t('common.actions.delete', 'Delete')}
-          </div>
-        ),
-        shouldDisable: (cluster) => cluster.isDefault,
-        onClick: (cluster) => {
-          setDeletingCluster(cluster)
-        },
-      },
-    ],
-    [t]
-  )
+  const tableColumns = useMemo<ColumnDef<Cluster>[]>(() => {
+    const actionColumn: ColumnDef<Cluster> = {
+      id: 'actions',
+      header: t('common.fields.actions', 'Actions'),
+      cell: ({ row }) => (
+        <div className="text-right">
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="ghost"
+                size="sm"
+                aria-label={t('common.fields.actions', 'Actions')}
+              >
+                •••
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem
+                onClick={() => {
+                  setEditingCluster(row.original)
+                  setShowClusterDialog(true)
+                }}
+                className="gap-2"
+              >
+                <IconEdit className="h-4 w-4" />
+                {t('common.actions.edit', 'Edit')}
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                disabled={row.original.isDefault}
+                onClick={() => setDeletingCluster(row.original)}
+                className="gap-2"
+              >
+                <div className="inline-flex items-center gap-2 text-destructive">
+                  <IconTrash className="h-4 w-4" />
+                  {t('common.actions.delete', 'Delete')}
+                </div>
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+      ),
+    }
+    return [...columns, actionColumn]
+  }, [columns, t])
+
+  const table = useReactTable({
+    data: clusters,
+    columns: tableColumns,
+    getCoreRowModel: getCoreRowModel(),
+    state: { pagination },
+    onPaginationChange: setPagination,
+    manualPagination: true,
+    pageCount: Math.ceil((data?.total ?? 0) / pagination.pageSize) || 0,
+  })
 
   const createMutation = useMutation({
     mutationFn: createCluster,
@@ -282,7 +321,7 @@ export function ClusterManagement() {
       connectorToken?: string
       connectorManifestURL?: string
     }) => {
-      queryClient.invalidateQueries({ queryKey: ['cluster-list'] })
+      queryClient.invalidateQueries({ queryKey: ['cluster-list-paged'] })
       toast.success(
         t('clusterManagement.messages.created', 'Cluster created successfully')
       )
@@ -344,7 +383,7 @@ export function ClusterManagement() {
   const importMutation = useMutation({
     mutationFn: (config: string) => importClusters({ config }),
     onSuccess: ({ importedCount }) => {
-      queryClient.invalidateQueries({ queryKey: ['cluster-list'] })
+      queryClient.invalidateQueries({ queryKey: ['cluster-list-paged'] })
       queryClient.invalidateQueries({ queryKey: ['clusters'] })
       toast.success(
         t(
@@ -362,7 +401,7 @@ export function ClusterManagement() {
     mutationFn: ({ id, data }: { id: number; data: ClusterUpdateRequest }) =>
       updateCluster(id, data),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['cluster-list'] })
+      queryClient.invalidateQueries({ queryKey: ['cluster-list-paged'] })
       toast.success(
         t('clusterManagement.messages.updated', 'Cluster updated successfully')
       )
@@ -384,7 +423,7 @@ export function ClusterManagement() {
   const deleteMutation = useMutation({
     mutationFn: deleteCluster,
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['cluster-list'] })
+      queryClient.invalidateQueries({ queryKey: ['cluster-list-paged'] })
       toast.success(
         t('clusterManagement.messages.deleted', 'Cluster deleted successfully')
       )
@@ -417,26 +456,6 @@ export function ClusterManagement() {
   const handleDeleteCluster = () => {
     if (!deletingCluster) return
     deleteMutation.mutate(deletingCluster.id)
-  }
-
-  if (isLoading) {
-    return (
-      <div className="flex items-center justify-center py-8">
-        <div className="text-muted-foreground">
-          {t('common.messages.loading', 'Loading...')}
-        </div>
-      </div>
-    )
-  }
-
-  if (error) {
-    return (
-      <div className="flex items-center justify-center py-8">
-        <div className="text-destructive">
-          {t('clusterManagement.errors.loadFailed', 'Failed to load clusters')}
-        </div>
-      </div>
-    )
   }
 
   return (
@@ -476,21 +495,54 @@ export function ClusterManagement() {
           </div>
         </CardHeader>
         <CardContent>
-          <ActionTable data={clusters} columns={columns} actions={actions} />
-          {clusters.length === 0 && (
-            <div className="text-center py-8 text-muted-foreground">
-              <IconServer className="h-12 w-12 mx-auto mb-4 opacity-50" />
-              <p>
-                {t('clusterManagement.empty.title', 'No clusters configured')}
-              </p>
-              <p className="text-sm mt-1">
-                {t(
-                  'clusterManagement.empty.description',
-                  'Add your first cluster to get started'
-                )}
-              </p>
-            </div>
-          )}
+          <ResourceTableView
+            table={table}
+            columnCount={tableColumns.length}
+            isLoading={isLoading}
+            data={clusters}
+            allPageSize={data?.total ?? 0}
+            emptyState={
+              isLoading ? (
+                <div className="flex items-center justify-center py-8">
+                  <div className="text-muted-foreground">
+                    {t('common.messages.loading', 'Loading...')}
+                  </div>
+                </div>
+              ) : error ? (
+                <div className="flex items-center justify-center py-8">
+                  <div className="text-destructive">
+                    {t(
+                      'clusterManagement.errors.loadFailed',
+                      'Failed to load clusters'
+                    )}
+                  </div>
+                </div>
+              ) : clusters.length === 0 ? (
+                <div className="text-center py-8 text-muted-foreground">
+                  <IconServer className="h-12 w-12 mx-auto mb-4 opacity-50" />
+                  <p>
+                    {t(
+                      'clusterManagement.empty.title',
+                      'No clusters configured'
+                    )}
+                  </p>
+                  <p className="text-sm mt-1">
+                    {t(
+                      'clusterManagement.empty.description',
+                      'Add your first cluster to get started'
+                    )}
+                  </p>
+                </div>
+              ) : null
+            }
+            hasActiveFilters={false}
+            filteredRowCount={clusters.length}
+            totalRowCount={data?.total ?? 0}
+            searchQuery=""
+            pagination={pagination}
+            setPagination={setPagination}
+            maxBodyHeightClassName="max-h-[600px]"
+          />
         </CardContent>
       </Card>
 

--- a/ui/src/components/settings/cluster-management.tsx
+++ b/ui/src/components/settings/cluster-management.tsx
@@ -541,7 +541,7 @@ export function ClusterManagement() {
             searchQuery=""
             pagination={pagination}
             setPagination={setPagination}
-            maxBodyHeightClassName="max-h-[600px]"
+            fitViewportHeight
           />
         </CardContent>
       </Card>

--- a/ui/src/components/settings/cluster-management.tsx
+++ b/ui/src/components/settings/cluster-management.tsx
@@ -21,6 +21,7 @@ import {
   importClusters,
   updateCluster,
   useClusterList,
+  useVersionInfo,
 } from '@/lib/api'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -36,7 +37,6 @@ import {
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Skeleton } from '@/components/ui/skeleton'
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { Textarea } from '@/components/ui/textarea'
 import {
   Tooltip,
@@ -52,6 +52,7 @@ import { ClusterImportDialog } from './cluster-import-dialog'
 export function ClusterManagement() {
   const { t } = useTranslation()
   const queryClient = useQueryClient()
+  const { data: versionInfo } = useVersionInfo()
 
   const {
     data: clusters = [],
@@ -188,6 +189,37 @@ export function ClusterManagement() {
         cell: ({ row: { original: cluster } }) => getClusterTypeBadge(cluster),
       },
       {
+        id: 'connectorVersion',
+        header: t('clusterManagement.connectorVersion', 'Connector Version'),
+        cell: ({ row: { original: cluster } }) => {
+          if (!cluster.connector) {
+            return <span className="text-muted-foreground">-</span>
+          }
+          const ver = cluster.connectorVersion
+          if (!ver) {
+            return <span className="text-muted-foreground">-</span>
+          }
+          const isOutdated = versionInfo?.version && ver !== versionInfo.version
+          return (
+            <Badge
+              variant="outline"
+              className={
+                isOutdated
+                  ? 'border-yellow-500/50 bg-yellow-500/10 text-yellow-700 dark:text-yellow-400 font-mono'
+                  : 'border-green-500/50 bg-green-500/10 text-green-700 dark:text-green-400 font-mono'
+              }
+            >
+              {ver}
+              {isOutdated && (
+                <span className="ml-1">
+                  {t('clusterManagement.needsUpgrade', 'Needs upgrade')}
+                </span>
+              )}
+            </Badge>
+          )
+        },
+      },
+      {
         id: 'status',
         header: t('common.fields.status', 'Status'),
         cell: ({ row: { original: cluster } }) => (
@@ -206,7 +238,7 @@ export function ClusterManagement() {
         ),
       },
     ],
-    [getClusterTypeBadge, getStatusBadge, t]
+    [getClusterTypeBadge, getStatusBadge, t, versionInfo]
   )
 
   const actions = useMemo<Action<Cluster>[]>(
@@ -512,16 +544,15 @@ export function ClusterManagement() {
               )}
             </DialogDescription>
           </DialogHeader>
-          <Tabs defaultValue="command">
-            <TabsList className="grid w-full grid-cols-2">
-              <TabsTrigger value="command">
-                {t('clusterManagement.connector.command', 'Command')}
-              </TabsTrigger>
-              <TabsTrigger value="yaml">
-                {t('clusterManagement.connector.yaml', 'Kubernetes YAML')}
-              </TabsTrigger>
-            </TabsList>
-            <TabsContent value="command" className="space-y-2">
+          <div className="space-y-4">
+            {/* Section 1: Command */}
+            <div className="space-y-2">
+              <Label className="text-xs text-muted-foreground">
+                {t(
+                  'clusterManagement.connector.runCommand',
+                  'Run Connector directly'
+                )}
+              </Label>
               <div className="flex gap-2">
                 <Input
                   readOnly
@@ -562,72 +593,78 @@ export function ClusterManagement() {
                   )}
                 </p>
               )}
-            </TabsContent>
-            <TabsContent value="yaml" className="space-y-2">
-              {connectorManifestURL && (
-                <div className="space-y-1">
-                  <Label className="text-xs text-muted-foreground">
-                    {t(
-                      'clusterManagement.connector.applyUrl',
-                      'Apply directly with URL'
-                    )}
-                  </Label>
-                  <div className="flex gap-2">
-                    <Input
-                      readOnly
-                      className="font-mono text-xs"
-                      value={`kubectl apply -f "${connectorManifestURL}"`}
-                    />
-                    <Button
-                      type="button"
-                      variant="outline"
-                      size="icon"
-                      aria-label={t(
-                        'clusterManagement.connector.copyApplyCommand',
-                        'Copy apply command'
-                      )}
-                      onClick={async () => {
-                        try {
-                          await navigator.clipboard.writeText(
-                            `kubectl apply -f "${connectorManifestURL}"`
-                          )
-                          setConnectorCopyError(null)
-                          toast.success(t('common.messages.copied', 'Copied'))
-                        } catch {
-                          setConnectorCopyError('yaml')
-                        }
-                      }}
-                    >
-                      <IconCopy className="size-4" />
-                    </Button>
-                  </div>
-                </div>
-              )}
-              <div className="space-y-1">
+            </div>
+
+            <div className="border-t" />
+
+            {/* Section 2: URL deploy */}
+            {connectorManifestURL && (
+              <div className="space-y-2">
                 <Label className="text-xs text-muted-foreground">
                   {t(
-                    'clusterManagement.connector.orUseYaml',
-                    'Or deploy with YAML'
+                    'clusterManagement.connector.applyUrl',
+                    'Deploy via Kubernetes YAML URL'
                   )}
                 </Label>
-                {isConnectorYamlLoading ? (
-                  <Skeleton className="h-96 w-full" />
-                ) : connectorYamlError ? (
-                  <p role="alert" className="text-sm text-destructive">
-                    {connectorYamlError}
-                  </p>
-                ) : (
-                  <Textarea
+                <div className="flex gap-2">
+                  <Input
                     readOnly
-                    className="h-96 resize-none font-mono text-xs"
-                    aria-label={t(
-                      'clusterManagement.connector.yaml',
-                      'Kubernetes YAML'
-                    )}
-                    value={connectorYaml}
+                    className="font-mono text-xs"
+                    value={`kubectl apply -f "${connectorManifestURL}"`}
                   />
-                )}
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="icon"
+                    aria-label={t(
+                      'clusterManagement.connector.copyApplyCommand',
+                      'Copy apply command'
+                    )}
+                    onClick={async () => {
+                      try {
+                        await navigator.clipboard.writeText(
+                          `kubectl apply -f "${connectorManifestURL}"`
+                        )
+                        setConnectorCopyError(null)
+                        toast.success(t('common.messages.copied', 'Copied'))
+                      } catch {
+                        setConnectorCopyError('yaml')
+                      }
+                    }}
+                  >
+                    <IconCopy className="size-4" />
+                  </Button>
+                </div>
               </div>
+            )}
+
+            <div className="border-t" />
+
+            {/* Section 3: Copy YAML */}
+            <div className="space-y-2">
+              <Label className="text-xs text-muted-foreground">
+                {t(
+                  'clusterManagement.connector.copyYamlManually',
+                  'Copy Kubernetes YAML manually'
+                )}
+              </Label>
+              {isConnectorYamlLoading ? (
+                <Skeleton className="h-96 w-full" />
+              ) : connectorYamlError ? (
+                <p role="alert" className="text-sm text-destructive">
+                  {connectorYamlError}
+                </p>
+              ) : (
+                <Textarea
+                  readOnly
+                  className="h-96 resize-none font-mono text-xs"
+                  aria-label={t(
+                    'clusterManagement.connector.yaml',
+                    'Kubernetes YAML'
+                  )}
+                  value={connectorYaml}
+                />
+              )}
               {connectorYaml && (
                 <div className="flex justify-end">
                   <Button
@@ -656,8 +693,8 @@ export function ClusterManagement() {
                   )}
                 </p>
               )}
-            </TabsContent>
-          </Tabs>
+            </div>
+          </div>
           <DialogFooter>
             <Button
               type="button"

--- a/ui/src/components/settings/oauth-provider-dialog.tsx
+++ b/ui/src/components/settings/oauth-provider-dialog.tsx
@@ -36,6 +36,8 @@ function createOAuthProviderFormData(provider?: OAuthProvider | null) {
     scopes: provider?.scopes || 'openid,profile,email',
     issuer: provider?.issuer || '',
     usernameClaim: provider?.usernameClaim || '',
+    nameClaim: provider?.nameClaim || '',
+    emailClaim: provider?.emailClaim || '',
     groupsClaim: provider?.groupsClaim || '',
     allowedGroups: provider?.allowedGroups || '',
     enabled: provider?.enabled ?? true,
@@ -118,6 +120,8 @@ function OAuthProviderDialogContent({
     if (formData.issuer) submitData.issuer = formData.issuer
     if (formData.usernameClaim)
       submitData.usernameClaim = formData.usernameClaim
+    if (formData.nameClaim) submitData.nameClaim = formData.nameClaim
+    if (formData.emailClaim) submitData.emailClaim = formData.emailClaim
     if (formData.groupsClaim) submitData.groupsClaim = formData.groupsClaim
     if (formData.allowedGroups)
       submitData.allowedGroups = formData.allowedGroups
@@ -330,6 +334,34 @@ function OAuthProviderDialogContent({
                 placeholder={t(
                   'common.placeholders.usernameClaim',
                   'e.g., preferred_username'
+                )}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="nameClaim">
+                {t('common.fields.nameClaim', 'Name Claim')}
+              </Label>
+              <Input
+                id="nameClaim"
+                value={formData.nameClaim}
+                onChange={handleInputChange('nameClaim')}
+                placeholder={t(
+                  'common.placeholders.nameClaim',
+                  'e.g., given_name'
+                )}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="emailClaim">
+                {t('settings.oauth.emailClaim', 'Email Claim')}
+              </Label>
+              <Input
+                id="emailClaim"
+                value={formData.emailClaim}
+                onChange={handleInputChange('emailClaim')}
+                placeholder={t(
+                  'settings.oauth.emailClaimPlaceholder',
+                  'e.g., email, mail, userPrincipalName'
                 )}
               />
             </div>

--- a/ui/src/components/settings/rbac-assignment-dialog.tsx
+++ b/ui/src/components/settings/rbac-assignment-dialog.tsx
@@ -5,7 +5,7 @@ import { AlertTriangle, ChevronsUpDown, Loader2 } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 
 import { Role } from '@/types/api'
-import { useUserList } from '@/lib/api'
+import { useIndependentAPIKeyList, useUserList } from '@/lib/api'
 import { cn } from '@/lib/utils'
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
 import { Badge } from '@/components/ui/badge'
@@ -47,12 +47,12 @@ interface Props {
   role?: Role | null
   onAssign: (
     roleId: number,
-    subjectType: 'user' | 'group',
+    subjectType: 'user' | 'group' | 'apikey',
     subject: string
   ) => void
   onUnassign: (
     roleId: number,
-    subjectType: 'user' | 'group',
+    subjectType: 'user' | 'group' | 'apikey',
     subject: string
   ) => void
   isAssigning?: boolean
@@ -70,12 +70,14 @@ export function RBACAssignmentDialog({
 }: Props) {
   const { t } = useTranslation()
   const { user } = useAuth()
-  const [subjectType, setSubjectType] = useState<'user' | 'group'>('user')
+  const [subjectType, setSubjectType] = useState<
+    'user' | 'group' | 'apikey'
+  >('user')
   const [subject, setSubject] = useState('')
   const [userSelectOpen, setUserSelectOpen] = useState(false)
   const [userSearch, setUserSearch] = useState('')
   const [pendingRemoval, setPendingRemoval] = useState<{
-    subjectType: 'user' | 'group'
+    subjectType: 'user' | 'group' | 'apikey'
     subject: string
   } | null>(null)
 
@@ -84,6 +86,8 @@ export function RBACAssignmentDialog({
     50,
     subjectType === 'user' ? userSearch : ''
   )
+  const { data: apiKeyList, isFetching: isFetchingAPIKeys } =
+    useIndependentAPIKeyList({ staleTime: 30000 })
 
   useEffect(() => {
     if (open) {
@@ -104,7 +108,7 @@ export function RBACAssignmentDialog({
   }
 
   const handleRemoveAssignment = (
-    assignmentSubjectType: 'user' | 'group',
+    assignmentSubjectType: 'user' | 'group' | 'apikey',
     assignmentSubject: string
   ) => {
     if (!role) return
@@ -234,7 +238,7 @@ export function RBACAssignmentDialog({
                 <Select
                   value={subjectType}
                   onValueChange={(v) => {
-                    setSubjectType(v as 'user' | 'group')
+                    setSubjectType(v as 'user' | 'group' | 'apikey')
                     setSubject('')
                     setUserSelectOpen(false)
                     setUserSearch('')
@@ -250,6 +254,9 @@ export function RBACAssignmentDialog({
                     </SelectItem>
                     <SelectItem value="group">
                       {t('common.fields.oidcGroup', 'OIDC Group')}
+                    </SelectItem>
+                    <SelectItem value="apikey">
+                      {t('common.fields.apiKey', 'API Key')}
                     </SelectItem>
                   </SelectContent>
                 </Select>
@@ -380,6 +387,100 @@ export function RBACAssignmentDialog({
                                     </div>
                                   </CommandItem>
                                 ))}
+                              </CommandGroup>
+                            </>
+                          )}
+                        </CommandList>
+                      </Command>
+                    </PopoverContent>
+                  </Popover>
+                ) : subjectType === 'apikey' ? (
+                  <Popover
+                    open={userSelectOpen}
+                    onOpenChange={setUserSelectOpen}
+                    modal
+                  >
+                    <PopoverTrigger asChild>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        role="combobox"
+                        aria-expanded={userSelectOpen}
+                        disabled={isAssigning}
+                        className="w-full justify-between"
+                      >
+                        <span
+                          className={cn(
+                            'truncate',
+                            !subject && 'text-muted-foreground'
+                          )}
+                        >
+                          {subject ||
+                            t('common.placeholders.selectAPIKey', 'Select API key')}
+                        </span>
+                        <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+                      </Button>
+                    </PopoverTrigger>
+                    <PopoverContent
+                      className="w-[var(--radix-popover-trigger-width)] p-0"
+                      align="start"
+                    >
+                      <Command shouldFilter>
+                        <CommandInput
+                          placeholder={t(
+                            'common.placeholders.searchAPIKeys',
+                            'Search API keys...'
+                          )}
+                          className="h-9"
+                        />
+                        <CommandList
+                          className="max-h-[min(45dvh,240px)] overflow-x-hidden overflow-y-auto overscroll-contain"
+                          onWheelCapture={(event) => event.stopPropagation()}
+                          onTouchMove={(event) => event.stopPropagation()}
+                        >
+                          {isFetchingAPIKeys ? (
+                            <div className="flex items-center justify-center p-6 text-sm text-muted-foreground">
+                              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                              {t('common.actions.search', 'Search')}...
+                            </div>
+                          ) : (
+                            <>
+                              <CommandEmpty>
+                                {t(
+                                  'common.messages.noAPIKeysFound',
+                                  'No API keys found'
+                                )}
+                              </CommandEmpty>
+                              <CommandGroup className="p-0">
+                                {(apiKeyList || [])
+                                  .filter(
+                                    (k) => !assignedUsers.has(k.username)
+                                  )
+                                  .map((k) => (
+                                    <CommandItem
+                                      key={k.id}
+                                      value={k.username}
+                                      className="min-h-11 rounded-none border-b px-3 py-1.5 last:border-b-0"
+                                      onSelect={() => {
+                                        setSubject(k.username)
+                                        setUserSelectOpen(false)
+                                      }}
+                                    >
+                                      <Avatar className="size-7">
+                                        <AvatarFallback className="bg-muted-foreground text-xs font-medium text-background">
+                                          {k.username.slice(0, 2).toUpperCase()}
+                                        </AvatarFallback>
+                                      </Avatar>
+                                      <div className="flex min-w-0 flex-1 flex-col">
+                                        <span
+                                          className="truncate text-sm font-semibold"
+                                          title={k.username}
+                                        >
+                                          {k.username}
+                                        </span>
+                                      </div>
+                                    </CommandItem>
+                                  ))}
                               </CommandGroup>
                             </>
                           )}

--- a/ui/src/components/settings/rbac-management.tsx
+++ b/ui/src/components/settings/rbac-management.tsx
@@ -312,7 +312,7 @@ export function RBACManagement() {
 
   const handleAssign = async (
     roleId: number,
-    subjectType: 'user' | 'group',
+    subjectType: 'user' | 'group' | 'apikey',
     subject: string
   ) => {
     if (isAssigning) return
@@ -343,7 +343,7 @@ export function RBACManagement() {
 
   const handleUnassign = async (
     roleId: number,
-    subjectType: 'user' | 'group',
+    subjectType: 'user' | 'group' | 'apikey',
     subject: string
   ) => {
     if (isUnassigning) return

--- a/ui/src/components/settings/rbac-management.tsx
+++ b/ui/src/components/settings/rbac-management.tsx
@@ -501,7 +501,7 @@ export function RBACManagement() {
             searchQuery=""
             pagination={pagination}
             setPagination={setPagination}
-            maxBodyHeightClassName="max-h-[600px]"
+            fitViewportHeight
           />
         </CardContent>
       </Card>

--- a/ui/src/components/settings/rbac-management.tsx
+++ b/ui/src/components/settings/rbac-management.tsx
@@ -7,24 +7,35 @@ import {
   IconTrash,
 } from '@tabler/icons-react'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
-import { ColumnDef } from '@tanstack/react-table'
+import {
+  ColumnDef,
+  getCoreRowModel,
+  PaginationState,
+  useReactTable,
+} from '@tanstack/react-table'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
 
-import { Role } from '@/types/api'
+import { Role, RoleListResponse } from '@/types/api'
 import {
   assignRole,
   createRole,
   deleteRole,
   unassignRole,
   updateRole,
-  useRoleList,
+  useRoleListPaged,
 } from '@/lib/api'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
 import { DeleteConfirmationDialog } from '@/components/delete-confirmation-dialog'
+import { ResourceTableView } from '@/components/resource-table-view'
 
-import { Action, ActionTable } from '../action-table'
 import { Badge } from '../ui/badge'
 import { RBACAssignmentDialog } from './rbac-assignment-dialog'
 import { RBACDialog } from './rbac-dialog'
@@ -34,7 +45,15 @@ export function RBACManagement() {
   const { user } = useAuth()
   const queryClient = useQueryClient()
 
-  const { data: roles = [], isLoading, error } = useRoleList()
+  const [pagination, setPagination] = useState<PaginationState>({
+    pageIndex: 0,
+    pageSize: 20,
+  })
+  const { data, isLoading, error } = useRoleListPaged(
+    pagination.pageIndex + 1,
+    pagination.pageSize
+  )
+  const roles = data?.data ?? []
 
   const [showDialog, setShowDialog] = useState(false)
   const [editingRole, setEditingRole] = useState<Role | null>(null)
@@ -185,53 +204,76 @@ export function RBACManagement() {
     [t]
   )
 
-  const actions = useMemo<Action<Role>[]>(
-    () => [
-      {
-        label: (
-          <>
-            <IconShieldCheck className="h-4 w-4" />
-            {t('common.actions.assign', 'Assign')}
-          </>
-        ),
-        onClick: (r) => {
-          setAssigningRole(r)
-          setShowAssignDialog(true)
-        },
-      },
-      {
-        label: (
-          <>
-            <IconEdit className="h-4 w-4" />
-            {t('common.actions.edit', 'Edit')}
-          </>
-        ),
-        shouldDisable: (role) => !!role.isSystem,
-        onClick: (role) => {
-          setEditingRole(role)
-          setShowDialog(true)
-        },
-      },
-      {
-        label: (
-          <div className="inline-flex items-center gap-2 text-destructive">
-            <IconTrash className="h-4 w-4" />
-            {t('common.actions.delete', 'Delete')}
-          </div>
-        ),
-        shouldDisable: (role) => !!role.isSystem,
-        onClick: (role) => {
-          setDeletingRole(role)
-        },
-      },
-    ],
-    [t]
-  )
+  const tableColumns = useMemo<ColumnDef<Role>[]>(() => {
+    const actionColumn: ColumnDef<Role> = {
+      id: 'actions',
+      header: t('common.fields.actions', 'Actions'),
+      cell: ({ row }) => (
+        <div className="text-right">
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="ghost"
+                size="sm"
+                aria-label={t('common.fields.actions', 'Actions')}
+              >
+                •••
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem
+                onClick={() => {
+                  setAssigningRole(row.original)
+                  setShowAssignDialog(true)
+                }}
+                className="gap-2"
+              >
+                <IconShieldCheck className="h-4 w-4" />
+                {t('common.actions.assign', 'Assign')}
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                disabled={!!row.original.isSystem}
+                onClick={() => {
+                  setEditingRole(row.original)
+                  setShowDialog(true)
+                }}
+                className="gap-2"
+              >
+                <IconEdit className="h-4 w-4" />
+                {t('common.actions.edit', 'Edit')}
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                disabled={!!row.original.isSystem}
+                onClick={() => setDeletingRole(row.original)}
+                className="gap-2"
+              >
+                <div className="inline-flex items-center gap-2 text-destructive">
+                  <IconTrash className="h-4 w-4" />
+                  {t('common.actions.delete', 'Delete')}
+                </div>
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+      ),
+    }
+    return [...columns, actionColumn]
+  }, [columns, t])
+
+  const table = useReactTable({
+    data: roles,
+    columns: tableColumns,
+    getCoreRowModel: getCoreRowModel(),
+    state: { pagination },
+    onPaginationChange: setPagination,
+    manualPagination: true,
+    pageCount: Math.ceil((data?.total ?? 0) / pagination.pageSize) || 0,
+  })
 
   const createMutation = useMutation({
     mutationFn: (data: Partial<Role>) => createRole(data),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['role-list'] })
+      queryClient.invalidateQueries({ queryKey: ['role-list-paged'] })
       toast.success(
         t('common.messages.created', {
           resource: t('common.fields.role', 'Role'),
@@ -254,7 +296,7 @@ export function RBACManagement() {
     mutationFn: ({ id, data }: { id: number; data: Partial<Role> }) =>
       updateRole(id, data),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['role-list'] })
+      queryClient.invalidateQueries({ queryKey: ['role-list-paged'] })
       toast.success(
         t('common.messages.updated', {
           resource: t('common.fields.role', 'Role'),
@@ -277,7 +319,7 @@ export function RBACManagement() {
   const deleteMutation = useMutation({
     mutationFn: (id: number) => deleteRole(id),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['role-list'] })
+      queryClient.invalidateQueries({ queryKey: ['role-list-paged'] })
       toast.success(
         t('common.messages.deleted', {
           resource: t('common.fields.role', 'Role'),
@@ -319,12 +361,16 @@ export function RBACManagement() {
     setIsAssigning(true)
     try {
       await assignRole(roleId, { subjectType, subject })
-      await queryClient.invalidateQueries({ queryKey: ['role-list'] })
+      await queryClient.invalidateQueries({ queryKey: ['role-list-paged'] })
 
       // Update assigningRole with fresh data to show the new assignment immediately
       if (assigningRole?.id === roleId) {
-        const updatedRoles = queryClient.getQueryData<Role[]>(['role-list'])
-        const updatedRole = updatedRoles?.find((r) => r.id === roleId)
+        const pagedData = queryClient.getQueryData<RoleListResponse>([
+          'role-list-paged',
+          pagination.pageIndex + 1,
+          pagination.pageSize,
+        ])
+        const updatedRole = pagedData?.data?.find((r) => r.id === roleId)
         if (updatedRole) {
           setAssigningRole(updatedRole)
         }
@@ -350,11 +396,15 @@ export function RBACManagement() {
     setIsUnassigning(true)
     try {
       await unassignRole(roleId, subjectType, subject)
-      await queryClient.invalidateQueries({ queryKey: ['role-list'] })
+      await queryClient.invalidateQueries({ queryKey: ['role-list-paged'] })
 
       if (assigningRole?.id === roleId) {
-        const updatedRoles = queryClient.getQueryData<Role[]>(['role-list'])
-        const updatedRole = updatedRoles?.find((r) => r.id === roleId)
+        const pagedData = queryClient.getQueryData<RoleListResponse>([
+          'role-list-paged',
+          pagination.pageIndex + 1,
+          pagination.pageSize,
+        ])
+        const updatedRole = pagedData?.data?.find((r) => r.id === roleId)
         if (updatedRole) {
           setAssigningRole(updatedRole)
         }
@@ -381,29 +431,6 @@ export function RBACManagement() {
       )
     : undefined
 
-  if (isLoading) {
-    return (
-      <div className="flex items-center justify-center py-8">
-        <div className="text-muted-foreground">
-          {t('common.messages.loading', 'Loading...')}
-        </div>
-      </div>
-    )
-  }
-
-  if (error) {
-    return (
-      <div className="flex items-center justify-center py-8">
-        <div className="text-destructive">
-          {t('common.messages.failedToLoad', {
-            resource: t('common.fields.roles', 'roles'),
-            defaultValue: 'Failed to load roles',
-          })}
-        </div>
-      </div>
-    )
-  }
-
   return (
     <div className="space-y-6">
       <Card>
@@ -428,24 +455,54 @@ export function RBACManagement() {
           </div>
         </CardHeader>
         <CardContent>
-          <ActionTable actions={actions} data={roles} columns={columns} />
-          {roles.length === 0 && (
-            <div className="text-center py-8 text-muted-foreground">
-              <IconShieldCheck className="h-12 w-12 mx-auto mb-4 opacity-50" />
-              <p>
-                {t('common.messages.noItemsConfigured', {
-                  resource: t('common.fields.roles', 'roles'),
-                  defaultValue: 'No roles configured',
-                })}
-              </p>
-              <p className="text-sm mt-1">
-                {t('common.messages.createFirstItem', {
-                  resource: t('common.fields.role', 'role'),
-                  defaultValue: 'Create roles to grant permissions',
-                })}
-              </p>
-            </div>
-          )}
+          <ResourceTableView
+            table={table}
+            columnCount={tableColumns.length}
+            isLoading={isLoading}
+            data={roles}
+            allPageSize={data?.total ?? 0}
+            emptyState={
+              isLoading ? (
+                <div className="flex items-center justify-center py-8">
+                  <div className="text-muted-foreground">
+                    {t('common.messages.loading', 'Loading...')}
+                  </div>
+                </div>
+              ) : error ? (
+                <div className="flex items-center justify-center py-8">
+                  <div className="text-destructive">
+                    {t('common.messages.failedToLoad', {
+                      resource: t('common.fields.roles', 'roles'),
+                      defaultValue: 'Failed to load roles',
+                    })}
+                  </div>
+                </div>
+              ) : roles.length === 0 ? (
+                <div className="text-center py-8 text-muted-foreground">
+                  <IconShieldCheck className="h-12 w-12 mx-auto mb-4 opacity-50" />
+                  <p>
+                    {t('common.messages.noItemsConfigured', {
+                      resource: t('common.fields.roles', 'roles'),
+                      defaultValue: 'No roles configured',
+                    })}
+                  </p>
+                  <p className="text-sm mt-1">
+                    {t('common.messages.createFirstItem', {
+                      resource: t('common.fields.role', 'role'),
+                      defaultValue: 'Create roles to grant permissions',
+                    })}
+                  </p>
+                </div>
+              ) : null
+            }
+            hasActiveFilters={false}
+            filteredRowCount={roles.length}
+            totalRowCount={data?.total ?? 0}
+            searchQuery=""
+            pagination={pagination}
+            setPagination={setPagination}
+            maxBodyHeightClassName="max-h-[600px]"
+          />
         </CardContent>
       </Card>
 

--- a/ui/src/components/settings/settings-sections.tsx
+++ b/ui/src/components/settings/settings-sections.tsx
@@ -7,6 +7,7 @@ import { AuthenticationManagement } from './authentication-management'
 import { ClusterManagement } from './cluster-management'
 import { GeneralManagement } from './general-management'
 import { RBACManagement } from './rbac-management'
+import { SMTPManagement } from './smtp-management'
 import { TemplateManagement } from './template-management'
 import { UserManagement } from './user-management'
 
@@ -49,6 +50,12 @@ export const settingsSectionRegistry: SettingsSectionDefinition[] = [
     'settings.tabs.oauth',
     'Authentication',
     AuthenticationManagement
+  ),
+  createSettingsSectionDefinition(
+    'smtp',
+    'settings.tabs.smtp',
+    'SMTP',
+    SMTPManagement
   ),
   createSettingsSectionDefinition(
     'rbac',

--- a/ui/src/components/settings/smtp-management.tsx
+++ b/ui/src/components/settings/smtp-management.tsx
@@ -1,0 +1,276 @@
+import { useEffect, useState } from 'react'
+import { Mail } from 'lucide-react'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { useTranslation } from 'react-i18next'
+import { toast } from 'sonner'
+
+import {
+  SMTPSettingUpdateRequest,
+  sendTestEmail,
+  updateSMTPSetting,
+  useSMTPSetting,
+} from '@/lib/api'
+import { translateError } from '@/lib/utils'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Switch } from '@/components/ui/switch'
+
+interface SMTPFormData {
+  enabled: boolean
+  host: string
+  port: number
+  username: string
+  password: string
+  passwordConfigured: boolean
+  fromEmail: string
+  useTLS: boolean
+  envManaged: boolean
+}
+
+export function SMTPManagement() {
+  const { t } = useTranslation()
+  const queryClient = useQueryClient()
+  const { data, isLoading } = useSMTPSetting()
+  const [formData, setFormData] = useState<SMTPFormData>({
+    enabled: false,
+    host: '',
+    port: 587,
+    username: '',
+    password: '',
+    passwordConfigured: false,
+    fromEmail: '',
+    useTLS: true,
+    envManaged: false,
+  })
+  const [testEmail, setTestEmail] = useState('')
+
+  useEffect(() => {
+    if (!data) return
+    setFormData({
+      enabled: data.enabled,
+      host: data.host,
+      port: data.port,
+      username: data.username,
+      password: '',
+      passwordConfigured: data.passwordConfigured,
+      fromEmail: data.fromEmail,
+      useTLS: data.useTLS,
+      envManaged: data.envManaged,
+    })
+  }, [data])
+
+  const saveMutation = useMutation({
+    mutationFn: (data: SMTPSettingUpdateRequest) => updateSMTPSetting(data),
+    onSuccess: () => {
+      toast.success(t('common.actions.saved', 'Saved'))
+      queryClient.invalidateQueries({ queryKey: ['smtp-setting'] })
+    },
+    onError: (error) => {
+      toast.error(translateError(error, t))
+    },
+  })
+
+  const testEmailMutation = useMutation({
+    mutationFn: (to: string) => sendTestEmail(to),
+    onSuccess: () => {
+      toast.success(
+        t('settings.smtp.testEmailSent', 'Test email sent successfully')
+      )
+    },
+    onError: (error) => {
+      toast.error(
+        translateError(error, t)
+      )
+    },
+  })
+
+  const handleSave = () => {
+    const updates: SMTPSettingUpdateRequest = {
+      enabled: formData.enabled,
+      host: formData.host,
+      port: formData.port,
+      username: formData.username,
+      fromEmail: formData.fromEmail,
+      useTLS: formData.useTLS,
+    }
+    if (formData.password) {
+      updates.password = formData.password
+    }
+    saveMutation.mutate(updates)
+  }
+
+  const handleSendTest = () => {
+    if (!testEmail.trim()) return
+    testEmailMutation.mutate(testEmail.trim())
+  }
+
+  if (isLoading) {
+    return null
+  }
+
+  const envManaged = formData.envManaged
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Mail className="h-5 w-5" />
+          {t('settings.smtp.title', 'SMTP')}
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {envManaged && (
+          <p className="text-sm text-muted-foreground">
+            {t(
+              'settings.smtp.envManaged',
+              'SMTP is managed by environment variables and cannot be modified through the UI'
+            )}
+          </p>
+        )}
+        <div className="flex items-center justify-between">
+          <Label htmlFor="smtp-enabled">
+            {t('settings.smtp.enabled', 'Enabled')}
+          </Label>
+          <Switch
+            id="smtp-enabled"
+            checked={formData.enabled}
+            disabled={envManaged}
+            onCheckedChange={(checked) =>
+              setFormData({ ...formData, enabled: checked })
+            }
+          />
+        </div>
+        {formData.enabled && (
+          <div className="grid gap-4 md:grid-cols-2">
+            <div className="space-y-2">
+              <Label htmlFor="smtp-host">
+                {t('settings.smtp.host', 'Host')}
+              </Label>
+              <Input
+                id="smtp-host"
+                placeholder={t('settings.smtp.hostPlaceholder', 'smtp.example.com')}
+                disabled={envManaged}
+                value={formData.host}
+                onChange={(e) => setFormData({ ...formData, host: e.target.value })}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="smtp-port">
+                {t('settings.smtp.port', 'Port')}
+              </Label>
+              <Input
+                id="smtp-port"
+                type="number"
+                disabled={envManaged}
+                value={formData.port}
+                onChange={(e) =>
+                  setFormData({ ...formData, port: parseInt(e.target.value) || 587 })
+                }
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="smtp-username">
+                {t('settings.smtp.username', 'Username')}
+              </Label>
+              <Input
+                id="smtp-username"
+                placeholder={t('settings.smtp.usernamePlaceholder', 'user@example.com')}
+                disabled={envManaged}
+                value={formData.username}
+                onChange={(e) =>
+                  setFormData({ ...formData, username: e.target.value })
+                }
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="smtp-password">
+                {t('settings.smtp.password', 'Password')}
+              </Label>
+              <Input
+                id="smtp-password"
+                type="password"
+                placeholder={
+                  formData.passwordConfigured
+                    ? t('settings.smtp.passwordPlaceholder', 'Leave blank to keep current password')
+                    : ''
+                }
+                disabled={envManaged}
+                value={formData.password}
+                onChange={(e) =>
+                  setFormData({ ...formData, password: e.target.value })
+                }
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="smtp-from-email">
+                {t('settings.smtp.fromEmail', 'From Email')}
+              </Label>
+              <Input
+                id="smtp-from-email"
+                type="email"
+                placeholder={t('settings.smtp.fromEmailPlaceholder', 'noreply@example.com')}
+                disabled={envManaged}
+                value={formData.fromEmail}
+                onChange={(e) =>
+                  setFormData({ ...formData, fromEmail: e.target.value })
+                }
+              />
+            </div>
+            <div className="flex items-center justify-between">
+              <Label htmlFor="smtp-use-tls">
+                {t('settings.smtp.useTLS', 'Use TLS')}
+              </Label>
+              <Switch
+                id="smtp-use-tls"
+                checked={formData.useTLS}
+                disabled={envManaged}
+                onCheckedChange={(checked) =>
+                  setFormData({ ...formData, useTLS: checked })
+                }
+              />
+            </div>
+          </div>
+        )}
+        {!envManaged && (
+          <div className="flex justify-end">
+            <Button onClick={handleSave} disabled={saveMutation.isPending}>
+              {saveMutation.isPending
+                ? t('common.actions.saving', 'Saving...')
+                : t('settings.smtp.save', 'Save')}
+            </Button>
+          </div>
+        )}
+        <div className="space-y-2 border-t pt-4">
+          <Label>{t('settings.smtp.testEmail', 'Test Email')}</Label>
+          <p className="text-sm text-muted-foreground">
+            {t(
+              'settings.smtp.testEmailDescription',
+              'Send a test email to verify SMTP configuration'
+            )}
+          </p>
+          <div className="flex gap-2">
+            <Input
+              placeholder={t(
+                'settings.smtp.testEmailRecipientPlaceholder',
+                'test@example.com'
+              )}
+              value={testEmail}
+              onChange={(e) => setTestEmail(e.target.value)}
+            />
+            <Button
+              variant="outline"
+              onClick={handleSendTest}
+              disabled={testEmailMutation.isPending || !testEmail.trim()}
+            >
+              {testEmailMutation.isPending
+                ? t('common.actions.sending', 'Sending...')
+                : t('settings.smtp.sendTest', 'Send Test')}
+            </Button>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/ui/src/components/settings/user-management.tsx
+++ b/ui/src/components/settings/user-management.tsx
@@ -598,7 +598,7 @@ export function UserManagement() {
             searchQuery={searchQuery}
             pagination={pagination}
             setPagination={setPagination}
-            maxBodyHeightClassName="max-h-[600px]"
+            fitViewportHeight
           />
         </CardContent>
       </Card>

--- a/ui/src/components/site-header.tsx
+++ b/ui/src/components/site-header.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import { useAuth } from '@/contexts/auth-context'
 import { useTerminal } from '@/contexts/terminal-context'
-import { Plus, Settings, TerminalSquare } from 'lucide-react'
+import { Download, Plus, Settings, TerminalSquare } from 'lucide-react'
 import { useNavigate } from 'react-router-dom'
 
 import { useIsMobile } from '@/hooks/use-mobile'
@@ -11,6 +11,7 @@ import { SidebarTrigger } from '@/components/ui/sidebar'
 
 import { CreateResourceDialog } from './create-resource-dialog'
 import { DynamicBreadcrumb } from './dynamic-breadcrumb'
+import { KubeconfigDownloadDialog } from './kubeconfig-download-dialog'
 import { LanguageToggle } from './language-toggle'
 import { ModeToggle } from './mode-toggle'
 import { Search } from './search'
@@ -22,6 +23,7 @@ export function SiteHeader() {
   const { user, capabilities } = useAuth()
   const { toggleTerminal, isOpen } = useTerminal()
   const [createDialogOpen, setCreateDialogOpen] = useState(false)
+  const [kubeconfigDialogOpen, setKubeconfigDialogOpen] = useState(false)
   const isAdmin = user?.isAdmin() ?? false
   const kubectlEnabled = capabilities.kubectlEnabled
 
@@ -56,6 +58,14 @@ export function SiteHeader() {
                 <TerminalSquare className="h-5 w-5" />
               </button>
             )}
+            <button
+              onClick={() => setKubeconfigDialogOpen(true)}
+              title="Download Kubeconfig"
+              aria-label="Download Kubeconfig"
+              className="flex items-center justify-center rounded-sm p-1 text-muted-foreground hover:text-foreground"
+            >
+              <Download className="h-5 w-5" />
+            </button>
             {!isMobile && (
               <>
                 <Separator
@@ -88,6 +98,11 @@ export function SiteHeader() {
           onOpenChange={setCreateDialogOpen}
         />
       ) : null}
+
+      <KubeconfigDownloadDialog
+        open={kubeconfigDialogOpen}
+        onOpenChange={setKubeconfigDialogOpen}
+      />
     </>
   )
 }

--- a/ui/src/components/user-menu.tsx
+++ b/ui/src/components/user-menu.tsx
@@ -47,7 +47,6 @@ export function UserMenu() {
   const [open, setOpen] = useState(false)
   const [accountSettingsOpen, setAccountSettingsOpen] = useState(false)
   const [scaleInput, setScaleInput] = useState(String(displayScale))
-  const isPasswordUser = !user?.provider || user.provider === 'password'
 
   if (!user) return null
 
@@ -135,7 +134,7 @@ export function UserMenu() {
 
           <DropdownMenuSeparator />
 
-          {isPasswordUser && (
+          {user.provider !== 'Anonymous' && (
             <>
               <DropdownMenuItem
                 onSelect={() => {
@@ -302,7 +301,7 @@ export function UserMenu() {
         </DropdownMenuContent>
       </DropdownMenu>
 
-      {isPasswordUser && (
+      {user.provider !== 'Anonymous' && (
         <AccountSettingsDialog
           open={accountSettingsOpen}
           onOpenChange={setAccountSettingsOpen}

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -263,6 +263,7 @@
       "noErrorMessage": "No error message",
       "noItemsConfigured": "No {{resource}} configured",
       "noItemsFound": "No {{resource}} found",
+      "noAPIKeysFound": "No API keys found",
       "noOwner": "No owner",
       "noPods": "No pods found",
       "noUsersFound": "No users found",
@@ -328,6 +329,8 @@
       "searchUsers": "Search users...",
       "selectTemplate": "Select a template",
       "selectUser": "Select user",
+      "selectAPIKey": "Select API key",
+      "searchAPIKeys": "Search API keys...",
       "subject": "username or group name",
       "tokenUrl": "https://provider.com/oauth/token",
       "userInfoUrl": "https://provider.com/oauth/userinfo",
@@ -1017,6 +1020,8 @@
     "table": {
       "prometheus": "Prometheus"
     },
+    "connectorVersion": "Connector Version",
+    "needsUpgrade": "Needs upgrade",
     "type": {
       "inCluster": "In-Cluster",
       "external": "External",
@@ -1028,14 +1033,15 @@
     },
     "connector": {
       "title": "Connect Kite Connector",
-      "description": "Choose a command or Kubernetes YAML to run inside the target cluster. This connection information is shown only once.",
+      "description": "Choose one of the following methods to run inside the target cluster. This connection information is shown only once.",
       "command": "Command",
       "yaml": "Kubernetes YAML",
+      "runCommand": "Run Connector directly",
       "copyCommand": "Copy command",
       "copyYaml": "Copy YAML",
-      "applyUrl": "Apply directly with URL",
+      "applyUrl": "Deploy via Kubernetes YAML URL",
       "copyApplyCommand": "Copy apply command",
-      "orUseYaml": "Or deploy with YAML",
+      "copyYamlManually": "Copy Kubernetes YAML manually",
       "loadYamlError": "Failed to load YAML from the manifest URL.",
       "copyError": "Failed to copy. Copy the content manually."
     },

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -19,6 +19,8 @@
       "describe": "Describe",
       "disable": "Disable",
       "done": "Done",
+      "download": "Download",
+      "downloading": "Downloading...",
       "drain": "Drain",
       "edit": "Edit",
       "enable": "Enable",
@@ -893,7 +895,8 @@
     "actions": {
       "add": "Add Cluster",
       "import": "Import Clusters",
-      "importing": "Importing..."
+      "importing": "Importing...",
+      "downloadKubeconfig": "Download Kubeconfig"
     },
     "table": {
       "prometheus": "Prometheus"
@@ -957,6 +960,15 @@
       "connectorDescription": "Create the cluster first, then run the generated command inside the target cluster.",
       "enabled": "Enabled",
       "isDefault": "Set as Default"
+    },
+    "kubeconfig": {
+      "title": "Download Kubeconfig",
+      "description": "Generate a kubeconfig that uses Kite as a proxy to access the cluster.",
+      "clusters": "Clusters",
+      "showAll": "Show all ({{count}})",
+      "noCluster": "Please select a cluster first",
+      "downloaded": "Kubeconfig downloaded",
+      "downloadError": "Download failed"
     }
   },
   "oauthManagement": {

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -9,6 +9,7 @@
       "close": "Close",
       "clone": "Clone",
       "confirm": "Confirm",
+      "continue": "Continue",
       "copy": "Copy",
       "collapse": "Collapse",
       "cordon": "Cordon",
@@ -208,6 +209,7 @@
       "user": "User",
       "username": "Username",
       "usernameClaim": "Username Claim",
+      "nameClaim": "Name Claim",
       "users": "Users",
       "value": "Value",
       "variables": "Variables",
@@ -310,6 +312,7 @@
       "emptyTemplate": "Empty Template",
       "no": "No",
       "none": "None",
+      "notSet": "Not set",
       "or": "or",
       "required": "This field is required",
       "yes": "Yes"
@@ -328,7 +331,8 @@
       "subject": "username or group name",
       "tokenUrl": "https://provider.com/oauth/token",
       "userInfoUrl": "https://provider.com/oauth/userinfo",
-      "usernameClaim": "e.g., preferred_username"
+      "usernameClaim": "e.g., preferred_username",
+      "nameClaim": "e.g., given_name"
     }
   },
   "globalSearch": {
@@ -739,7 +743,11 @@
   },
   "errors": {
     "crdNotInstalledTitle": "Resource Type Not Available",
-    "crdNotInstalled": "The {{kind}} resource type ({{version}}) is not installed in this cluster. Install the required CRD to use this feature."
+    "crdNotInstalled": "The {{kind}} resource type ({{version}}) is not installed in this cluster. Install the required CRD to use this feature.",
+    "noPermission": {
+      "title": "Access Denied",
+      "adminRequired": "You do not have permission to access this page."
+    }
   },
   "rbac": {
     "noPermissionCluster": "User {{user}} does not have permission to {{verb}} {{resource}} on cluster {{cluster}}",
@@ -769,8 +777,114 @@
       "clusters": "Cluster",
       "general": "General",
       "oauth": "Authentication",
+      "smtp": "SMTP",
       "rbac": "RBAC",
       "users": "User"
+    },
+    "oauth": {
+      "emailClaim": "Email Claim",
+      "emailClaimPlaceholder": "e.g., email, mail, userPrincipalName"
+    },
+    "smtp": {
+      "title": "SMTP",
+      "description": "Configure email server for sending verification codes",
+      "enabled": "Enabled",
+      "host": "Host",
+      "hostPlaceholder": "smtp.example.com",
+      "port": "Port",
+      "username": "Username",
+      "usernamePlaceholder": "user@example.com",
+      "password": "Password",
+      "passwordPlaceholder": "Leave blank to keep current password",
+      "fromEmail": "From Email",
+      "fromEmailPlaceholder": "noreply@example.com",
+      "useTLS": "Use TLS",
+      "save": "Save",
+      "testEmail": "Test Email",
+      "testEmailDescription": "Send a test email to verify SMTP configuration",
+      "testEmailRecipient": "Recipient",
+      "testEmailRecipientPlaceholder": "test@example.com",
+      "sendTest": "Send Test",
+      "testEmailSent": "Test email sent successfully",
+      "envManaged": "SMTP is managed by environment variables and cannot be modified through the UI"
+    }
+  },
+  "accountSettings": {
+    "title": "Account Settings",
+    "tabs": {
+      "profile": "Profile",
+      "password": "Password",
+      "security": "Security"
+    },
+    "profile": {
+      "nickname": "Nickname",
+      "email": "Email",
+      "newEmail": "New Email",
+      "saveButton": "Save Profile",
+      "managedByProvider": "This information is managed by your identity provider",
+      "saved": "Account updated",
+      "error": "Failed to update account",
+      "emailSaved": "Email updated",
+      "emailError": "Failed to update email",
+      "verifyEmailTitle": "Verify Email Change",
+      "verifyEmailDescription": "Enter your current password and the verification code sent to your new email to save changes.",
+      "codeSentTo": "Verification code will be sent to: {{email}}",
+      "notProvidedByProvider": "Not provided by identity provider"
+    },
+    "password": {
+      "currentPassword": "Current Password",
+      "newPassword": "New Password",
+      "confirmNewPassword": "Confirm New Password",
+      "changeButton": "Change Password",
+      "mismatch": "New passwords do not match",
+      "changed": "Password changed",
+      "error": "Failed to change password"
+    },
+    "security": {
+      "mfa": {
+        "setupButton": "Set Up MFA",
+        "enableButton": "Enable MFA",
+        "disableButton": "Disable MFA",
+        "authCode": "Authentication Code",
+        "qrCodeAlt": "MFA QR code",
+        "otpauthUrl": "otpauth URL",
+        "enabled": "MFA enabled",
+        "disabled": "MFA disabled",
+        "enableError": "Failed to enable MFA",
+        "disableError": "Failed to disable MFA",
+        "setupError": "Failed to set up MFA"
+      },
+      "passkeys": {
+        "title": "Passkeys",
+        "namePlaceholder": "Passkey name",
+        "addButton": "Add Passkey",
+        "empty": "No passkeys added.",
+        "lastUsed": "Last used {{date}}",
+        "addedOn": "Added {{date}}",
+        "deleteAriaLabel": "Delete {{name}}",
+        "added": "Passkey added",
+        "deleted": "Passkey deleted",
+        "loadError": "Failed to load passkeys",
+        "addError": "Failed to add passkey",
+        "deleteError": "Failed to delete passkey"
+      },
+      "confirmPassword": {
+        "title": "Confirm password",
+        "description": "Enter your current password to continue."
+      },
+      "confirmMFA": {
+        "title": "Confirm with MFA",
+        "description": "Enter your authentication code to continue."
+      },
+      "confirmEmail": {
+        "title": "Confirm with email",
+        "description": "Enter the verification code sent to your email to continue."
+      },
+      "emailCode": "Email Verification Code",
+      "sendCode": "Send Code",
+      "resendIn": "Resend in {{seconds}}s",
+      "verificationCodeSent": "Verification code sent",
+      "sendCodeError": "Failed to send verification code"
     }
   },
   "generalManagement": {
@@ -858,6 +972,8 @@
         "userFilter": "User Filter",
         "usernameAttribute": "Username Attribute",
         "displayNameAttribute": "Display Name Attribute",
+        "emailAttribute": "Email Attribute",
+        "emailAttributePlaceholder": "mail",
         "groupBaseDn": "Group Base DN",
         "groupFilter": "Group Filter",
         "groupNameAttribute": "Group Name Attribute"

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -45,6 +45,7 @@
       "scale": "Scale",
       "search": "Search",
       "show": "Show",
+      "showMore": "Show more",
       "assigning": "Assigning...",
       "removing": "Removing...",
       "taint": "Taint",

--- a/ui/src/i18n/locales/zh.json
+++ b/ui/src/i18n/locales/zh.json
@@ -45,6 +45,7 @@
       "scale": "扩缩容",
       "search": "搜索",
       "show": "显示",
+      "showMore": "显示更多",
       "assigning": "分配中...",
       "removing": "移除中...",
       "taint": "污点",

--- a/ui/src/i18n/locales/zh.json
+++ b/ui/src/i18n/locales/zh.json
@@ -19,6 +19,8 @@
       "describe": "描述",
       "disable": "禁用",
       "done": "完成",
+      "download": "下载",
+      "downloading": "下载中...",
       "drain": "驱逐",
       "edit": "编辑",
       "enable": "启用",
@@ -904,7 +906,8 @@
     "actions": {
       "add": "添加集群",
       "import": "导入集群",
-      "importing": "导入中..."
+      "importing": "导入中...",
+      "downloadKubeconfig": "下载 Kubeconfig"
     },
     "table": {
       "prometheus": "Prometheus"
@@ -968,6 +971,15 @@
       "connectorDescription": "先创建集群，然后在目标集群内运行生成的命令。",
       "enabled": "启用",
       "isDefault": "设为默认"
+    },
+    "kubeconfig": {
+      "title": "下载 Kubeconfig",
+      "description": "生成以 Kite 为代理访问集群的 kubeconfig。",
+      "clusters": "集群",
+      "showAll": "显示全部 ({{count}})",
+      "noCluster": "请先选择一个集群",
+      "downloaded": "Kubeconfig 已下载",
+      "downloadError": "下载失败"
     }
   },
   "oauthManagement": {

--- a/ui/src/i18n/locales/zh.json
+++ b/ui/src/i18n/locales/zh.json
@@ -9,6 +9,7 @@
       "close": "关闭",
       "clone": "克隆",
       "confirm": "确认",
+      "continue": "继续",
       "copy": "复制",
       "collapse": "收起",
       "cordon": "停止调度",
@@ -208,6 +209,7 @@
       "user": "用户",
       "username": "用户名",
       "usernameClaim": "用户名 Claim",
+      "nameClaim": "昵称 Claim",
       "users": "用户",
       "value": "值",
       "variables": "变量",
@@ -310,6 +312,7 @@
       "emptyTemplate": "空模板",
       "no": "否",
       "none": "无",
+      "notSet": "未设置",
       "or": "或",
       "required": "必填",
       "yes": "是"
@@ -328,7 +331,8 @@
       "subject": "用户名或用户组名称",
       "tokenUrl": "https://provider.com/oauth/token",
       "userInfoUrl": "https://provider.com/oauth/userinfo",
-      "usernameClaim": "例如：preferred_username"
+      "usernameClaim": "例如：preferred_username",
+      "nameClaim": "例如：given_name"
     }
   },
   "globalSearch": {
@@ -744,7 +748,11 @@
   },
   "errors": {
     "crdNotInstalledTitle": "资源类型不可用",
-    "crdNotInstalled": "此集群未安装 {{kind}} ({{version}})。请先安装对应的 CRD。"
+    "crdNotInstalled": "此集群未安装 {{kind}} ({{version}})。请先安装对应的 CRD。",
+    "noPermission": {
+      "title": "无权访问",
+      "adminRequired": "您没有权限访问此页面。"
+    }
   },
   "rbac": {
     "title": "RBAC 管理",
@@ -779,9 +787,115 @@
       "clusters": "集群",
       "general": "通用",
       "oauth": "认证",
+      "smtp": "SMTP",
       "rbac": "RBAC",
       "users": "用户",
       "apikeys": "API 密钥"
+    },
+    "oauth": {
+      "emailClaim": "邮箱 Claim",
+      "emailClaimPlaceholder": "例如 email, mail, userPrincipalName"
+    },
+    "smtp": {
+      "title": "SMTP",
+      "description": "配置邮件服务器以发送验证码",
+      "enabled": "启用",
+      "host": "主机",
+      "hostPlaceholder": "smtp.example.com",
+      "port": "端口",
+      "username": "用户名",
+      "usernamePlaceholder": "user@example.com",
+      "password": "密码",
+      "passwordPlaceholder": "留空保留当前密码",
+      "fromEmail": "发件邮箱",
+      "fromEmailPlaceholder": "noreply@example.com",
+      "useTLS": "使用 TLS",
+      "save": "保存",
+      "testEmail": "测试邮件",
+      "testEmailDescription": "发送测试邮件以验证 SMTP 配置",
+      "testEmailRecipient": "收件人",
+      "testEmailRecipientPlaceholder": "test@example.com",
+      "sendTest": "发送测试",
+      "testEmailSent": "测试邮件发送成功",
+      "envManaged": "SMTP 由环境变量管理，无法通过界面修改"
+    }
+  },
+  "accountSettings": {
+    "title": "账户设置",
+    "tabs": {
+      "profile": "个人资料",
+      "password": "密码",
+      "security": "安全"
+    },
+    "profile": {
+      "nickname": "昵称",
+      "email": "邮箱",
+      "newEmail": "新邮箱",
+      "saveButton": "保存资料",
+      "managedByProvider": "以上信息由身份提供商管理",
+      "saved": "账户已更新",
+      "error": "更新账户失败",
+      "emailSaved": "邮箱已更新",
+      "emailError": "更新邮箱失败",
+      "verifyEmailTitle": "验证邮箱变更",
+      "verifyEmailDescription": "输入当前密码和发送到新邮箱的验证码以保存更改。",
+      "codeSentTo": "验证码将发送至：{{email}}",
+      "notProvidedByProvider": "身份提供商未提供"
+    },
+    "password": {
+      "currentPassword": "当前密码",
+      "newPassword": "新密码",
+      "confirmNewPassword": "确认新密码",
+      "changeButton": "修改密码",
+      "mismatch": "两次输入的新密码不一致",
+      "changed": "密码已修改",
+      "error": "修改密码失败"
+    },
+    "security": {
+      "mfa": {
+        "setupButton": "设置 MFA",
+        "enableButton": "启用 MFA",
+        "disableButton": "禁用 MFA",
+        "authCode": "验证码",
+        "qrCodeAlt": "MFA 二维码",
+        "otpauthUrl": "otpauth URL",
+        "enabled": "MFA 已启用",
+        "disabled": "MFA 已禁用",
+        "enableError": "启用 MFA 失败",
+        "disableError": "禁用 MFA 失败",
+        "setupError": "设置 MFA 失败"
+      },
+      "passkeys": {
+        "title": "Passkey",
+        "namePlaceholder": "Passkey 名称",
+        "addButton": "添加 Passkey",
+        "empty": "尚未添加 Passkey。",
+        "lastUsed": "上次使用 {{date}}",
+        "addedOn": "添加于 {{date}}",
+        "deleteAriaLabel": "删除 {{name}}",
+        "added": "Passkey 已添加",
+        "deleted": "Passkey 已删除",
+        "loadError": "加载 Passkey 列表失败",
+        "addError": "添加 Passkey 失败",
+        "deleteError": "删除 Passkey 失败"
+      },
+      "confirmPassword": {
+        "title": "确认密码",
+        "description": "输入当前密码以继续。"
+      },
+      "confirmMFA": {
+        "title": "通过 MFA 确认",
+        "description": "输入验证码以继续。"
+      },
+      "confirmEmail": {
+        "title": "邮箱验证",
+        "description": "输入发送到您邮箱的验证码以继续。"
+      },
+      "emailCode": "邮箱验证码",
+      "sendCode": "发送验证码",
+      "resendIn": "{{seconds}}秒后可重发",
+      "verificationCodeSent": "验证码已发送",
+      "sendCodeError": "发送验证码失败"
     }
   },
   "generalManagement": {
@@ -869,6 +983,8 @@
         "userFilter": "用户过滤器",
         "usernameAttribute": "用户名属性",
         "displayNameAttribute": "显示名属性",
+        "emailAttribute": "邮箱属性",
+        "emailAttributePlaceholder": "mail",
         "groupBaseDn": "用户组 Base DN",
         "groupFilter": "用户组过滤器",
         "groupNameAttribute": "用户组名称属性"

--- a/ui/src/i18n/locales/zh.json
+++ b/ui/src/i18n/locales/zh.json
@@ -263,6 +263,7 @@
       "noErrorMessage": "没有错误信息",
       "noItemsConfigured": "暂无{{resource}}",
       "noItemsFound": "暂无{{resource}}",
+      "noAPIKeysFound": "暂无 API Key",
       "noOwner": "无 Owner",
       "noPods": "暂无 Pods",
       "noUsersFound": "暂无用户",
@@ -328,6 +329,8 @@
       "searchUsers": "搜索用户...",
       "selectTemplate": "选择模板",
       "selectUser": "选择用户",
+      "selectAPIKey": "选择 API Key",
+      "searchAPIKeys": "搜索 API Key...",
       "subject": "用户名或用户组名称",
       "tokenUrl": "https://provider.com/oauth/token",
       "userInfoUrl": "https://provider.com/oauth/userinfo",
@@ -1028,6 +1031,8 @@
     "table": {
       "prometheus": "Prometheus"
     },
+    "connectorVersion": "Connector 版本",
+    "needsUpgrade": "需升级",
     "type": {
       "inCluster": "集群内",
       "external": "外部",
@@ -1039,14 +1044,15 @@
     },
     "connector": {
       "title": "连接 Kite Connector",
-      "description": "选择命令行或 Kubernetes YAML 在目标集群中运行。此连接信息仅显示一次。",
+      "description": "选择以下任一方式在目标集群中运行。此连接信息仅显示一次。",
       "command": "命令行",
       "yaml": "Kubernetes YAML",
+      "runCommand": "直接运行 Connector 命令",
       "copyCommand": "复制命令行",
       "copyYaml": "复制 YAML",
-      "applyUrl": "通过 URL 直接部署",
+      "applyUrl": "通过 Kubernetes YAML URL 直接部署",
       "copyApplyCommand": "复制部署命令",
-      "orUseYaml": "或使用 YAML 部署",
+      "copyYamlManually": "复制 Kubernetes YAML 手动部署",
       "loadYamlError": "无法通过 Manifest URL 加载 YAML。",
       "copyError": "复制失败，请手动复制内容。"
     },

--- a/ui/src/lib/api-client.ts
+++ b/ui/src/lib/api-client.ts
@@ -1,4 +1,6 @@
 // API client with authentication support
+import i18next from 'i18next'
+
 import { appendCurrentClusterHeader } from './current-cluster'
 import { withSubPath } from './subpath'
 
@@ -46,6 +48,10 @@ class ApiClient {
 
     const headers: Record<string, string> = {
       ...(options.headers as Record<string, string>),
+    }
+
+    if (!headers['Accept-Language']) {
+      headers['Accept-Language'] = i18next.language || 'en'
     }
 
     // Only set default Content-Type to application/json if not already set and body is not FormData

--- a/ui/src/lib/api/admin.ts
+++ b/ui/src/lib/api/admin.ts
@@ -194,7 +194,7 @@ export const assignRole = async (
 
 export const unassignRole = async (
   id: number,
-  subjectType: 'user' | 'group',
+  subjectType: 'user' | 'group' | 'apikey',
   subject: string
 ) => {
   const params = new URLSearchParams({ subjectType, subject })
@@ -551,6 +551,20 @@ export const useAPIKeyList = (options?: { staleTime?: number }) => {
   return useQuery({
     queryKey: ['apikey-list'],
     queryFn: fetchAPIKeyList,
+    staleTime: options?.staleTime || 30000,
+  })
+}
+
+export const fetchIndependentAPIKeys = async (): Promise<APIKey[]> => {
+  return fetchAPI<{ apiKeys: APIKey[] }>('/admin/apikeys/independent').then(
+    (response) => response.apiKeys
+  )
+}
+
+export const useIndependentAPIKeyList = (options?: { staleTime?: number }) => {
+  return useQuery({
+    queryKey: ['apikey-list-independent'],
+    queryFn: fetchIndependentAPIKeys,
     staleTime: options?.staleTime || 30000,
   })
 }

--- a/ui/src/lib/api/admin.ts
+++ b/ui/src/lib/api/admin.ts
@@ -1,4 +1,4 @@
-import { useQuery } from '@tanstack/react-query'
+import { keepPreviousData, useQuery } from '@tanstack/react-query'
 
 import {
   APIKey,
@@ -271,6 +271,7 @@ export const useUserList = (
     queryKey: ['user-list', page, size, search, sortBy, sortOrder, role],
     queryFn: () => fetchUserList(page, size, search, sortBy, sortOrder, role),
     staleTime: 20000,
+    placeholderData: keepPreviousData,
   })
 }
 
@@ -350,6 +351,7 @@ export const useAuditLogs = (
         namespace
       ),
     staleTime: 20000,
+    placeholderData: keepPreviousData,
   })
 }
 // API Key Management

--- a/ui/src/lib/api/admin.ts
+++ b/ui/src/lib/api/admin.ts
@@ -2,11 +2,14 @@ import { keepPreviousData, useQuery } from '@tanstack/react-query'
 
 import {
   APIKey,
+  APIKeyListResponse,
   AuditLogResponse,
   Cluster,
+  ClusterListResponse,
   FetchUserListResponse,
   OAuthProvider,
   Role,
+  RoleListResponse,
   UserItem,
 } from '@/types/api'
 
@@ -28,8 +31,11 @@ export interface ClusterUpdateRequest extends ClusterCreateRequest {
 }
 
 // Get cluster list for management
-export const fetchClusterList = (): Promise<Cluster[]> => {
-  return fetchAPI<Cluster[]>('/admin/clusters/')
+export const fetchClusterList = async (): Promise<Cluster[]> => {
+  const resp = await fetchAPI<{ data: Cluster[]; total: number }>(
+    '/admin/clusters/?page=1&size=10000'
+  )
+  return resp.data
 }
 
 export const useClusterList = (options?: {
@@ -41,6 +47,30 @@ export const useClusterList = (options?: {
     queryFn: fetchClusterList,
     staleTime: options?.staleTime ?? 30000, // 30 seconds cache
     refetchInterval: options?.refetchInterval,
+  })
+}
+
+// Paginated cluster list for management page
+export const fetchClusterListPaged = async (
+  page: number,
+  size: number
+): Promise<ClusterListResponse> => {
+  return fetchAPI<ClusterListResponse>(
+    `/admin/clusters/?page=${page}&size=${size}`
+  )
+}
+
+export const useClusterListPaged = (
+  page: number,
+  size: number,
+  options?: { staleTime?: number; refetchInterval?: number | false }
+) => {
+  return useQuery<ClusterListResponse, Error>({
+    queryKey: ['cluster-list-paged', page, size],
+    queryFn: () => fetchClusterListPaged(page, size),
+    staleTime: options?.staleTime ?? 30000,
+    refetchInterval: options?.refetchInterval,
+    placeholderData: keepPreviousData,
   })
 }
 
@@ -162,7 +192,10 @@ export const fetchOAuthProvider = async (
 
 // RBAC API
 export const fetchRoleList = async (): Promise<Role[]> => {
-  return fetchAPI<{ roles: Role[] }>(`/admin/roles/`).then((resp) => resp.roles)
+  const resp = await fetchAPI<{ data: Role[]; total: number }>(
+    `/admin/roles/?page=1&size=10000`
+  )
+  return resp.data
 }
 
 export const useRoleList = (options?: { staleTime?: number }) => {
@@ -170,6 +203,25 @@ export const useRoleList = (options?: { staleTime?: number }) => {
     queryKey: ['role-list'],
     queryFn: fetchRoleList,
     staleTime: options?.staleTime || 30000,
+  })
+}
+
+// Paginated role list for management page
+export const fetchRoleListPaged = async (
+  page: number,
+  size: number
+): Promise<RoleListResponse> => {
+  return fetchAPI<RoleListResponse>(
+    `/admin/roles/?page=${page}&size=${size}`
+  )
+}
+
+export const useRoleListPaged = (page: number, size: number) => {
+  return useQuery<RoleListResponse, Error>({
+    queryKey: ['role-list-paged', page, size],
+    queryFn: () => fetchRoleListPaged(page, size),
+    staleTime: 30000,
+    placeholderData: keepPreviousData,
   })
 }
 
@@ -544,9 +596,10 @@ export const sendTestEmail = async (
 }
 
 export const fetchAPIKeyList = async (): Promise<APIKey[]> => {
-  return fetchAPI<{ apiKeys: APIKey[] }>('/admin/apikeys/').then(
-    (response) => response.apiKeys
+  const resp = await fetchAPI<{ data: APIKey[]; total: number }>(
+    '/admin/apikeys/?page=1&size=10000'
   )
+  return resp.data
 }
 
 export const useAPIKeyList = (options?: { staleTime?: number }) => {
@@ -554,6 +607,25 @@ export const useAPIKeyList = (options?: { staleTime?: number }) => {
     queryKey: ['apikey-list'],
     queryFn: fetchAPIKeyList,
     staleTime: options?.staleTime || 30000,
+  })
+}
+
+// Paginated API key list for management page
+export const fetchAPIKeyListPaged = async (
+  page: number,
+  size: number
+): Promise<APIKeyListResponse> => {
+  return fetchAPI<APIKeyListResponse>(
+    `/admin/apikeys/?page=${page}&size=${size}`
+  )
+}
+
+export const useAPIKeyListPaged = (page: number, size: number) => {
+  return useQuery<APIKeyListResponse, Error>({
+    queryKey: ['apikey-list-paged', page, size],
+    queryFn: () => fetchAPIKeyListPaged(page, size),
+    staleTime: 30000,
+    placeholderData: keepPreviousData,
   })
 }
 

--- a/ui/src/lib/api/admin.ts
+++ b/ui/src/lib/api/admin.ts
@@ -92,7 +92,9 @@ export interface OAuthProviderCreateRequest {
   scopes?: string
   issuer?: string
   usernameClaim?: string
+  nameClaim?: string
   groupsClaim?: string
+  emailClaim?: string
   allowedGroups?: string
   enabled?: boolean
 }
@@ -405,6 +407,7 @@ export interface LDAPSetting {
   userFilter: string
   usernameAttribute: string
   displayNameAttribute: string
+  emailAttribute: string
   groupBaseDn: string
   groupFilter: string
   groupNameAttribute: string
@@ -420,6 +423,7 @@ export interface LDAPSettingUpdateRequest {
   userFilter: string
   usernameAttribute: string
   displayNameAttribute: string
+  emailAttribute: string
   groupBaseDn: string
   groupFilter: string
   groupNameAttribute: string
@@ -482,6 +486,59 @@ export const updateLDAPSetting = async (
   data: LDAPSettingUpdateRequest
 ): Promise<LDAPSetting> => {
   return await apiClient.put<LDAPSetting>('/admin/ldap-setting/', data)
+}
+
+export interface SMTPSetting {
+  enabled: boolean
+  host: string
+  port: number
+  username: string
+  password: string
+  passwordConfigured: boolean
+  fromEmail: string
+  useTLS: boolean
+  envManaged: boolean
+}
+
+export interface SMTPSettingUpdateRequest {
+  enabled?: boolean
+  host?: string
+  port?: number
+  username?: string
+  password?: string
+  fromEmail?: string
+  useTLS?: boolean
+}
+
+export const fetchSMTPSetting = async (): Promise<SMTPSetting> => {
+  return fetchAPI<SMTPSetting>('/admin/smtp-setting/')
+}
+
+export const useSMTPSetting = (options?: {
+  staleTime?: number
+  enabled?: boolean
+}) => {
+  return useQuery({
+    queryKey: ['smtp-setting'],
+    queryFn: fetchSMTPSetting,
+    enabled: options?.enabled ?? true,
+    staleTime: options?.staleTime || 30000,
+  })
+}
+
+export const updateSMTPSetting = async (
+  data: SMTPSettingUpdateRequest
+): Promise<SMTPSetting> => {
+  return await apiClient.put<SMTPSetting>('/admin/smtp-setting/', data)
+}
+
+export const sendTestEmail = async (
+  to: string
+): Promise<{ message: string }> => {
+  return await apiClient.post<{ message: string }>(
+    '/admin/smtp-setting/test',
+    { to }
+  )
 }
 
 export const fetchAPIKeyList = async (): Promise<APIKey[]> => {

--- a/ui/src/lib/api/auth.ts
+++ b/ui/src/lib/api/auth.ts
@@ -12,6 +12,7 @@ export interface AuthUser {
   id: string
   username: string
   name: string
+  email?: string
   avatar_url: string
   provider: string
   mfa_enabled?: boolean
@@ -80,6 +81,24 @@ export const changeCurrentUserPassword = async (
   })
 }
 
+export const setUserEmail = async (
+  currentPassword: string,
+  email: string,
+  emailCode: string
+): Promise<void> => {
+  await authApiClient.post<void>('/users/me/email', {
+    current_password: currentPassword,
+    email,
+    email_code: emailCode,
+  })
+}
+
+export const sendEmailVerificationCode = async (
+  email?: string
+): Promise<void> => {
+  await authApiClient.post<void>('/users/me/email/send-code', email ? { email } : undefined)
+}
+
 export interface MFASetupResponse {
   secret: string
   otpauth_url: string
@@ -95,10 +114,12 @@ export interface PasskeyCredential {
 }
 
 export const setupCurrentUserMFA = async (
-  currentPassword: string
+  currentPassword?: string,
+  emailCode?: string
 ): Promise<MFASetupResponse> => {
   return authApiClient.post<MFASetupResponse>('/users/me/mfa/setup', {
-    current_password: currentPassword,
+    current_password: currentPassword || '',
+    ...(emailCode ? { email_code: emailCode } : {}),
   })
 }
 
@@ -123,15 +144,17 @@ export const listCurrentUserPasskeys = async (): Promise<
 
 export const beginCurrentUserPasskeyRegistration = async (
   name: string,
-  currentPassword: string,
-  mfaCode?: string
+  currentPassword?: string,
+  mfaCode?: string,
+  emailCode?: string
 ): Promise<WebAuthnCreationOptionsJSON> => {
   return authApiClient.post<WebAuthnCreationOptionsJSON>(
     '/users/me/passkeys/begin',
     {
       name,
-      current_password: currentPassword,
+      current_password: currentPassword || '',
       ...(mfaCode ? { mfa_code: mfaCode } : {}),
+      ...(emailCode ? { email_code: emailCode } : {}),
     }
   )
 }

--- a/ui/src/pages/settings.tsx
+++ b/ui/src/pages/settings.tsx
@@ -1,15 +1,35 @@
 import { useMemo } from 'react'
+import { ShieldAlert } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 
+import { useAuth } from '@/contexts/auth-context'
 import { usePageTitle } from '@/hooks/use-page-title'
 import { ResponsiveTabs } from '@/components/ui/responsive-tabs'
 import { createSettingsTabs } from '@/components/settings/settings-sections'
 
 export function SettingsPage() {
   const { t } = useTranslation()
+  const { user } = useAuth()
   const tabs = useMemo(() => createSettingsTabs(t), [t])
 
   usePageTitle('Settings')
+
+  if (!user?.isAdmin()) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-3 py-20">
+        <ShieldAlert className="h-12 w-12 text-muted-foreground" />
+        <p className="text-lg font-medium">
+          {t('errors.noPermission.title', 'Access Denied')}
+        </p>
+        <p className="text-sm text-muted-foreground">
+          {t(
+            'errors.noPermission.adminRequired',
+            'You do not have permission to access this page.'
+          )}
+        </p>
+      </div>
+    )
+  }
 
   return (
     <div className="space-y-2">

--- a/ui/src/types/api.ts
+++ b/ui/src/types/api.ts
@@ -654,7 +654,9 @@ export interface OAuthProvider {
   scopes?: string
   issuer?: string
   usernameClaim?: string
+  nameClaim?: string
   groupsClaim?: string
+  emailClaim?: string
   allowedGroups?: string
   enabled: boolean
   createdAt: string

--- a/ui/src/types/api.ts
+++ b/ui/src/types/api.ts
@@ -639,6 +639,7 @@ export interface Cluster {
   createdAt: string
   updatedAt: string
   prometheusURL?: string
+  uuid?: string
   error?: string
 }
 

--- a/ui/src/types/api.ts
+++ b/ui/src/types/api.ts
@@ -635,6 +635,7 @@ export interface Cluster {
   inCluster: boolean
   connector: boolean
   connected: boolean
+  connectorVersion?: string
   isDefault: boolean
   createdAt: string
   updatedAt: string
@@ -714,6 +715,8 @@ export interface APIKey {
   createdAt: string
   updatedAt: string
   roles?: Role[]
+  ownerUserId?: number
+  owner?: { id: number; username: string; name?: string } | null
 }
 
 // Resource History types

--- a/ui/src/types/api.ts
+++ b/ui/src/types/api.ts
@@ -644,6 +644,13 @@ export interface Cluster {
   error?: string
 }
 
+export interface ClusterListResponse {
+  data: Cluster[]
+  total: number
+  page: number
+  size: number
+}
+
 export interface OAuthProvider {
   id: number
   name: string
@@ -687,6 +694,13 @@ export interface Role {
   updatedAt: string
 }
 
+export interface RoleListResponse {
+  data: Role[]
+  total: number
+  page: number
+  size: number
+}
+
 export interface UserItem {
   id: number
   username: string
@@ -717,6 +731,13 @@ export interface APIKey {
   roles?: Role[]
   ownerUserId?: number
   owner?: { id: number; username: string; name?: string } | null
+}
+
+export interface APIKeyListResponse {
+  data: APIKey[]
+  total: number
+  page: number
+  size: number
 }
 
 // Resource History types


### PR DESCRIPTION
## Summary

This PR bundles three feature commits covering authentication enhancements, kubeconfig download with API proxy, and API key RBAC with connector architecture refactoring.

**1. Kubeconfig download with K8s API proxy (`2c71fc8`)**
- Add ability for users to download a kubeconfig that uses Kite as a reverse proxy to access Kubernetes clusters
- Implement `HandleK8sProxy` handler with two-layer RBAC enforcement (cluster-level + resource-level) and SPDY/WebSocket upgrade support
- Add kubeconfig generation logic that creates proxy-configured YAML with an auto-generated API key inheriting the user's RBAC permissions
- Add kubeconfig download dialog component in UI with cluster selection
- Add comprehensive tests for k8s proxy, connector manager, and run logic
- Add documentation in English and Chinese

**2. SMTP email verification & MFA for all user types (`f7dcb4b`)**
- Add SMTP settings model, handler, and email sender with verification code manager for step-up authentication
- Extend MFA and passkey support to OAuth and LDAP users via email verification codes
- Add `emailClaim`/`nameClaim` to OAuth providers and `emailAttribute` to LDAP
- Add i18n middleware with locale detection
- Add user email field with auto-sync from identity providers
- Update account settings dialog and add SMTP management UI

**3. API key RBAC & connector architecture refactor (`f38b95b`)**
- Add independent API key as a distinct RBAC subject type, normalized to "user" at the storage layer
- Refactor connector to use credential-based TCP tunneling, replacing the local HTTP proxy layer
- Use SPDY executor for connector clusters to fix DNS resolution for the virtual API server hostname in exec/terminal sessions
- API keys created via kubeconfig now track their owner and inherit the owner's RBAC roles
- Track connector agent version and display it in the cluster list UI
- Update i18n translations and documentation

## Why

- **Kubeconfig download**: Users need a simple way to access clusters from their local `kubectl` without sharing raw kubeconfig files. The proxy approach with auto-generated API keys enables fine-grained RBAC enforcement.
- **SMTP email verification & MFA**: Previously MFA/passkey was only available for password-based users. OAuth and LDAP users had no second-factor option. Email verification fills this gap and enables step-up authentication.
- **API key RBAC & connector refactor**: Independent API keys (not tied to a user) couldn't be assigned roles directly. The connector's local HTTP proxy layer was overly complex and caused SPDY/WebSocket compatibility issues. The credential-based tunneling approach simplifies the architecture and fixes DNS resolution failures for exec/terminal sessions.

## Related issue

Closes #

## Validation

- `go test ./pkg/cluster/...` — k8s proxy and connector manager tests pass
- `go test ./pkg/connector/...` — connector credentials and run tests pass
- `go test ./pkg/kube/...` — executor tests pass
- `go test ./pkg/rbac/...` — RBAC handler and additional tests pass
- `go test ./pkg/i18n/...` — i18n middleware tests pass
- `go test ./pkg/model/...` — cluster model tests pass
- `pnpm --dir ui run type-check` — frontend type check passes
- Manual testing: kubeconfig download flow, connector cluster creation, exec/terminal sessions on connector clusters, RBAC assignment with API keys, SMTP verification code flow, OAuth/LDAP MFA enrollment

## Checklist

- [x] I reviewed this PR myself before requesting review.
- [x] I understand the changes, including AI-generated parts (if any).
- [ ] For new features, a feature request issue is linked.
- [x] I cleaned up AI noise (unnecessary comments, dead code, and unrelated changes).
- [x] This PR is reasonably scoped (or split into smaller PRs).