### PR TITLE
Support Prometheus for cluster agent clusters

### DIFF
--- a/docs/config/env.md
+++ b/docs/config/env.md
@@ -19,7 +19,7 @@ Kite supports several environment variables by default to change the default val
 
 - **NODE_TERMINAL_IMAGE**: Docker image used for generating Node Terminal Agent.
 
-- **CLUSTER_AGENT_IMAGE**: Docker image used when generating the Kite Cluster Agent manifest for Cluster Agent clusters.
+- **CLUSTER_AGENT_IMAGE**: Docker image used when generating the Cluster Agent manifest for Cluster Agent clusters.
 
 - **ENABLE_ANALYTICS**: Enable data analytics functionality, default value is `false`. When enabled, Kite will collect limited data to help improve the product.
 

--- a/docs/guide/kite-cluster-agent.md
+++ b/docs/guide/kite-cluster-agent.md
@@ -2,15 +2,15 @@
 outline: deep
 ---
 
-# Kite Cluster Agent
+# Cluster Agent
 
-Kite Cluster Agent is used to onboard Kubernetes clusters that Kite Server cannot reach directly. The Cluster Agent runs inside the target cluster, initiates the connection to Kite, and forwards Kubernetes API requests issued by Kite over that connection.
+Cluster Agent is used to onboard Kubernetes clusters that Kite Server cannot reach directly. The Cluster Agent runs inside the target cluster, initiates the connection to Kite, and forwards Kubernetes API requests issued by Kite over that connection.
 
 ## Background
 
 In private networks, edge environments, or firewall-restricted scenarios, the target cluster may be able to reach Kite while Kite Server cannot connect to the cluster's kube-apiserver. The traditional kubeconfig onboarding method requires Kite Server to connect to kube-apiserver, so it cannot cover this one-way network topology.
 
-Kite Cluster Agent reverses the connection direction:
+Cluster Agent reverses the connection direction:
 
 - The Cluster Agent dials Kite Server from the cluster side; Kite does not need to enter the cluster network.
 - Kubernetes credentials are encrypted with the cluster's registration public key before they are uploaded to Kite Server.
@@ -53,7 +53,7 @@ The detailed process:
 Go to **Settings → Cluster Management** in Kite, select **Add Cluster**, and then:
 
 1. Fill in the cluster name and description.
-2. Set the cluster type to **Kite Cluster Agent**.
+2. Set the cluster type to **Cluster Agent**.
 3. Create the cluster.
 
 After creation, Kite shows the connection info only once, and you can choose the command-line or Kubernetes YAML option.

--- a/docs/zh/config/env.md
+++ b/docs/zh/config/env.md
@@ -19,7 +19,7 @@ Kite 默认支持一些环境变量，来改变一些配置项的默认值。
 
 - **NODE_TERMINAL_IMAGE**: 用于生成 Node Terminal Agent 的 Docker 镜像。
 
-- **CLUSTER_AGENT_IMAGE**: 为 Cluster Agent 类型集群生成 Kite Cluster Agent 部署清单时使用的 Docker 镜像。
+- **CLUSTER_AGENT_IMAGE**: 为 Cluster Agent 类型集群生成 Cluster Agent 部署清单时使用的 Docker 镜像。
 
 - **ENABLE_ANALYTICS**：启用数据分析功能，默认值为 `false`。当启用后，Kite 将收集有限数据以帮助改进产品。
 

--- a/docs/zh/guide/kite-cluster-agent.md
+++ b/docs/zh/guide/kite-cluster-agent.md
@@ -2,15 +2,15 @@
 outline: deep
 ---
 
-# Kite Cluster Agent
+# Cluster Agent
 
-Kite Cluster Agent 用于接入 Kite Server 无法主动访问的 Kubernetes 集群。Cluster Agent 运行在目标集群一侧，主动连接 Kite，并通过这条连接转发 Kite 发起的 Kubernetes API 请求。
+Cluster Agent 用于接入 Kite Server 无法主动访问的 Kubernetes 集群。Cluster Agent 运行在目标集群一侧，主动连接 Kite，并通过这条连接转发 Kite 发起的 Kubernetes API 请求。
 
 ## 背景
 
 在私有网络、边缘环境或受防火墙限制的场景中，目标集群可能只能访问 Kite，Kite Server 却无法直接访问集群的 kube-apiserver。传统的 kubeconfig 接入方式要求 Kite Server 能够连接 kube-apiserver，因此无法覆盖这种单向网络环境。
 
-Kite Cluster Agent 将连接方向反转：
+Cluster Agent 将连接方向反转：
 
 - Cluster Agent 从集群侧主动连接 Kite Server，不要求 Kite 主动进入集群网络。
 - Kubernetes 凭据使用集群注册公钥加密后再上传到 Kite Server。
@@ -53,7 +53,7 @@ Cluster Agent 代拨 TCP
 进入 Kite 的 **设置 → 集群管理**，选择 **添加集群**，然后：
 
 1. 填写集群名称和描述。
-2. 将集群类型选择为 **Kite Cluster Agent**。
+2. 将集群类型选择为 **Cluster Agent**。
 3. 创建集群。
 
 创建成功后，Kite 会展示仅出现一次的连接信息，可以选择命令行或 Kubernetes YAML。

--- a/pkg/cluster/cluster_agent_manifest_test.go
+++ b/pkg/cluster/cluster_agent_manifest_test.go
@@ -214,8 +214,8 @@ func TestCreateClusterAgentClusterIgnoresKubeconfig(t *testing.T) {
 	if cluster.InCluster {
 		t.Error("cluster agent cluster InCluster should be false")
 	}
-	if cluster.PrometheusURL != "" {
-		t.Errorf("cluster agent cluster PrometheusURL should be empty, got %q", cluster.PrometheusURL)
+	if cluster.PrometheusURL != "https://prom.example.com" {
+		t.Errorf("cluster agent cluster PrometheusURL = %q, want %q", cluster.PrometheusURL, "https://prom.example.com")
 	}
 }
 

--- a/pkg/cluster/cluster_handler.go
+++ b/pkg/cluster/cluster_handler.go
@@ -128,7 +128,6 @@ func (cm *ClusterManager) CreateCluster(c *gin.Context) {
 	if req.ClusterAgent {
 		req.InCluster = false
 		req.Config = ""
-		req.PrometheusURL = ""
 	}
 
 	if _, err := model.GetClusterByName(req.Name); err == nil {
@@ -252,7 +251,6 @@ func (cm *ClusterManager) UpdateCluster(c *gin.Context) {
 	if cluster.ClusterAgent {
 		req.InCluster = false
 		req.Config = ""
-		req.PrometheusURL = ""
 	}
 
 	updates := map[string]interface{}{

--- a/pkg/cluster/cluster_manager.go
+++ b/pkg/cluster/cluster_manager.go
@@ -96,6 +96,12 @@ func newClientSet(name string, k8sConfig *rest.Config, prometheusURL string) (*C
 			} else {
 				klog.Infof("Using k8s API proxy for Prometheus in cluster %s", name)
 			}
+		} else if k8sConfig.Dial != nil {
+			transport := http.DefaultTransport.(*http.Transport).Clone()
+			transport.Proxy = nil
+			transport.DialContext = k8sConfig.Dial
+			rt = transport
+			klog.Infof("Using cluster agent TCP proxy for Prometheus in cluster %s", name)
 		}
 		cs.PromClient, err = prometheus.NewClientWithRoundTripper(prometheusURL, rt)
 		if err != nil {

--- a/pkg/clusteragent/run.go
+++ b/pkg/clusteragent/run.go
@@ -22,8 +22,8 @@ func Run(ctx context.Context, args []string) error {
 	flags := flag.NewFlagSet("kite cluster-agent", flag.ContinueOnError)
 	klog.InitFlags(flags)
 	server := flags.String("server", "", "Kite server URL")
-	token := flags.String("token", "", "Kite cluster agent token")
-	publicKey := flags.String("public-key", "", "Kite cluster agent registration public key")
+	token := flags.String("token", "", "Cluster Agent token")
+	publicKey := flags.String("public-key", "", "Cluster Agent registration public key")
 	kubeconfig := flags.String("kubeconfig", "", "Path to kubeconfig file")
 	if err := flags.Parse(args); err != nil {
 		return err
@@ -100,7 +100,7 @@ func Run(ctx context.Context, args []string) error {
 		return network == "tcp"
 	}
 
-	klog.Info("Kite cluster agent started")
+	klog.Info("Cluster Agent started")
 	for {
 		err := registerClusterAgent(ctx, client, registrationURL.String(), *token, *publicKey, config)
 		if err == nil {
@@ -109,7 +109,7 @@ func Run(ctx context.Context, args []string) error {
 		if ctx.Err() != nil {
 			return nil //nolint:nilerr // Context cancellation is a clean shutdown.
 		}
-		klog.Warningf("Kite cluster agent unavailable: %v; retrying in 5 seconds", err)
+		klog.Warningf("Cluster Agent unavailable: %v; retrying in 5 seconds", err)
 		select {
 		case <-ctx.Done():
 			return nil

--- a/ui/src/components/settings/cluster-dialog.tsx
+++ b/ui/src/components/settings/cluster-dialog.tsx
@@ -210,19 +210,17 @@ function ClusterDialogContent({
           </div>
         )}
 
-        {!formData.clusterAgent && (
-          <div className="space-y-2">
-            <Label htmlFor="prometheus-url">
-              {t('clusterManagement.dialog.prometheusUrl', 'Prometheus URL')}
-            </Label>
-            <Input
-              id="prometheus-url"
-              value={formData.prometheusURL}
-              onChange={(e) => handleChange('prometheusURL', e.target.value)}
-              type="url"
-            />
-          </div>
-        )}
+        <div className="space-y-2">
+          <Label htmlFor="prometheus-url">
+            {t('clusterManagement.dialog.prometheusUrl', 'Prometheus URL')}
+          </Label>
+          <Input
+            id="prometheus-url"
+            value={formData.prometheusURL}
+            onChange={(e) => handleChange('prometheusURL', e.target.value)}
+            type="url"
+          />
+        </div>
 
         {/* Cluster Status Controls */}
         <div className="space-y-4 border-t pt-4">

--- a/ui/src/components/settings/cluster-dialog.tsx
+++ b/ui/src/components/settings/cluster-dialog.tsx
@@ -152,10 +152,7 @@ function ClusterDialogContent({
                     {t('clusterManagement.type.inCluster', 'In-Cluster')}
                   </SelectItem>
                   <SelectItem value="clusterAgent">
-                    {t(
-                      'clusterManagement.type.clusterAgent',
-                      'Kite Cluster Agent'
-                    )}
+                    {t('clusterManagement.type.clusterAgent', 'Cluster Agent')}
                   </SelectItem>
                 </SelectContent>
               </Select>

--- a/ui/src/components/settings/cluster-management.tsx
+++ b/ui/src/components/settings/cluster-management.tsx
@@ -86,7 +86,7 @@ export function ClusterManagement() {
             variant="outline"
             className="bg-violet-50 text-violet-700 border-violet-200"
           >
-            {t('clusterManagement.type.clusterAgent', 'Kite Cluster Agent')}
+            {t('clusterManagement.type.clusterAgent', 'Cluster Agent')}
           </Badge>
         )
       }
@@ -508,7 +508,7 @@ export function ClusterManagement() {
             <DialogTitle className="text-balance">
               {t(
                 'clusterManagement.clusterAgent.title',
-                'Connect Kite Cluster Agent'
+                'Connect Cluster Agent'
               )}
             </DialogTitle>
             <DialogDescription className="text-pretty">

--- a/ui/src/components/settings/general-management.tsx
+++ b/ui/src/components/settings/general-management.tsx
@@ -426,7 +426,7 @@ export function GeneralManagement() {
             <p className="text-xs text-muted-foreground">
               {t(
                 'generalManagement.clusterAgent.description',
-                'Container image used when generating the Kite Cluster Agent manifest for Cluster Agent clusters.'
+                'Container image used when generating the Cluster Agent manifest for Cluster Agent clusters.'
               )}
             </p>
           </div>

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -801,7 +801,7 @@
     },
     "clusterAgent": {
       "title": "Cluster Agent Image",
-      "description": "Container image used when generating the Kite Cluster Agent manifest for Cluster Agent clusters.",
+      "description": "Container image used when generating the Cluster Agent manifest for Cluster Agent clusters.",
       "form": {
         "image": "Image"
       }
@@ -901,14 +901,14 @@
     "type": {
       "inCluster": "In-Cluster",
       "external": "External",
-      "clusterAgent": "Kite Cluster Agent"
+      "clusterAgent": "Cluster Agent"
     },
     "status": {
       "waiting": "Waiting for Cluster Agent",
       "connected": "Connected"
     },
     "clusterAgent": {
-      "title": "Connect Kite Cluster Agent",
+      "title": "Connect Cluster Agent",
       "description": "Choose a command or Kubernetes YAML to run inside the target cluster. This connection information is shown only once.",
       "command": "Command",
       "yaml": "Kubernetes YAML",

--- a/ui/src/i18n/locales/zh.json
+++ b/ui/src/i18n/locales/zh.json
@@ -812,7 +812,7 @@
     },
     "clusterAgent": {
       "title": "Cluster Agent 镜像",
-      "description": "为 Cluster Agent 类型集群生成 Kite Cluster Agent 部署清单时使用的容器镜像。",
+      "description": "为 Cluster Agent 类型集群生成 Cluster Agent 部署清单时使用的容器镜像。",
       "form": {
         "image": "镜像"
       }
@@ -912,14 +912,14 @@
     "type": {
       "inCluster": "集群内",
       "external": "外部",
-      "clusterAgent": "Kite Cluster Agent"
+      "clusterAgent": "Cluster Agent"
     },
     "status": {
       "waiting": "等待 Cluster Agent",
       "connected": "已连接"
     },
     "clusterAgent": {
-      "title": "连接 Kite Cluster Agent",
+      "title": "连接 Cluster Agent",
       "description": "选择命令行或 Kubernetes YAML 在目标集群中运行。此连接信息仅显示一次。",
       "command": "命令行",
       "yaml": "Kubernetes YAML",


### PR DESCRIPTION
## What changed

- allow cluster agent clusters to save and edit a Prometheus URL
- keep cluster-local Prometheus URLs on the existing Kubernetes API proxy path
- route other Prometheus URLs through the cluster agent TCP tunnel
- standardize user-facing naming from `Kite Cluster Agent` to `Cluster Agent` across the UI, CLI text, and documentation

## Why

Cluster agent requests previously discarded the configured Prometheus URL, and the UI hid the field for agent clusters. Non-cluster-local Prometheus endpoints would also be reached directly from the Kite server instead of from inside the target cluster. The product copy also used inconsistent `Kite Cluster Agent` and `Cluster Agent` names.

## Impact

Cluster agent clusters can now use either Kubernetes service addresses or other network-local Prometheus endpoints without changing the behavior of regular clusters. User-facing copy consistently uses `Cluster Agent`; technical identifiers such as the `kite cluster-agent` command and `kite-cluster-agent` Kubernetes resources remain unchanged.

## Validation

- `make pre-commit`
- `go test ./pkg/cluster ./pkg/clusteragent`
- `pnpm --dir ui run type-check`