### PR TITLE
Add SMTP configuration to General Settings

### DIFF
--- a/charts/kite/templates/secret.yaml
+++ b/charts/kite/templates/secret.yaml
@@ -1,21 +1,27 @@
-{{- if .Values.secret.create }}
+{{- if and (not .Values.secret.create) (not .Values.secret.existingSecret) }}
+{{- fail "secret.existingSecret must be set when secret.create is false" }}
+{{- end }}
+{{- if and .Values.secret.create (not .Values.secret.existingSecret) }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "kite.fullname" . }}-secret
+  name: {{ include "kite.secret" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kite.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-1"
+    "helm.sh/hook-delete-policy": hook-failed
+    "helm.sh/resource-policy": keep
 type: Opaque
-data:
-  {{- if .Values.jwtSecret }}
-  JWT_SECRET: {{ .Values.jwtSecret | b64enc | quote }}
-  {{- end }}
-  {{- if .Values.encryptKey }}
-  KITE_ENCRYPT_KEY: {{ .Values.encryptKey | b64enc | quote }}
-  {{- end }}
+stringData:
+  JWT_SECRET: {{ .Values.jwtSecret | default (randAlphaNum 64) | quote }}
+  KITE_ENCRYPT_KEY: {{ .Values.encryptKey | default (randAlphaNum 64) | quote }}
+  KUBECONFIG_JWT_SECRET: {{ .Values.kubeconfigJwtSecret | default (randAlphaNum 64) | quote }}
+  KUBECONFIG_JWT_KID: {{ .Values.kubeconfigJwtKid | default "primary" | quote }}
   {{- if ne .Values.db.type "sqlite" }}
-  DB_TYPE: {{ .Values.db.type | b64enc | quote }}
-  DB_DSN: {{ .Values.db.dsn | b64enc | quote }}
+  DB_TYPE: {{ .Values.db.type | quote }}
+  DB_DSN: {{ .Values.db.dsn | quote }}
   {{- end }}
 {{- end }}

--- a/charts/kite/values.yaml
+++ b/charts/kite/values.yaml
@@ -49,27 +49,21 @@ basePath: ""
 # Be careful with this setting in production
 anonymousUserEnabled: false
 
-# Secret key for signing JWT tokens. Auto-generated if empty.
-# Ignored if using existingSecret
+# Optional explicit secrets. Leave empty to have Helm generate a cryptographically random value during installation.
+# Ignored when secret.existingSecret is set.
 jwtSecret: ""
-
-# This is the key used for encrypting sensitive data
-# Change this in production
-# Ignored if using existingSecret
-encryptKey: "kite-default-encryption-key-change-in-production"
+encryptKey: ""
+kubeconfigJwtSecret: ""
+# This is an identifier, not secret material. Keep it stable while downloaded kubeconfigs are valid.
+kubeconfigJwtKid: "primary"
 
 # Secret handling
-# By default the chart will create a Kubernetes Secret containing sensitive values.
 secret:
-  # Create the Secret from chart values (true) or reference an existing Secret (false)
+  # Create a pre-install hook Secret. It is kept when the release is uninstalled and is not changed by upgrades.
   create: true
-  # If set, the deployment will use this existing secret name instead of the generated one (ignored when `create: true`).
-  # must contain all required keys.
-  #  JWT_SECRET
-  #  KITE_ENCRYPT_KEY
-  #  DB_TYPE supported values: sqlite, postgres, mysql (defaults to sqlite if not set)
-  #  DB_DSN (not required for sqlite)
-  # if set, the db.dsn and db.type values from the chart will be ignored.
+  # Name of a Secret managed outside this chart. When set, the hook is skipped and this Secret must contain:
+  # JWT_SECRET, KITE_ENCRYPT_KEY, KUBECONFIG_JWT_SECRET, KUBECONFIG_JWT_KID.
+  # For external databases it must also contain DB_TYPE and DB_DSN.
   existingSecret: ""
 
 # Database configuration

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -112,6 +112,7 @@ export default defineConfig({
             { text: "Resource History", link: "/guide/resource-history" },
             { text: "Custom Sidebar", link: "/guide/custom-sidebar" },
             { text: "Kube Proxy", link: "/guide/kube-proxy" },
+            { text: "Download a kubeconfig", link: "/guide/kubeconfig-download" },
           ],
         },
         {
@@ -139,6 +140,10 @@ export default defineConfig({
         {
           text: "User Management",
           link: "/api/user-management",
+        },
+        {
+          text: "Kubeconfig",
+          link: "/api/kubeconfig",
         },
       ],
       "/zh/": [
@@ -176,6 +181,7 @@ export default defineConfig({
             { text: "资源历史", link: "/zh/guide/resource-history" },
             { text: "自定义侧边栏", link: "/zh/guide/custom-sidebar" },
             { text: "Kube Proxy", link: "/zh/guide/kube-proxy" },
+            { text: "下载 kubeconfig", link: "/zh/guide/kubeconfig-download" },
           ],
         },
         {
@@ -203,6 +209,10 @@ export default defineConfig({
         {
           text: "用户管理",
           link: "/zh/api/user-management",
+        },
+        {
+          text: "Kubeconfig",
+          link: "/zh/api/kubeconfig",
         },
       ],
     },

--- a/docs/api/kubeconfig.md
+++ b/docs/api/kubeconfig.md
@@ -1,0 +1,97 @@
+# Kubeconfig API
+
+Kite provides a kubeconfig download endpoint, token-management endpoints, and a Kubernetes API proxy. Download requests use the existing authenticated browser session. The proxy accepts only a dedicated Kubeconfig Token, not a browser login token or API key.
+
+All token-management responses contain metadata only. They never return the JWT, its `jti`, or its hash.
+
+## Download a kubeconfig
+
+```http
+POST /api/v1/kubeconfig
+Content-Type: application/json
+```
+
+```json
+{
+  "clusterUUIDs": [
+    "7be79e50-6213-4e73-bdf4-f606d9ae81e2"
+  ],
+  "ttlSeconds": 2592000
+}
+```
+
+`clusterUUIDs` must contain at least one UUID for an enabled cluster the signed-in user can access. `ttlSeconds` must be an integer from 3,600 through 157,680,000.
+
+Success returns the downloaded YAML directly:
+
+```http
+200 OK
+Content-Type: application/yaml
+Content-Disposition: attachment; filename="kite-kubeconfig.yaml"
+Cache-Control: no-store
+Pragma: no-cache
+```
+
+The response is not a JSON token response. It contains a kubeconfig with a single bearer token shared by the selected contexts.
+
+Typical errors are `400` for an invalid request or UUID, `401` for a missing or expired browser session, `403` for a cluster the user cannot access, `404` for an unknown cluster, `409` for a disabled cluster, and `500` if signing or file generation fails.
+
+## Current-user token management
+
+```http
+GET    /api/users/me/kubeconfig-tokens
+DELETE /api/users/me/kubeconfig-tokens/:id
+```
+
+These endpoints require an authenticated user. The list includes only tokens owned by the current user. `DELETE` physically removes the token record. The token becomes invalid immediately and cannot be recovered. A missing token, including one owned by another user, returns `404`.
+
+Example list response:
+
+```json
+{
+  "tokens": [
+    {
+      "id": 42,
+      "name": "kubeconfig-alice-20260814153045.987",
+      "createdAt": "2026-08-14T07:30:45Z",
+      "expiresAt": "2026-09-13T07:30:45Z",
+      "lastUsedAt": "2026-08-14T08:00:00Z",
+      "signingKeyId": "primary"
+    }
+  ]
+}
+```
+
+Clients derive active and expired display states from the expiration time.
+
+## Administrator token management
+
+```http
+GET    /api/v1/admin/kubeconfig-tokens
+DELETE /api/v1/admin/kubeconfig-tokens/:id
+```
+
+These endpoints require an authenticated administrator. The administrator list includes the same safe metadata plus `ownerId` and `owner`. Administrators can physically delete any token; deletion invalidates it immediately and cannot be recovered.
+
+The list supports `page` (default `1`), `size` (default `20`, maximum `100`), `owner` (case-insensitive username substring), and `status` (`active` or `expired`). Results are ordered by `createdAt` descending and include `tokens`, `total`, `page`, and `size`.
+
+## Kubernetes API proxy
+
+```http
+GET|POST|PUT|PATCH|DELETE /api/v1/clusters/:clusterUUID/k8s-proxy/*path
+Authorization: Bearer <kubeconfig-jwt>
+```
+
+The proxy forwards Kubernetes API paths for the selected cluster, including discovery, resource operations, logs, Watch, and supported upgrade requests. It evaluates token state, owner status, cluster access, and current Kite RBAC permissions for every request. Requests with an expired, deleted, invalid, or browser-login token receive a Kubernetes `Status` response with HTTP `401`; authorization failures receive `403`.
+
+The external bearer token, cookies, and `Impersonate-*` headers are removed before forwarding to the target Kubernetes API.
+
+## Authentication model
+
+Kubeconfig Tokens are independently issued JWTs with `iss`, `sub`, `jti`, `token_use=kubeconfig`, `iat`, `nbf`, and `exp` claims. They are non-refreshable and have a server-side state record, so signature validation alone is insufficient. Kite checks the corresponding record on every proxy request and applies current RBAC rather than embedding a permissions snapshot in the token.
+
+### Stateful token module
+
+Kite uses the in-process `pkg/statefultoken` module for stateful token issuance, signature and server-side state validation, deletion, and last-used updates. The Kubeconfig domain connects it to `kubeconfig_tokens` through a storage adapter; cluster selection, kubeconfig YAML generation, owner-enabled checks, Kubernetes request parsing, and current RBAC remain in the Kubeconfig/cluster domain.
+
+The module does not serve browser-session JWTs and does not store cluster or resource permissions in tokens. Kubeconfig Tokens currently use one HS256 key and KID; a verification key set and uninterrupted key rotation are not implemented yet.

--- a/docs/config/config-file.md
+++ b/docs/config/config-file.md
@@ -1,6 +1,6 @@
 # Configuration File
 
-Kite supports loading cluster, OAuth/LDAP, and RBAC configuration from a YAML file. When a section is configured this way, it becomes **read-only** in the UI — users can view the settings but cannot modify them through the dashboard.
+Kite supports loading cluster, OAuth/LDAP, SMTP, and RBAC configuration from a YAML file. When a section is configured this way, it becomes **read-only** in the UI — users can view the settings but cannot modify them through the dashboard.
 
 This is useful for GitOps workflows where configuration is version-controlled and applied via Helm.
 
@@ -70,6 +70,18 @@ ldap:
   groupFilter: "(member=%s)"
   groupNameAttribute: "cn"
 
+smtp:
+  enabled: true
+  host: "smtp.example.com"
+  port: 587
+  username: "kite"
+  password: "smtp-password"
+  fromEmail: "kite@example.com"
+  fromName: "Kite"
+  encryption: "starttls" # Options: none, starttls, tls
+  skipTLSVerify: false
+  timeoutSeconds: 30
+
 rbac:
   roles:
     - name: admin
@@ -100,7 +112,7 @@ rbac:
       oidcGroups: ["developers"]
 ```
 
-You only need to include the sections you want to manage. For example, if you only want to manage clusters via config file, just include the `clusters` section — OAuth, LDAP, and RBAC will remain editable through the UI.
+You only need to include the sections you want to manage. For example, if you only want to manage clusters via config file, just include the `clusters` section — OAuth, LDAP, SMTP, and RBAC will remain editable through the UI.
 
 ## Using with Helm
 
@@ -217,59 +229,76 @@ config:
 
 ### Super User Configuration
 
-| Field      | Type   | Description                           | Required |
-| ---------- | ------ | ------------------------------------- | -------- |
-| `username` | string | Super user username                   | Yes      |
-| `password` | string | Super user password                   | Yes      |
+| Field      | Type   | Description         | Required |
+| ---------- | ------ | ------------------- | -------- |
+| `username` | string | Super user username | Yes      |
+| `password` | string | Super user password | Yes      |
 
 The super user is created on first startup if it doesn't exist. On subsequent startups, the password is updated to match the config file.
 
 ### Cluster Configuration
 
-| Field           | Type    | Description                     | Required |
-| --------------- | ------- | ------------------------------- | -------- |
-| `name`          | string  | Unique cluster name             | Yes      |
-| `description`   | string  | Cluster description             | No       |
-| `config`        | string  | Kubeconfig YAML content         | No *     |
-| `prometheusURL` | string  | Prometheus endpoint URL         | No       |
-| `inCluster`     | boolean | Use in-cluster service account  | No       |
-| `default`       | boolean | Set as default cluster          | No       |
+| Field           | Type    | Description                    | Required |
+| --------------- | ------- | ------------------------------ | -------- |
+| `name`          | string  | Unique cluster name            | Yes      |
+| `description`   | string  | Cluster description            | No       |
+| `config`        | string  | Kubeconfig YAML content        | No *     |
+| `prometheusURL` | string  | Prometheus endpoint URL        | No       |
+| `inCluster`     | boolean | Use in-cluster service account | No       |
+| `default`       | boolean | Set as default cluster         | No       |
 
 \* Either `config` or `inCluster: true` must be provided.
 
 ### OAuth Provider Configuration
 
-| Field           | Type    | Description                                 | Required |
-| --------------- | ------- | ------------------------------------------- | -------- |
-| `name`          | string  | Provider name (e.g., "google", "github")    | Yes      |
-| `clientId`      | string  | OAuth client ID                             | Yes      |
-| `clientSecret`  | string  | OAuth client secret                         | Yes      |
-| `issuer`        | string  | OIDC issuer URL (enables auto-discovery)    | No       |
-| `authUrl`       | string  | Authorization endpoint (if no issuer)       | No       |
-| `tokenUrl`      | string  | Token endpoint (if no issuer)               | No       |
-| `userInfoUrl`   | string  | User info endpoint (if no issuer)           | No       |
-| `scopes`        | string  | Comma-separated scopes                      | No       |
-| `usernameClaim` | string  | JWT claim for username                      | No       |
-| `groupsClaim`   | string  | JWT claim for groups                        | No       |
-| `allowedGroups` | string  | Comma-separated list of allowed groups      | No       |
-| `enabled`       | boolean | Enable this provider                        | No       |
+| Field           | Type    | Description                              | Required |
+| --------------- | ------- | ---------------------------------------- | -------- |
+| `name`          | string  | Provider name (e.g., "google", "github") | Yes      |
+| `clientId`      | string  | OAuth client ID                          | Yes      |
+| `clientSecret`  | string  | OAuth client secret                      | Yes      |
+| `issuer`        | string  | OIDC issuer URL (enables auto-discovery) | No       |
+| `authUrl`       | string  | Authorization endpoint (if no issuer)    | No       |
+| `tokenUrl`      | string  | Token endpoint (if no issuer)            | No       |
+| `userInfoUrl`   | string  | User info endpoint (if no issuer)        | No       |
+| `scopes`        | string  | Comma-separated scopes                   | No       |
+| `usernameClaim` | string  | JWT claim for username                   | No       |
+| `groupsClaim`   | string  | JWT claim for groups                     | No       |
+| `allowedGroups` | string  | Comma-separated list of allowed groups   | No       |
+| `enabled`       | boolean | Enable this provider                     | No       |
 
 ### LDAP Configuration
 
-| Field                  | Type    | Description                          | Default        |
-| ---------------------- | ------- | ------------------------------------ | -------------- |
-| `enabled`              | boolean | Enable LDAP authentication           | `false`        |
-| `serverUrl`            | string  | LDAP server URL                      |                |
-| `useStartTLS`          | boolean | Use StartTLS for `ldap://`           | `false`        |
-| `bindDn`               | string  | Service account DN                   |                |
-| `bindPassword`         | string  | Service account password             |                |
-| `userBaseDn`           | string  | Base DN for user searches            |                |
-| `userFilter`           | string  | User search filter                   | `(uid=%s)`     |
-| `usernameAttribute`    | string  | Username attribute                   | `uid`          |
-| `displayNameAttribute` | string  | Display name attribute               | `cn`           |
-| `groupBaseDn`          | string  | Base DN for group searches           |                |
-| `groupFilter`          | string  | Group membership filter              | `(member=%s)`  |
-| `groupNameAttribute`   | string  | Group name attribute                 | `cn`           |
+| Field                  | Type    | Description                | Default       |
+| ---------------------- | ------- | -------------------------- | ------------- |
+| `enabled`              | boolean | Enable LDAP authentication | `false`       |
+| `serverUrl`            | string  | LDAP server URL            |               |
+| `useStartTLS`          | boolean | Use StartTLS for `ldap://` | `false`       |
+| `bindDn`               | string  | Service account DN         |               |
+| `bindPassword`         | string  | Service account password   |               |
+| `userBaseDn`           | string  | Base DN for user searches  |               |
+| `userFilter`           | string  | User search filter         | `(uid=%s)`    |
+| `usernameAttribute`    | string  | Username attribute         | `uid`         |
+| `displayNameAttribute` | string  | Display name attribute     | `cn`          |
+| `groupBaseDn`          | string  | Base DN for group searches |               |
+| `groupFilter`          | string  | Group membership filter    | `(member=%s)` |
+| `groupNameAttribute`   | string  | Group name attribute       | `cn`          |
+
+### SMTP Configuration
+
+| Field            | Type    | Description                                           | Required     |
+| ---------------- | ------- | ----------------------------------------------------- | ------------ |
+| `enabled`        | boolean | Enable SMTP email delivery                            | Yes          |
+| `host`           | string  | SMTP server hostname or address                       | When enabled |
+| `port`           | integer | SMTP server port (`1`–`65535`)                        | When enabled |
+| `username`       | string  | Optional SMTP authentication username                 | No           |
+| `password`       | string  | Optional SMTP authentication password                 | No           |
+| `fromEmail`      | string  | Sender email address                                  | When enabled |
+| `fromName`       | string  | Optional sender display name                          | No           |
+| `encryption`     | string  | Transport security mode: `none`, `starttls`, or `tls` | When enabled |
+| `skipTLSVerify`  | boolean | Skip TLS certificate verification                     | No           |
+| `timeoutSeconds` | integer | Connection and mail-operation timeout in seconds      | No           |
+
+SMTP testing is shown and available only when SMTP is enabled. When SMTP is not managed by the configuration file, a test email uses the current SMTP form values without saving them; after a successful test, click **Save** at the bottom of **Settings → General Settings** to persist them. When SMTP is managed by the configuration file, the form is read-only and tests use the displayed managed configuration.
 
 ### RBAC Configuration
 
@@ -286,11 +315,11 @@ The super user is created on first startup if it doesn't exist. On subsequent st
 
 #### Role Mapping
 
-| Field        | Type     | Description                     | Required |
-| ------------ | -------- | ------------------------------- | -------- |
-| `name`       | string   | Role name to map to             | Yes      |
-| `users`      | string[] | Usernames (`*` for all users)   | No       |
-| `oidcGroups` | string[] | OIDC/LDAP group names           | No       |
+| Field        | Type     | Description                   | Required |
+| ------------ | -------- | ----------------------------- | -------- |
+| `name`       | string   | Role name to map to           | Yes      |
+| `users`      | string[] | Usernames (`*` for all users) | No       |
+| `oidcGroups` | string[] | OIDC/LDAP group names         | No       |
 
 ## Behavior Notes
 

--- a/docs/config/env.md
+++ b/docs/config/env.md
@@ -8,7 +8,9 @@ Kite supports several environment variables by default to change the default val
 - **KUBECONFIG**: Legacy kubeconfig environment variable used to import clusters when `KITE_CONFIG_FILE` is not set.
 - **ANONYMOUS_USER_ENABLED**: Enable anonymous user access, default value is `false`. When enabled, all access will no longer require authentication and will have the highest permissions by default.
 
-- **JWT_SECRET**: Secret key used for signing and verifying JWT
+- **JWT_SECRET**: Secret key used for signing and verifying browser-session JWTs.
+- **KUBECONFIG_JWT_SECRET**: Dedicated secret used to sign and verify downloaded kubeconfig JWTs. In production, set this independently from `JWT_SECRET`; Kite requires it when `KITE_ENV=production`.
+- **KUBECONFIG_JWT_KID**: Identifier written in the `kid` header of newly issued kubeconfig JWTs and required when verifying them. The current implementation uses one configured HS256 key (`KUBECONFIG_JWT_SECRET`) and one matching KID; it does not implement a verification key set.
 - **KITE_ENCRYPT_KEY**: Secret key used for encrypting sensitive data, such as user passwords, OAuth clientSecret, kubeconfig, etc.
 
 - **HOST**: Used for generating OAuth 2.0 authorization callback addresses, default will be obtained from request headers. If you find the result not as expected, you can manually configure this environment variable.

--- a/docs/config/env.md
+++ b/docs/config/env.md
@@ -2,7 +2,7 @@
 
 Kite supports several environment variables by default to change the default values of some configuration items.
 
-- **KITE_CONFIG_FILE**: Path to the configuration file. Available in Kite `v0.10.0` and later. When set, Kite loads cluster, OAuth, LDAP, RBAC, and super user settings from this file. See [Configuration File](/config/config-file) for details.
+- **KITE_CONFIG_FILE**: Path to the configuration file. Available in Kite `v0.10.0` and later. When set, Kite loads cluster, OAuth, LDAP, SMTP, RBAC, and super user settings from this file. See [Configuration File](/config/config-file) for details.
 - **KITE_USERNAME**: Legacy environment variable for the initial administrator username. It is only used for env-to-DB migration when `KITE_CONFIG_FILE` is not set.
 - **KITE_PASSWORD**: Legacy environment variable for the initial administrator password. It is only used for env-to-DB migration when `KITE_CONFIG_FILE` is not set.
 - **KUBECONFIG**: Legacy kubeconfig environment variable used to import clusters when `KITE_CONFIG_FILE` is not set.

--- a/docs/guide/kubeconfig-download.md
+++ b/docs/guide/kubeconfig-download.md
@@ -1,0 +1,59 @@
+---
+outline: deep
+---
+
+# Download a kubeconfig
+
+Kite can generate a kubeconfig that lets you use `kubectl` against the Kubernetes API through Kite. The downloaded file contains a dedicated, stateful Kubeconfig Token; it does not contain your browser login token, a target cluster kubeconfig, or Cluster Agent credentials.
+
+## Download and select clusters
+
+1. Sign in and select a cluster you can access.
+2. In the top toolbar, select **Download Kubeconfig** next to **Kubectl Terminal**.
+3. The current accessible, enabled cluster is selected by default. Select more clusters, or use **Select all** / **Deselect all**. When there are many clusters, use the search box to filter them by name.
+4. Select an expiration preset, or choose **Custom** and select the expiration year, month, day, hour, minute, and second.
+5. Select **Download**. Kite downloads `kite-kubeconfig.yaml`.
+
+The default lifetime is 30 days. Available presets are 1 day, 7 days, 30 days, and 1 year. Custom durations must be whole seconds from 3,600 seconds (1 hour) through 157,680,000 seconds (1,825 days). The expiry displayed in the dialog is an estimate; the server determines the final expiry time.
+
+Each selected cluster gets its own cluster and context. If the current cluster is selected, it is the kubeconfig `current-context`; otherwise the first selected cluster is used.
+
+## Use the downloaded file
+
+Treat the file as a password. Restrict its permissions before using it:
+
+```bash
+chmod 600 ~/Downloads/kite-kubeconfig.yaml
+export KUBECONFIG=~/Downloads/kite-kubeconfig.yaml
+kubectl config get-contexts
+kubectl get pods -A
+```
+
+You can also pass the file for one command:
+
+```bash
+kubectl --kubeconfig ~/Downloads/kite-kubeconfig.yaml get pods -A
+```
+
+Kite authorizes every proxied Kubernetes request using your current Kite account and RBAC permissions. Changes to your account, cluster access, namespace permissions, or resource permissions affect subsequent commands.
+
+## Streaming and interactive commands
+
+The proxy is intended for normal Kubernetes API requests as well as Watch, logs, `exec`, `attach`, and `port-forward` requests. For example:
+
+```bash
+kubectl get pods -A -w
+kubectl logs -f deployment/example
+kubectl exec -it pod/example -- sh
+kubectl port-forward service/example 8080:80
+```
+
+The `ktctl` version and supported command scope have not yet been confirmed. Do not treat ktctl compatibility as a release guarantee until the project publishes the fixed version and command matrix.
+
+## Token lifecycle and deletion
+
+Every download creates a separate Kubeconfig Token. Tokens cannot be refreshed or extended; download a new kubeconfig when one expires. Deleting one token does not affect your other kubeconfig downloads.
+
+In **Account Settings**, use the separate **Kubeconfig Tokens** section to view your token metadata and delete a token you no longer need. Administrators can view and delete tokens in their separate management view. Neither view exposes the kubeconfig JWT, its `jti`, or its hash.
+
+Deleting a token removes its record, invalidates it immediately, and cannot be undone or recovered. After a token expires or is deleted, `kubectl` requests receive HTTP 401 with a Kubernetes Status message asking you to download a new kubeconfig. If the file is lost or exposed, delete its token immediately and download a replacement only if needed.

--- a/docs/zh/api/kubeconfig.md
+++ b/docs/zh/api/kubeconfig.md
@@ -1,0 +1,97 @@
+# Kubeconfig API
+
+Kite 提供 kubeconfig 下载接口、Token 管理接口和 Kubernetes API 代理。下载请求使用现有的已认证浏览器会话。代理仅接受专用 Kubeconfig Token，不接受浏览器登录 Token 或 API 密钥。
+
+所有 Token 管理响应仅返回元数据，绝不返回 JWT、其 `jti` 或哈希。
+
+## 下载 kubeconfig
+
+```http
+POST /api/v1/kubeconfig
+Content-Type: application/json
+```
+
+```json
+{
+  "clusterUUIDs": [
+    "7be79e50-6213-4e73-bdf4-f606d9ae81e2"
+  ],
+  "ttlSeconds": 2592000
+}
+```
+
+`clusterUUIDs` 至少包含一个当前登录用户有权访问的已启用集群 UUID。`ttlSeconds` 必须是 3,600 至 157,680,000 之间的整数。
+
+成功时直接返回下载 YAML：
+
+```http
+200 OK
+Content-Type: application/yaml
+Content-Disposition: attachment; filename="kite-kubeconfig.yaml"
+Cache-Control: no-store
+Pragma: no-cache
+```
+
+响应不是 JSON Token 响应。其内容是一个 kubeconfig，其中选中 contexts 共用一个 bearer token。
+
+常见错误包括：请求或 UUID 无效时的 `400`、浏览器会话缺失或过期时的 `401`、用户无集群权限时的 `403`、集群不存在时的 `404`、集群已禁用时的 `409`，以及签名或文件生成失败时的 `500`。
+
+## 当前用户 Token 管理
+
+```http
+GET    /api/users/me/kubeconfig-tokens
+DELETE /api/users/me/kubeconfig-tokens/:id
+```
+
+这些接口需要已认证用户。列表仅包含当前用户拥有的 Token。`DELETE` 会物理删除 Token 记录；Token 会立即失效且不可恢复。不存在的 Token（包括属于其他用户的 Token）返回 `404`。
+
+列表示例：
+
+```json
+{
+  "tokens": [
+    {
+      "id": 42,
+      "name": "kubeconfig-alice-20260814153045.987",
+      "createdAt": "2026-08-14T07:30:45Z",
+      "expiresAt": "2026-09-13T07:30:45Z",
+      "lastUsedAt": "2026-08-14T08:00:00Z",
+      "signingKeyId": "primary"
+    }
+  ]
+}
+```
+
+客户端根据过期时间计算有效和已过期状态。
+
+## 管理员 Token 管理
+
+```http
+GET    /api/v1/admin/kubeconfig-tokens
+DELETE /api/v1/admin/kubeconfig-tokens/:id
+```
+
+这些接口需要已认证管理员。管理员列表在相同的安全元数据外，还包含 `ownerId` 和 `owner`。管理员可物理删除任意 Token；删除后立即失效且不可恢复。
+
+列表支持 `page`（默认 `1`）、`size`（默认 `20`，最大 `100`）、`owner`（不区分大小写的用户名子串）和 `status`（`active` 或 `expired`）参数。结果按 `createdAt` 降序排列，响应包含 `tokens`、`total`、`page` 和 `size`。
+
+## Kubernetes API 代理
+
+```http
+GET|POST|PUT|PATCH|DELETE /api/v1/clusters/:clusterUUID/k8s-proxy/*path
+Authorization: Bearer <kubeconfig-jwt>
+```
+
+代理会转发所选集群的 Kubernetes API 路径，包括 discovery、资源操作、日志、Watch 和受支持的 Upgrade 请求。每次请求都会检查 Token 状态、所有者状态、集群访问权限和当前 Kite RBAC 权限。过期、已删除、无效或浏览器登录 Token 的请求会得到 HTTP `401` 的 Kubernetes `Status` 响应；无授权请求得到 `403`。
+
+转发到目标 Kubernetes API 前，会移除外部 bearer token、Cookie 和 `Impersonate-*` 请求头。
+
+## 认证模型
+
+Kubeconfig Token 是独立签发的 JWT，包含 `iss`、`sub`、`jti`、`token_use=kubeconfig`、`iat`、`nbf` 和 `exp` claims。它不可刷新，并有服务端状态记录，因此仅校验签名不足以获得访问权限。Kite 会在每个代理请求中检查对应记录，并应用当前 RBAC，而不是在 Token 中嵌入权限快照。
+
+### 有状态 Token 模块
+
+Kite 使用进程内 `pkg/statefultoken` 模块处理有状态 Token 的签发、签名校验、服务端状态校验、删除和最近使用时间更新。Kubeconfig 域通过存储适配层将该模块连接到 `kubeconfig_tokens` 记录；集群选择、kubeconfig YAML 生成、用户启用状态检查、Kubernetes 请求解析和当前 RBAC 仍由 Kubeconfig/集群业务层负责。
+
+该模块不用于浏览器会话 JWT，也不在 Token 中保存集群或资源权限。当前 Kubeconfig Token 使用单个 HS256 密钥和 KID；密钥验证集合与无中断密钥轮换尚未实现。

--- a/docs/zh/config/config-file.md
+++ b/docs/zh/config/config-file.md
@@ -1,6 +1,6 @@
 # 配置文件
 
-Kite 支持通过 YAML 配置文件来管理集群、OAuth/LDAP 和 RBAC 配置。通过配置文件管理的部分在 UI 中将变为**只读**——用户可以查看配置但无法通过界面修改。
+Kite 支持通过 YAML 配置文件来管理集群、OAuth/LDAP、SMTP 和 RBAC 配置。通过配置文件管理的部分在 UI 中将变为**只读**——用户可以查看配置但无法通过界面修改。
 
 这对于 GitOps 工作流非常有用，配置可以版本控制并通过 Helm 部署。
 
@@ -70,6 +70,18 @@ ldap:
   groupFilter: "(member=%s)"
   groupNameAttribute: "cn"
 
+smtp:
+  enabled: true
+  host: "smtp.example.com"
+  port: 587
+  username: "kite"
+  password: "smtp-password"
+  fromEmail: "kite@example.com"
+  fromName: "Kite"
+  encryption: "starttls" # 可选值：none、starttls、tls
+  skipTLSVerify: false
+  timeoutSeconds: 30
+
 rbac:
   roles:
     - name: admin
@@ -100,7 +112,7 @@ rbac:
       oidcGroups: ["developers"]
 ```
 
-你只需包含想要管理的部分。例如，如果只想通过配置文件管理集群，只需包含 `clusters` 部分——OAuth、LDAP 和 RBAC 仍然可以通过 UI 编辑。
+你只需包含想要管理的部分。例如，如果只想通过配置文件管理集群，只需包含 `clusters` 部分——OAuth、LDAP、SMTP 和 RBAC 仍然可以通过 UI 编辑。
 
 ## 通过 Helm 使用
 
@@ -226,71 +238,88 @@ config:
 
 ### 集群配置
 
-| 字段            | 类型    | 描述                    | 必填   |
-| --------------- | ------- | ----------------------- | ------ |
-| `name`          | string  | 唯一集群名称            | 是     |
-| `description`   | string  | 集群描述                | 否     |
-| `config`        | string  | Kubeconfig YAML 内容    | 否 *   |
-| `prometheusURL` | string  | Prometheus 端点 URL     | 否     |
-| `inCluster`     | boolean | 使用集群内服务账号      | 否     |
-| `default`       | boolean | 设为默认集群            | 否     |
+| 字段            | 类型    | 描述                 | 必填 |
+| --------------- | ------- | -------------------- | ---- |
+| `name`          | string  | 唯一集群名称         | 是   |
+| `description`   | string  | 集群描述             | 否   |
+| `config`        | string  | Kubeconfig YAML 内容 | 否 * |
+| `prometheusURL` | string  | Prometheus 端点 URL  | 否   |
+| `inCluster`     | boolean | 使用集群内服务账号   | 否   |
+| `default`       | boolean | 设为默认集群         | 否   |
 
 \* 必须提供 `config` 或 `inCluster: true`。
 
 ### OAuth 提供者配置
 
-| 字段            | 类型    | 描述                                    | 必填 |
-| --------------- | ------- | --------------------------------------- | ---- |
-| `name`          | string  | 提供者名称（如 "google"、"github"）     | 是   |
-| `clientId`      | string  | OAuth Client ID                         | 是   |
-| `clientSecret`  | string  | OAuth Client Secret                     | 是   |
-| `issuer`        | string  | OIDC Issuer URL（启用自动发现）         | 否   |
-| `authUrl`       | string  | 授权端点（无 issuer 时）                | 否   |
-| `tokenUrl`      | string  | Token 端点（无 issuer 时）              | 否   |
-| `userInfoUrl`   | string  | 用户信息端点（无 issuer 时）            | 否   |
-| `scopes`        | string  | 逗号分隔的 scopes                       | 否   |
-| `usernameClaim` | string  | 用于用户名的 JWT claim                  | 否   |
-| `groupsClaim`   | string  | 用于组的 JWT claim                      | 否   |
-| `allowedGroups` | string  | 逗号分隔的允许组列表                    | 否   |
-| `enabled`       | boolean | 启用此提供者                            | 否   |
+| 字段            | 类型    | 描述                                | 必填 |
+| --------------- | ------- | ----------------------------------- | ---- |
+| `name`          | string  | 提供者名称（如 "google"、"github"） | 是   |
+| `clientId`      | string  | OAuth Client ID                     | 是   |
+| `clientSecret`  | string  | OAuth Client Secret                 | 是   |
+| `issuer`        | string  | OIDC Issuer URL（启用自动发现）     | 否   |
+| `authUrl`       | string  | 授权端点（无 issuer 时）            | 否   |
+| `tokenUrl`      | string  | Token 端点（无 issuer 时）          | 否   |
+| `userInfoUrl`   | string  | 用户信息端点（无 issuer 时）        | 否   |
+| `scopes`        | string  | 逗号分隔的 scopes                   | 否   |
+| `usernameClaim` | string  | 用于用户名的 JWT claim              | 否   |
+| `groupsClaim`   | string  | 用于组的 JWT claim                  | 否   |
+| `allowedGroups` | string  | 逗号分隔的允许组列表                | 否   |
+| `enabled`       | boolean | 启用此提供者                        | 否   |
 
 ### LDAP 配置
 
-| 字段                   | 类型    | 描述                | 默认值         |
-| ---------------------- | ------- | ------------------- | -------------- |
-| `enabled`              | boolean | 启用 LDAP 认证      | `false`        |
-| `serverUrl`            | string  | LDAP 服务器 URL     |                |
-| `useStartTLS`          | boolean | 对 `ldap://` 使用 StartTLS | `false` |
-| `bindDn`               | string  | 服务账号 DN         |                |
-| `bindPassword`         | string  | 服务账号密码        |                |
-| `userBaseDn`           | string  | 用户搜索 Base DN    |                |
-| `userFilter`           | string  | 用户搜索过滤器      | `(uid=%s)`     |
-| `usernameAttribute`    | string  | 用户名属性          | `uid`          |
-| `displayNameAttribute` | string  | 显示名属性          | `cn`           |
-| `groupBaseDn`          | string  | 组搜索 Base DN      |                |
-| `groupFilter`          | string  | 组成员过滤器        | `(member=%s)`  |
-| `groupNameAttribute`   | string  | 组名属性            | `cn`           |
+| 字段                   | 类型    | 描述                       | 默认值        |
+| ---------------------- | ------- | -------------------------- | ------------- |
+| `enabled`              | boolean | 启用 LDAP 认证             | `false`       |
+| `serverUrl`            | string  | LDAP 服务器 URL            |               |
+| `useStartTLS`          | boolean | 对 `ldap://` 使用 StartTLS | `false`       |
+| `bindDn`               | string  | 服务账号 DN                |               |
+| `bindPassword`         | string  | 服务账号密码               |               |
+| `userBaseDn`           | string  | 用户搜索 Base DN           |               |
+| `userFilter`           | string  | 用户搜索过滤器             | `(uid=%s)`    |
+| `usernameAttribute`    | string  | 用户名属性                 | `uid`         |
+| `displayNameAttribute` | string  | 显示名属性                 | `cn`          |
+| `groupBaseDn`          | string  | 组搜索 Base DN             |               |
+| `groupFilter`          | string  | 组成员过滤器               | `(member=%s)` |
+| `groupNameAttribute`   | string  | 组名属性                   | `cn`          |
+
+### SMTP 配置
+
+| 字段             | 类型    | 描述                                      | 必填   |
+| ---------------- | ------- | ----------------------------------------- | ------ |
+| `enabled`        | boolean | 启用 SMTP 邮件投递                        | 是     |
+| `host`           | string  | SMTP 服务器主机名或地址                   | 启用时 |
+| `port`           | integer | SMTP 服务器端口（`1`–`65535`）            | 启用时 |
+| `username`       | string  | 可选的 SMTP 认证用户名                    | 否     |
+| `password`       | string  | 可选的 SMTP 认证密码                      | 否     |
+| `fromEmail`      | string  | 发件人邮箱地址                            | 启用时 |
+| `fromName`       | string  | 可选的发件人显示名称                      | 否     |
+| `encryption`     | string  | 传输安全模式：`none`、`starttls` 或 `tls` | 启用时 |
+| `skipTLSVerify`  | boolean | 跳过 TLS 证书校验                         | 否     |
+| `timeoutSeconds` | integer | 连接和邮件操作超时时间（秒）              | 否     |
+
+仅在 SMTP 启用时显示和提供测试功能。SMTP 未由配置文件管理时，测试邮件使用当前页面表单中的配置，不会保存；测试成功后需点击**设置 → 通用设置**页面底部的**保存**按钮才会持久化。SMTP 由配置文件管理时，表单为只读，测试使用展示的托管配置。
 
 ### RBAC 配置
 
 #### 角色
 
-| 字段          | 类型     | 描述                                     | 必填 |
-| ------------- | -------- | ---------------------------------------- | ---- |
-| `name`        | string   | 角色名称                                 | 是   |
-| `description` | string   | 角色描述                                 | 否   |
-| `clusters`    | string[] | 集群匹配模式（`*`、`prod-*`、`!dev`）   | 是   |
-| `namespaces`  | string[] | 命名空间匹配模式                         | 是   |
-| `resources`   | string[] | 资源类型（`pods`、`*` 等）               | 是   |
-| `verbs`       | string[] | 允许的操作（`get`、`create`、`*`）       | 是   |
+| 字段          | 类型     | 描述                                  | 必填 |
+| ------------- | -------- | ------------------------------------- | ---- |
+| `name`        | string   | 角色名称                              | 是   |
+| `description` | string   | 角色描述                              | 否   |
+| `clusters`    | string[] | 集群匹配模式（`*`、`prod-*`、`!dev`） | 是   |
+| `namespaces`  | string[] | 命名空间匹配模式                      | 是   |
+| `resources`   | string[] | 资源类型（`pods`、`*` 等）            | 是   |
+| `verbs`       | string[] | 允许的操作（`get`、`create`、`*`）    | 是   |
 
 #### 角色映射
 
-| 字段         | 类型     | 描述                          | 必填 |
-| ------------ | -------- | ----------------------------- | ---- |
-| `name`       | string   | 要映射的角色名称              | 是   |
-| `users`      | string[] | 用户名（`*` 表示所有用户）    | 否   |
-| `oidcGroups` | string[] | OIDC/LDAP 组名                | 否   |
+| 字段         | 类型     | 描述                       | 必填 |
+| ------------ | -------- | -------------------------- | ---- |
+| `name`       | string   | 要映射的角色名称           | 是   |
+| `users`      | string[] | 用户名（`*` 表示所有用户） | 否   |
+| `oidcGroups` | string[] | OIDC/LDAP 组名             | 否   |
 
 ## 行为说明
 

--- a/docs/zh/config/env.md
+++ b/docs/zh/config/env.md
@@ -8,7 +8,9 @@ Kite 默认支持一些环境变量，来改变一些配置项的默认值。
 - **KUBECONFIG**：兼容旧配置的 kubeconfig 环境变量。仅在未设置 `KITE_CONFIG_FILE` 时读取并导入集群配置。
 - **ANONYMOUS_USER_ENABLED**：启用匿名用户访问，默认值为 `false`，当启用后所有访问将不再需要身份验证，并且默认拥有最高权限。
 
-- **JWT_SECRET**：用于签名和验证 JWT 的密钥
+- **JWT_SECRET**：用于签名和验证浏览器会话 JWT 的密钥。
+- **KUBECONFIG_JWT_SECRET**：用于签名和验证下载 kubeconfig JWT 的专用密钥。生产环境中应与 `JWT_SECRET` 独立配置；当 `KITE_ENV=production` 时，Kite 要求设置该变量。
+- **KUBECONFIG_JWT_KID**：写入新签发 kubeconfig JWT 的 `kid` header、并在验证时匹配的标识。当前实现使用一个配置的 HS256 密钥（`KUBECONFIG_JWT_SECRET`）和一个对应的 KID；尚未实现验证 key set。
 - **KITE_ENCRYPT_KEY**：用于加密敏感数据的密钥, 例如用户密码，OAuth 的 clientSecret ，kubeconfig 等。
 
 - **HOST**: 用户 OAuth 2.0 授权回调地址生成，默认会从请求头获取，如果您发现结果不及预期可以手动配置此环境变量。

--- a/docs/zh/config/env.md
+++ b/docs/zh/config/env.md
@@ -2,7 +2,7 @@
 
 Kite 默认支持一些环境变量，来改变一些配置项的默认值。
 
-- **KITE_CONFIG_FILE**：配置文件路径。该功能仅适用于 Kite `v0.10.0` 及以上版本。设置后，Kite 从该文件加载集群、OAuth、LDAP、RBAC 和超级用户设置。详见[配置文件](/zh/config/config-file)。
+- **KITE_CONFIG_FILE**：配置文件路径。该功能仅适用于 Kite `v0.10.0` 及以上版本。设置后，Kite 从该文件加载集群、OAuth、LDAP、SMTP、RBAC 和超级用户设置。详见[配置文件](/zh/config/config-file)。
 - **KITE_USERNAME**：兼容旧配置的超级用户名环境变量。仅在未设置 `KITE_CONFIG_FILE` 时，用于环境变量到数据库配置的迁移。
 - **KITE_PASSWORD**：兼容旧配置的超级用户密码环境变量。仅在未设置 `KITE_CONFIG_FILE` 时，用于环境变量到数据库配置的迁移。
 - **KUBECONFIG**：兼容旧配置的 kubeconfig 环境变量。仅在未设置 `KITE_CONFIG_FILE` 时读取并导入集群配置。

--- a/docs/zh/guide/kubeconfig-download.md
+++ b/docs/zh/guide/kubeconfig-download.md
@@ -1,0 +1,59 @@
+---
+outline: deep
+---
+
+# 下载 kubeconfig
+
+Kite 可以生成 kubeconfig，使您通过 Kite 访问 Kubernetes API 并使用 `kubectl`。下载文件包含独立的、有状态的 Kubeconfig Token；其中不包含浏览器登录 Token、目标集群 kubeconfig 或 Cluster Agent 凭证。
+
+## 下载并选择集群
+
+1. 登录并选择一个您有访问权限的集群。
+2. 在顶部工具栏中，点击 **Kubectl Terminal** 旁的 **下载 Kubeconfig**。
+3. 弹窗默认选中当前可访问且已启用的集群。可选择更多集群，或使用**全选** / **取消全选**；集群较多时，可通过搜索框按名称筛选。
+4. 选择有效期预设，或选择**自定义**并选择到期的年、月、日、时、分、秒。
+5. 点击**下载**。Kite 会下载 `kite-kubeconfig.yaml`。
+
+默认有效期为 30 天。可选预设为 1 天、7 天、30 天和 1 年。自定义时长必须是 3,600 秒（1 小时）至 157,680,000 秒（1,825 天）之间的整数秒。弹窗显示的过期时间仅为估算，最终过期时间由服务端决定。
+
+每个选中集群都会生成独立的 cluster 和 context。如果当前集群被选中，它会成为 kubeconfig 的 `current-context`；否则使用选中列表中的第一个集群。
+
+## 使用下载文件
+
+请将该文件视为密码并限制文件权限：
+
+```bash
+chmod 600 ~/Downloads/kite-kubeconfig.yaml
+export KUBECONFIG=~/Downloads/kite-kubeconfig.yaml
+kubectl config get-contexts
+kubectl get pods -A
+```
+
+也可以仅为单个命令指定文件：
+
+```bash
+kubectl --kubeconfig ~/Downloads/kite-kubeconfig.yaml get pods -A
+```
+
+Kite 会根据您当前的 Kite 账号和 RBAC 权限，对每一次代理的 Kubernetes 请求授权。账号状态、集群访问权限、命名空间权限或资源权限的变化会作用于后续命令。
+
+## 流式与交互式命令
+
+该代理用于普通 Kubernetes API 请求，也用于 Watch、日志、`exec`、`attach` 和 `port-forward` 请求。例如：
+
+```bash
+kubectl get pods -A -w
+kubectl logs -f deployment/example
+kubectl exec -it pod/example -- sh
+kubectl port-forward service/example 8080:80
+```
+
+`ktctl` 的固定支持版本和命令范围尚未确认。在项目发布固定版本和命令矩阵前，请勿将 ktctl 兼容性视为发布保证。
+
+## Token 生命周期与删除
+
+每次下载都会创建一个独立的 Kubeconfig Token。Token 不支持刷新或续期；过期后请重新下载 kubeconfig。删除一个 Token 不会影响您的其他 kubeconfig 下载。
+
+在**账号设置**的独立 **Kubeconfig Tokens** 区域，可查看 Token 元数据并删除不再需要的 Token。管理员在独立的管理视图中查看和删除 Token。两个列表均不会显示 kubeconfig JWT、其 `jti` 或哈希。
+
+删除 Token 会移除其记录，使其立即失效且不可撤销或恢复。Token 过期或被删除后，`kubectl` 请求会收到 HTTP 401 和提示重新下载 kubeconfig 的 Kubernetes Status 消息。文件丢失或泄露时，请立即删除其 Token，仅在需要时重新下载。

--- a/e2e/specs/general-kubectl-toggle.spec.ts
+++ b/e2e/specs/general-kubectl-toggle.spec.ts
@@ -1,37 +1,41 @@
-import { expect, test } from '@playwright/test'
+import { expect, test } from "@playwright/test";
 
-test('kubectl terminal toggle updates the header button', async ({ page }) => {
-  await page.goto('/')
+test("kubectl terminal toggle updates the header button", async ({ page }) => {
+  await page.goto("/");
 
-  const kubectlButton = page.getByRole('button', {
-    name: 'Toggle Kubectl Terminal',
-  })
-  await expect(kubectlButton).toBeVisible()
+  const kubectlButton = page.getByRole("button", {
+    name: "Toggle Kubectl Terminal",
+  });
+  await expect(kubectlButton).toBeVisible();
 
-  await page.goto('/settings?tab=general')
-  await expect(page.getByRole('heading', { name: 'Settings' })).toBeVisible()
+  await page.goto("/settings?tab=general");
+  await expect(page.getByRole("heading", { name: "Settings" })).toBeVisible();
 
-  const kubectlSection = page
-    .locator('div.rounded-lg.border')
-    .filter({ has: page.getByText('Kubectl', { exact: true }) })
-    .first()
-  const kubectlSwitch = kubectlSection.getByRole('switch').first()
+  const kubectlSwitch = page.getByRole("switch", {
+    name: "Enable kubectl",
+  });
 
-  await expect(kubectlSwitch).toBeChecked()
-  await kubectlSwitch.click()
-  await expect(kubectlSwitch).not.toBeChecked()
-  await page.getByRole('button', { name: 'Save' }).click()
-  await expect(page.getByText('General settings updated')).toBeVisible()
+  await expect(kubectlSwitch).toBeChecked();
+  await kubectlSwitch.click();
+  await expect(kubectlSwitch).not.toBeChecked();
+  await page
+    .locator("div.flex.justify-end")
+    .getByRole("button", { name: "Save" })
+    .click();
+  await expect(page.getByText("General settings updated")).toBeVisible();
 
-  await page.reload()
-  await expect(kubectlButton).toHaveCount(0)
+  await page.reload();
+  await expect(kubectlButton).toHaveCount(0);
 
-  await expect(kubectlSwitch).not.toBeChecked()
-  await kubectlSwitch.click()
-  await expect(kubectlSwitch).toBeChecked()
-  await page.getByRole('button', { name: 'Save' }).click()
-  await expect(page.getByText('General settings updated')).toBeVisible()
+  await expect(kubectlSwitch).not.toBeChecked();
+  await kubectlSwitch.click();
+  await expect(kubectlSwitch).toBeChecked();
+  await page
+    .locator("div.flex.justify-end")
+    .getByRole("button", { name: "Save" })
+    .click();
+  await expect(page.getByText("General settings updated")).toBeVisible();
 
-  await page.reload()
-  await expect(kubectlButton).toBeVisible()
-})
+  await page.reload();
+  await expect(kubectlButton).toBeVisible();
+});

--- a/e2e/specs/kubeconfig-download.spec.ts
+++ b/e2e/specs/kubeconfig-download.spec.ts
@@ -1,0 +1,54 @@
+import { expect, test } from "@playwright/test";
+
+test("downloads a kubeconfig for the current cluster with the selected TTL", async ({
+  page,
+}) => {
+  await page.route("**/api/v1/kubeconfig", async (route) => {
+    expect(route.request().method()).toBe("POST");
+    const { clusterUUIDs, ttlSeconds } = await route.request().postDataJSON();
+    expect(ttlSeconds).toBe(86400);
+    expect(clusterUUIDs[0]).toEqual(expect.any(String));
+    expect(clusterUUIDs[0]).not.toBe("");
+    await route.fulfill({
+      status: 200,
+      contentType: "application/yaml",
+      headers: {
+        "Content-Disposition": 'attachment; filename="kite-kubeconfig.yaml"',
+        "Cache-Control": "no-store",
+      },
+      body: "apiVersion: v1\nkind: Config\n",
+    });
+  });
+
+  await page.goto("/");
+
+  const downloadButton = page.getByRole("button", {
+    name: "Download Kubeconfig",
+  });
+  await expect(downloadButton).toBeVisible();
+  await downloadButton.click();
+  const dialog = page.getByRole("dialog");
+  await expect(dialog).toBeVisible();
+  const clusterCheckbox = dialog.getByRole("checkbox").first();
+  const clusterLabel = clusterCheckbox.locator("xpath=ancestor::label");
+  await expect(clusterCheckbox).toBeVisible();
+  await expect(clusterCheckbox).toBeChecked();
+  await expect(clusterLabel).toHaveText(/\S/);
+  await expect(dialog.getByText(/1 selected\s*\/\s*1 total/)).toBeVisible();
+
+  const clusterSearch = dialog.getByPlaceholder("Search clusters");
+  await clusterSearch.fill("missing");
+  await expect(
+    dialog.getByRole("button", { name: "Select matching", exact: true }),
+  ).toBeDisabled();
+  await expect(
+    dialog.getByText("No matching clusters found.", { exact: true }),
+  ).toBeVisible();
+  await clusterSearch.fill("");
+
+  await dialog.getByTestId("kubeconfig-ttl-86400").click();
+
+  const download = page.waitForEvent("download");
+  await dialog.getByRole("button", { name: "Download", exact: true }).click();
+  expect((await download).suggestedFilename()).toBe("kite-kubeconfig.yaml");
+});

--- a/e2e/specs/settings-management.spec.ts
+++ b/e2e/specs/settings-management.spec.ts
@@ -1,24 +1,80 @@
-import { expect, test } from '@playwright/test'
+import { expect, test } from "@playwright/test";
 
-test.describe('settings management', () => {
-  test('creates an API key and shows it in the table', async ({ page }) => {
-    const apiKeyName = `e2e-api-key-${Date.now()}`
+test.describe("settings management", () => {
+  test("admin can save unauthenticated SMTP settings without sending email", async ({
+    page,
+  }) => {
+    await page.goto("/settings?tab=general");
 
-    await page.goto('/settings?tab=apikeys')
+    await expect(page.getByRole("heading", { name: "Settings" })).toBeVisible();
 
-    await expect(page.getByRole('heading', { name: 'Settings' })).toBeVisible()
-    await expect(page.getByRole('button', { name: 'Add API Key' })).toBeVisible()
+    const smtpSection = page
+      .locator("div.rounded-lg.border")
+      .filter({ has: page.getByText("SMTP", { exact: true }) });
+    const smtpSwitch = smtpSection.getByRole("switch", {
+      name: "Enable SMTP",
+    });
+    if ((await smtpSwitch.getAttribute("data-state")) !== "checked") {
+      await smtpSwitch.click();
+    }
+    await expect(smtpSection.getByLabel("Test recipient")).toBeVisible();
 
-    await page.getByRole('button', { name: 'Add API Key' }).click()
+    await smtpSection.getByLabel("Host").fill("smtp.example.test");
+    await smtpSection.getByLabel("Port").fill("2525");
+    await smtpSection.getByLabel("From Email").fill("kite@example.test");
+    await smtpSection.getByLabel("From Name").fill("Kite E2E");
+    await smtpSection.getByLabel("Encryption").click();
+    await page.getByRole("option", { name: "None" }).click();
+
+    const saveResponse = page.waitForResponse(
+      (response) =>
+        response.url().includes("/api/v1/admin/general-setting/") &&
+        response.request().method() === "PUT",
+    );
+    await page.getByRole("button", { name: "Save", exact: true }).click();
+    await expect(page.getByText("General settings updated")).toBeVisible();
+    const response = await saveResponse;
+    expect(response.ok()).toBe(true);
+
+    await page.reload();
+    const refreshedSMTPSection = page
+      .locator("div.rounded-lg.border")
+      .filter({ has: page.getByText("SMTP", { exact: true }) });
     await expect(
-      page.getByRole('dialog', { name: 'Create API Key' })
-    ).toBeVisible()
+      refreshedSMTPSection.getByRole("switch", { name: "Enable SMTP" }),
+    ).toBeChecked();
+    await expect(refreshedSMTPSection.getByLabel("Host")).toHaveValue(
+      "smtp.example.test",
+    );
+    await expect(refreshedSMTPSection.getByLabel("Port")).toHaveValue("2525");
+    await expect(refreshedSMTPSection.getByLabel("From Email")).toHaveValue(
+      "kite@example.test",
+    );
+    await expect(refreshedSMTPSection.getByLabel("From Name")).toHaveValue(
+      "Kite E2E",
+    );
+  });
 
-    await page.getByLabel('Name').fill(apiKeyName)
-    await page.getByRole('button', { name: 'Create' }).click()
+  test("creates an API key and shows it in the table", async ({ page }) => {
+    const apiKeyName = `e2e-api-key-${Date.now()}`;
 
-    const row = page.getByRole('row').filter({ hasText: apiKeyName })
-    await expect(row).toBeVisible()
-    await expect(row.locator('code')).not.toHaveText(/^•+$/)
-  })
-})
+    await page.goto("/settings?tab=apikeys");
+
+    await expect(page.getByRole("heading", { name: "Settings" })).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Add API Key" }),
+    ).toBeVisible();
+
+    await page.getByRole("button", { name: "Add API Key" }).click();
+    await expect(
+      page.getByRole("dialog", { name: "Create API Key" }),
+    ).toBeVisible();
+
+    await page.getByLabel("Name").fill(apiKeyName);
+    await page.getByRole("button", { name: "Create" }).click();
+
+    const row = page.getByRole("row").filter({ hasText: apiKeyName });
+    await expect(row).toBeVisible();
+    await expect(row.locator("code")).not.toHaveText(/^•+$/);
+  });
+});

--- a/e2e/specs/user-access.spec.ts
+++ b/e2e/specs/user-access.spec.ts
@@ -1,221 +1,235 @@
-import { type Browser, type Page, expect, test } from '@playwright/test'
+import { type Browser, type Page, expect, test } from "@playwright/test";
 
-import { adminUser as seededAdminUser } from '../env'
+import { adminUser as seededAdminUser } from "../env";
 
 async function openUsersPage(page: Page) {
-  await page.goto('/settings?tab=users')
-  await expect(page.getByRole('heading', { name: 'Settings' })).toBeVisible()
-  await expect(page.getByRole('button', { name: 'Add Password User' })).toBeVisible()
+  await page.goto("/settings?tab=users");
+  await expect(page.getByRole("heading", { name: "Settings" })).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: "Add Password User" }),
+  ).toBeVisible();
 }
 
 async function createPasswordUser(
   page: Page,
   username: string,
   name: string,
-  password: string
+  password: string,
 ) {
-  await page.getByRole('button', { name: 'Add Password User' }).click()
+  await page.getByRole("button", { name: "Add Password User" }).click();
 
-  const dialog = page.getByRole('dialog', { name: 'Add Password User' })
-  await expect(dialog).toBeVisible()
+  const dialog = page.getByRole("dialog", { name: "Add Password User" });
+  await expect(dialog).toBeVisible();
 
-  await dialog.locator('input').nth(0).fill(username)
-  await dialog.locator('input').nth(1).fill(name)
-  await dialog.locator('input').nth(2).fill(password)
-  await dialog.getByRole('button', { name: 'Create' }).click()
+  await dialog.locator("input").nth(0).fill(username);
+  await dialog.locator("input").nth(1).fill(name);
+  await dialog.locator("input").nth(2).fill(password);
+  await dialog.getByRole("button", { name: "Create" }).click();
 
-  await expect(dialog).toBeHidden()
-  await expect(page.getByRole('row').filter({ hasText: username })).toBeVisible()
+  await expect(dialog).toBeHidden();
+  await expect(
+    page.getByRole("row").filter({ hasText: username }),
+  ).toBeVisible();
 }
 
 async function assignBuiltInRole(
   page: Page,
   username: string,
-  roleName: 'viewer' | 'admin'
+  roleName: "viewer" | "admin",
 ) {
-  const row = page.getByRole('row').filter({ hasText: username }).first()
-  await expect(row).toBeVisible()
+  const row = page.getByRole("row").filter({ hasText: username }).first();
+  await expect(row).toBeVisible();
 
-  await row.getByRole('button', { name: 'Actions' }).click()
-  await page.getByRole('menuitem', { name: 'Assign' }).click()
+  await row.getByRole("button", { name: "Actions" }).click();
+  await page.getByRole("menuitem", { name: "Assign" }).click();
 
-  const dialog = page.getByRole('dialog', { name: 'Assign Roles' })
-  await expect(dialog).toBeVisible()
-  const checkbox = dialog.getByRole('checkbox').nth(roleName === 'admin' ? 0 : 1)
-  await expect(checkbox).toBeVisible()
-  await checkbox.click()
-  await expect(checkbox).toBeChecked()
+  const dialog = page.getByRole("dialog", { name: "Assign Roles" });
+  await expect(dialog).toBeVisible();
+  const checkbox = dialog
+    .getByRole("checkbox")
+    .nth(roleName === "admin" ? 0 : 1);
+  await expect(checkbox).toBeVisible();
+  await checkbox.click();
+  await expect(checkbox).toBeChecked();
 
-  await dialog.getByRole('button', { name: 'Close' }).first().click()
-  await expect(dialog).toBeHidden()
-  await expect(page.getByRole('row').filter({ hasText: username })).toContainText(
-    roleName
-  )
+  await dialog.getByRole("button", { name: "Close" }).first().click();
+  await expect(dialog).toBeHidden();
+  await expect(
+    page.getByRole("row").filter({ hasText: username }),
+  ).toContainText(roleName);
 }
 
-async function deleteUser(
-  page: Page,
-  username: string
-) {
-  const row = page.getByRole('row').filter({ hasText: username }).first()
-  await expect(row).toBeVisible()
+async function deleteUser(page: Page, username: string) {
+  const row = page.getByRole("row").filter({ hasText: username }).first();
+  await expect(row).toBeVisible();
 
-  await row.getByRole('button', { name: 'Actions' }).click()
-  await page.getByRole('menuitem', { name: 'Delete' }).click()
+  await row.getByRole("button", { name: "Actions" }).click();
+  await page.getByRole("menuitem", { name: "Delete" }).click();
 
-  const dialog = page.getByRole('dialog').last()
-  await expect(dialog).toBeVisible()
-  await dialog.getByPlaceholder(username).fill(username)
-  await dialog.getByRole('button', { name: 'Delete' }).click()
+  const dialog = page.getByRole("dialog").last();
+  await expect(dialog).toBeVisible();
+  await dialog.getByPlaceholder(username).fill(username);
+  await dialog.getByRole("button", { name: "Delete" }).click();
 
-  await expect(page.getByRole('row').filter({ hasText: username })).toHaveCount(0)
+  await expect(page.getByRole("row").filter({ hasText: username })).toHaveCount(
+    0,
+  );
 }
 
 async function loginFreshContext(
   browser: Browser,
   origin: string,
   username: string,
-  password: string
+  password: string,
 ) {
   const context = await browser.newContext({
     storageState: { cookies: [], origins: [] },
-  })
-  const page = await context.newPage()
+  });
+  const page = await context.newPage();
 
-  await page.goto(`${origin}/login`)
-  await loginWithPasswordUi(page, username, password)
-  await page.waitForURL((url) => url.pathname === '/')
-  await expect(page.getByRole('heading', { name: 'Overview' })).toBeVisible()
+  await page.goto(`${origin}/login`);
+  await loginWithPasswordUi(page, username, password);
+  await page.waitForURL((url) => url.pathname === "/");
+  await expect(page.getByRole("heading", { name: "Overview" })).toBeVisible();
 
-  return { context, page }
+  return { context, page };
 }
 
 async function loginWithPasswordUi(
   page: Page,
   username: string,
-  password: string
+  password: string,
 ) {
   await expect(
-    page.getByRole('button', { name: 'Sign In with Password' })
-  ).toBeVisible()
+    page.getByRole("button", { name: "Sign In with Password" }),
+  ).toBeVisible();
 
-  await page.getByLabel('Username').fill(username)
-  await page.getByLabel('Password', { exact: true }).fill(password)
-  await page.getByRole('button', { name: 'Sign In with Password' }).click()
+  await page.getByLabel("Username").fill(username);
+  await page.getByLabel("Password", { exact: true }).fill(password);
+  await page.getByRole("button", { name: "Sign In with Password" }).click();
 }
 
 async function loginCurrentContext(
   page: Page,
   origin: string,
   username: string,
-  password: string
+  password: string,
 ) {
-  await page.goto(`${origin}/login`)
-  await loginWithPasswordUi(page, username, password)
-  await page.waitForURL((url) => url.pathname === '/')
-  await expect(page.getByRole('heading', { name: 'Overview' })).toBeVisible()
+  await page.goto(`${origin}/login`);
+  await loginWithPasswordUi(page, username, password);
+  await page.waitForURL((url) => url.pathname === "/");
+  await expect(page.getByRole("heading", { name: "Overview" })).toBeVisible();
 }
 
-test('password user lifecycle and built-in roles', async ({
+test("password user lifecycle and built-in roles", async ({
   page,
   browser,
 }) => {
-  const suffix = Date.now().toString(36)
+  const suffix = Date.now().toString(36);
   const noRoleUser = {
     username: `e2e-norole-${suffix}`,
-    name: 'E2E No Role',
-    password: 'E2Epass!2345',
-  }
+    name: "E2E No Role",
+    password: "E2Epass!2345",
+  };
   const viewerUser = {
     username: `e2e-viewer-${suffix}`,
-    name: 'E2E Viewer',
-    password: 'E2Epass!2345',
-  }
+    name: "E2E Viewer",
+    password: "E2Epass!2345",
+  };
   const managedAdminUser = {
     username: `e2e-admin-${suffix}`,
-    name: 'E2E Admin',
-    password: 'E2Epass!2345',
-  }
+    name: "E2E Admin",
+    password: "E2Epass!2345",
+  };
 
-  await openUsersPage(page)
-  const origin = new URL(page.url()).origin
+  await openUsersPage(page);
+  const origin = new URL(page.url()).origin;
   await createPasswordUser(
     page,
     noRoleUser.username,
     noRoleUser.name,
-    noRoleUser.password
-  )
+    noRoleUser.password,
+  );
 
   await page.evaluate(async () => {
-    await fetch('/api/auth/logout', {
-      method: 'POST',
-      credentials: 'include',
-    })
-  })
-  await page.goto(`${origin}/login`)
-  await loginWithPasswordUi(page, noRoleUser.username, noRoleUser.password)
-  await expect(page).toHaveURL(/\/login/)
-  await expect(page.getByRole('alert')).toContainText(
-    'insufficient permissions'
-  )
+    await fetch("/api/auth/logout", {
+      method: "POST",
+      credentials: "include",
+    });
+  });
+  await page.goto(`${origin}/login`);
+  await loginWithPasswordUi(page, noRoleUser.username, noRoleUser.password);
+  await expect(page).toHaveURL(/\/login/);
+  await expect(page.getByRole("alert")).toContainText(
+    "insufficient permissions",
+  );
   await loginCurrentContext(
     page,
     origin,
     seededAdminUser.username,
-    seededAdminUser.password
-  )
+    seededAdminUser.password,
+  );
 
-  await openUsersPage(page)
+  await openUsersPage(page);
   await createPasswordUser(
     page,
     viewerUser.username,
     viewerUser.name,
-    viewerUser.password
-  )
+    viewerUser.password,
+  );
   await createPasswordUser(
     page,
     managedAdminUser.username,
     managedAdminUser.name,
-    managedAdminUser.password
-  )
+    managedAdminUser.password,
+  );
 
-  await assignBuiltInRole(page, viewerUser.username, 'viewer')
-  await assignBuiltInRole(page, managedAdminUser.username, 'admin')
+  await assignBuiltInRole(page, viewerUser.username, "viewer");
+  await assignBuiltInRole(page, managedAdminUser.username, "admin");
 
   const viewerSession = await loginFreshContext(
     browser,
     origin,
     viewerUser.username,
-    viewerUser.password
-  )
-  await viewerSession.page.goto(`${origin}/namespaces`)
+    viewerUser.password,
+  );
+  await viewerSession.page.goto(`${origin}/namespaces`);
   await expect(
-    viewerSession.page.getByRole('link', { name: 'kube-system' })
-  ).toBeVisible()
+    viewerSession.page.getByRole("link", { name: "kube-system" }),
+  ).toBeVisible();
   await expect(
-    viewerSession.page.getByRole('button', { name: 'Settings', exact: true })
-  ).toHaveCount(0)
+    viewerSession.page.getByRole("button", { name: "Settings", exact: true }),
+  ).toHaveCount(0);
   await expect(
-    viewerSession.page.getByRole('button', { name: 'Toggle Kubectl Terminal' })
-  ).toHaveCount(0)
-  await viewerSession.context.close()
+    viewerSession.page.getByRole("button", { name: "Toggle Kubectl Terminal" }),
+  ).toHaveCount(0);
+  await viewerSession.page.goto(`${origin}/settings`);
+  await expect(
+    viewerSession.page.getByText("Access Denied", { exact: true }),
+  ).toBeVisible();
+  await expect(
+    viewerSession.page.getByText(
+      "You do not have permission to access this page.",
+    ),
+  ).toBeVisible();
+  await viewerSession.context.close();
 
   const adminSession = await loginFreshContext(
     browser,
     origin,
     managedAdminUser.username,
-    managedAdminUser.password
-  )
+    managedAdminUser.password,
+  );
   await expect(
-    adminSession.page.getByRole('button', { name: 'Settings', exact: true })
-  ).toBeVisible()
+    adminSession.page.getByRole("button", { name: "Settings", exact: true }),
+  ).toBeVisible();
   await expect(
-    adminSession.page.getByRole('button', { name: 'Toggle Kubectl Terminal' })
-  ).toBeVisible()
-  await adminSession.context.close()
+    adminSession.page.getByRole("button", { name: "Toggle Kubectl Terminal" }),
+  ).toBeVisible();
+  await adminSession.context.close();
 
-  await openUsersPage(page)
-  await deleteUser(page, noRoleUser.username)
-  await deleteUser(page, viewerUser.username)
-  await deleteUser(page, managedAdminUser.username)
-})
+  await openUsersPage(page);
+  await deleteUser(page, noRoleUser.username);
+  await deleteUser(page, viewerUser.username);
+  await deleteUser(page, managedAdminUser.username);
+});

--- a/go.mod
+++ b/go.mod
@@ -60,6 +60,7 @@ require (
 	github.com/go-viper/mapstructure/v2 v2.5.0 // indirect
 	github.com/go-webauthn/x v0.2.6 // indirect
 	github.com/google/go-tpm v0.9.8 // indirect
+	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
 	github.com/pb33f/ordered-map/v2 v2.3.1 // indirect
 	github.com/philhofer/fwd v1.2.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
@@ -124,7 +125,7 @@ require (
 	github.com/gofrs/flock v0.13.0 // indirect
 	github.com/google/btree v1.1.3 // indirect
 	github.com/google/gnostic-models v0.7.1 // indirect
-	github.com/google/uuid v1.6.0 // indirect
+	github.com/google/uuid v1.6.0
 	github.com/gopherjs/gopherjs v1.12.80 // indirect
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674
 	github.com/gosuri/uitable v0.0.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -341,6 +341,8 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f h1:KUppIJq7/+SVif2QVs3tOP0zanoHgBEVAwHxUSIzRqU=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
+github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f h1:y5//uYreIhSUg3J1GEMiLbxo1LJaP8RfCpH6pymGZus=
+github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/neelance/astrewrite v0.0.0-20160511093645-99348263ae86/go.mod h1:kHJEU3ofeGjhHklVoIGuVj85JJwZ6kWPaJwCIxgnFmo=
 github.com/neelance/sourcemap v0.0.0-20151028013722-8c68805598ab/go.mod h1:Qr6/a/Q4r9LP1IltGz7tA7iOK1WonHEYhu1HRBA7ZiM=
 github.com/onsi/ginkgo/v2 v2.28.1 h1:S4hj+HbZp40fNKuLUQOYLDgZLwNUVn19N3Atb98NCyI=

--- a/internal/config.go
+++ b/internal/config.go
@@ -21,6 +21,7 @@ type KiteConfig struct {
 	Clusters  []ClusterConfig  `yaml:"clusters"`
 	OAuth     []OAuthConfig    `yaml:"oauth"`
 	LDAP      *LDAPConfig      `yaml:"ldap"`
+	SMTP      *SMTPConfig      `yaml:"smtp"`
 	RBAC      *RBACConfig      `yaml:"rbac"`
 }
 
@@ -68,6 +69,19 @@ type LDAPConfig struct {
 	GroupBaseDN          string `yaml:"groupBaseDn"`
 	GroupFilter          string `yaml:"groupFilter"`
 	GroupNameAttribute   string `yaml:"groupNameAttribute"`
+}
+
+type SMTPConfig struct {
+	Enabled        bool   `yaml:"enabled"`
+	Host           string `yaml:"host"`
+	Port           int    `yaml:"port"`
+	Username       string `yaml:"username"`
+	Password       string `yaml:"password"`
+	FromEmail      string `yaml:"fromEmail"`
+	FromName       string `yaml:"fromName"`
+	Encryption     string `yaml:"encryption"`
+	SkipTLSVerify  bool   `yaml:"skipTLSVerify"`
+	TimeoutSeconds int    `yaml:"timeoutSeconds"`
 }
 
 type RBACConfig struct {
@@ -153,6 +167,15 @@ func applyConfig(path string, cfg *KiteConfig) AppliedSections {
 		} else {
 			sections["ldap"] = true
 			klog.Info("Applied LDAP settings from config file")
+		}
+	}
+
+	if cfg.SMTP != nil {
+		if err := applySMTP(cfg.SMTP); err != nil {
+			klog.Errorf("Failed to apply SMTP config: %v", err)
+		} else {
+			sections["smtp"] = true
+			klog.Info("Applied SMTP settings from config file")
 		}
 	}
 
@@ -309,6 +332,25 @@ func applyLDAP(cfg *LDAPConfig) error {
 	}
 
 	_, err := model.UpdateLDAPSetting(setting)
+	return err
+}
+
+func applySMTP(cfg *SMTPConfig) error {
+	if _, err := model.GetGeneralSetting(); err != nil {
+		return err
+	}
+	_, err := model.UpdateGeneralSetting(map[string]any{
+		"smtp_enabled":         cfg.Enabled,
+		"smtp_host":            cfg.Host,
+		"smtp_port":            cfg.Port,
+		"smtp_username":        cfg.Username,
+		"smtp_password":        model.SecretString(cfg.Password),
+		"smtp_from_email":      cfg.FromEmail,
+		"smtp_from_name":       cfg.FromName,
+		"smtp_encryption":      cfg.Encryption,
+		"smtp_skip_tls_verify": cfg.SkipTLSVerify,
+		"smtp_timeout_seconds": cfg.TimeoutSeconds,
+	})
 	return err
 }
 

--- a/internal/config_test.go
+++ b/internal/config_test.go
@@ -96,6 +96,18 @@ ldap:
   groupBaseDn: "ou=groups,dc=example,dc=com"
   groupFilter: "(member=%s)"
 
+smtp:
+  enabled: true
+  host: "smtp.example.com"
+  port: 587
+  username: "kite"
+  password: "smtp-password"
+  fromEmail: "kite@example.com"
+  fromName: "Kite"
+  encryption: "starttls"
+  skipTLSVerify: true
+  timeoutSeconds: 45
+
 rbac:
   roles:
     - name: admin
@@ -245,6 +257,17 @@ func TestLoadConfigFromFile_EndToEnd(t *testing.T) { //nolint:gocyclo // end-to-
 		}
 		if setting.GroupBaseDN != "ou=groups,dc=example,dc=com" {
 			t.Errorf("groupBaseDn = %q", setting.GroupBaseDN)
+		}
+	})
+
+	// --- Verify SMTP ---
+	t.Run("SMTP", func(t *testing.T) {
+		setting, err := model.GetGeneralSetting()
+		if err != nil {
+			t.Fatalf("GetGeneralSetting: %v", err)
+		}
+		if !setting.SMTPEnabled || setting.SMTPHost != "smtp.example.com" || setting.SMTPPort != 587 || setting.SMTPUsername != "kite" || setting.SMTPPassword != model.SecretString("smtp-password") || setting.SMTPFromEmail != "kite@example.com" || setting.SMTPFromName != "Kite" || setting.SMTPEncryption != "starttls" || !setting.SMTPSkipTLSVerify || setting.SMTPTimeoutSeconds != 45 {
+			t.Errorf("SMTP setting = %#v", setting)
 		}
 	})
 

--- a/pkg/auth/bootstrap_handler.go
+++ b/pkg/auth/bootstrap_handler.go
@@ -34,6 +34,7 @@ type bootstrapResponse struct {
 	Setup                      bootstrapSetupState   `json:"setup"`
 	Auth                       bootstrapAuthOptions  `json:"auth"`
 	Capabilities               bootstrapCapabilities `json:"capabilities"`
+	ManagedSections            map[string]bool       `json:"managedSections"`
 	User                       *model.User           `json:"user"`
 	HasGlobalSidebarPreference bool                  `json:"hasGlobalSidebarPreference"`
 	GlobalSidebarPreference    string                `json:"globalSidebarPreference"`
@@ -65,6 +66,9 @@ func (h *AuthHandler) Bootstrap(c *gin.Context) {
 		Capabilities: bootstrapCapabilities{
 			AIEnabled:      setting.AIAgentEnabled && strings.TrimSpace(string(setting.AIAPIKey)) != "",
 			KubectlEnabled: setting.KubectlEnabled,
+		},
+		ManagedSections: map[string]bool{
+			"smtp": common.IsSectionManaged("smtp"),
 		},
 		User:                       user,
 		HasGlobalSidebarPreference: globalSidebarPreference != "",

--- a/pkg/cluster/cluster_handler.go
+++ b/pkg/cluster/cluster_handler.go
@@ -40,28 +40,48 @@ func clusterAgentServerURL(c *gin.Context) string {
 
 func (cm *ClusterManager) GetClusters(c *gin.Context) {
 	clusters, errors, defaultContext := cm.snapshotState()
+	clusterMetadata := make(map[string]*model.Cluster)
+	if model.DB != nil {
+		if storedClusters, err := model.ListClusters(); err == nil {
+			for _, cluster := range storedClusters {
+				clusterMetadata[cluster.Name] = cluster
+			}
+		}
+	}
 	result := make([]common.ClusterInfo, 0, len(clusters))
 	user := c.MustGet("user").(model.User)
 	for name, cluster := range clusters {
 		if !rbac.CanAccessCluster(user, name) {
 			continue
 		}
-		result = append(result, common.ClusterInfo{
+		info := common.ClusterInfo{
 			Name:      name,
 			Version:   cluster.Version,
+			Enabled:   true,
 			IsDefault: name == defaultContext,
-		})
+		}
+		if dbCluster := clusterMetadata[name]; dbCluster != nil {
+			info.UUID = dbCluster.UUID
+			info.Enabled = dbCluster.Enable
+		}
+		result = append(result, info)
 	}
 	for name, errMsg := range errors {
 		if !rbac.CanAccessCluster(user, name) {
 			continue
 		}
-		result = append(result, common.ClusterInfo{
+		info := common.ClusterInfo{
 			Name:      name,
 			Version:   "",
+			Enabled:   true,
 			IsDefault: false,
 			Error:     errMsg,
-		})
+		}
+		if dbCluster := clusterMetadata[name]; dbCluster != nil {
+			info.UUID = dbCluster.UUID
+			info.Enabled = dbCluster.Enable
+		}
+		result = append(result, info)
 	}
 	sort.Slice(result, func(i, j int) bool {
 		return result[i].Name < result[j].Name

--- a/pkg/cluster/cluster_handler_test.go
+++ b/pkg/cluster/cluster_handler_test.go
@@ -122,6 +122,9 @@ func TestGetClustersFiltersByAccessAndSortsFailures(t *testing.T) {
 	if result[0].Error != "invalid kubeconfig" || !result[1].IsDefault {
 		t.Fatalf("cluster metadata = %#v", result)
 	}
+	if !result[0].Enabled || !result[1].Enabled {
+		t.Fatalf("clusters without database metadata must remain enabled: %#v", result)
+	}
 }
 
 func TestClusterMutationsHonorManagedConfiguration(t *testing.T) {

--- a/pkg/cluster/k8s_proxy.go
+++ b/pkg/cluster/k8s_proxy.go
@@ -1,0 +1,292 @@
+package cluster
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"path"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/zxh326/kite/pkg/common"
+	"github.com/zxh326/kite/pkg/model"
+	"github.com/zxh326/kite/pkg/rbac"
+	"github.com/zxh326/kite/pkg/statefultoken"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilnet "k8s.io/apimachinery/pkg/util/net"
+	"k8s.io/apimachinery/pkg/util/proxy"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+var discoveryPaths = map[string]bool{"/api": true, "/apis": true, "/version": true, "/openapi": true}
+var subResourceVerbs = map[string]string{"exec": string(common.VerbExec), "attach": string(common.VerbExec), "log": string(common.VerbLog), "portforward": string(common.VerbExec)}
+
+func (cm *ClusterManager) HandleK8sProxy(c *gin.Context) {
+	user, ok := cm.authenticateKubeconfigToken(c)
+	if !ok {
+		return
+	}
+	clusterUUID := c.Param("clusterUUID")
+	proxyPath, err := url.PathUnescape(c.Param("path"))
+	if err != nil || strings.Contains(proxyPath, "..") {
+		writeK8sStatus(c, http.StatusBadRequest, "invalid proxy path", metav1.StatusReasonBadRequest)
+		return
+	}
+	cluster, err := model.GetClusterByUUID(clusterUUID)
+	if err != nil || !cluster.Enable {
+		writeK8sStatus(c, http.StatusNotFound, "cluster not found", metav1.StatusReasonNotFound)
+		return
+	}
+	if !rbac.CanAccessClusterCurrent(user, cluster.Name) {
+		writeK8sStatus(c, http.StatusForbidden, rbac.NoAccess(user.Key(), "access", "cluster", "", cluster.Name), metav1.StatusReasonForbidden)
+		return
+	}
+	if !isDiscoveryPath(proxyPath) {
+		resource, namespace, verb, subresource := parseK8sAPIPath(proxyPath, c.Request.Method)
+		if resource == "" {
+			writeK8sStatus(c, http.StatusForbidden, "unsupported Kubernetes API path", metav1.StatusReasonForbidden)
+			return
+		}
+		if mapped, ok := subResourceVerbs[subresource]; ok {
+			verb = mapped
+		}
+		if namespace == "" {
+			namespace = common.AllNamespaces
+		}
+		if !rbac.CanAccessCurrent(user, resource, verb, cluster.Name, namespace) {
+			writeK8sStatus(c, http.StatusForbidden, rbac.NoAccess(user.Key(), verb, resource, namespace, cluster.Name), metav1.StatusReasonForbidden)
+			return
+		}
+	}
+	if tokenID, ok := c.Get("kubeconfig_token_id"); ok {
+		if service, err := newKubeconfigTokenService(); err == nil {
+			_ = service.Touch(c.Request.Context(), tokenID.(uint))
+		}
+	}
+	config, err := cm.getRestConfig(cluster)
+	if err != nil {
+		writeK8sStatus(c, http.StatusServiceUnavailable, "failed to connect to cluster", metav1.StatusReasonServiceUnavailable)
+		return
+	}
+	target, err := buildK8sProxyURL(config.Host, proxyPath)
+	if err != nil {
+		writeK8sStatus(c, http.StatusBadRequest, "invalid proxy path", metav1.StatusReasonBadRequest)
+		return
+	}
+	target.RawQuery = c.Request.URL.RawQuery
+	forceHTTP1 := c.GetHeader("Upgrade") != ""
+	proxyConfig := rest.CopyConfig(config)
+	var transport http.RoundTripper
+	if forceHTTP1 {
+		transport, err = buildUpgradeConnectionTransport(proxyConfig)
+	} else {
+		transport, err = buildProxyTransport(proxyConfig, false)
+	}
+	if err != nil {
+		writeK8sStatus(c, http.StatusInternalServerError, "failed to create transport", metav1.StatusReasonInternalError)
+		return
+	}
+	c.Request.Header.Del("Authorization")
+	c.Request.Header.Del("Cookie")
+	for name := range c.Request.Header {
+		if strings.HasPrefix(strings.ToLower(name), "impersonate-") {
+			c.Request.Header.Del(name)
+		}
+	}
+	handler := proxy.NewUpgradeAwareHandler(target, transport, false, false, &k8sProxyResponder{})
+	// Preserve Cluster Agent WrapTransport (authorizationRoundTripper) outside
+	// MirrorRequest so captured Upgrade requests contain target credentials.
+	authConfig := rest.CopyConfig(config)
+	originalWrap := authConfig.WrapTransport
+	authConfig.WrapTransport = func(next http.RoundTripper) http.RoundTripper {
+		wrapped := proxy.MirrorRequest
+		if originalWrap != nil {
+			wrapped = originalWrap(wrapped)
+		}
+		return wrapped
+	}
+	authTransport, err := rest.TransportFor(authConfig)
+	if err != nil {
+		writeK8sStatus(c, http.StatusInternalServerError, "failed to create transport", metav1.StatusReasonInternalError)
+		return
+	}
+	handler.UpgradeTransport = proxy.NewUpgradeRequestRoundTripper(transport, authTransport)
+	handler.FlushInterval = 200 * time.Millisecond
+	handler.ServeHTTP(c.Writer, c.Request)
+}
+
+func (cm *ClusterManager) authenticateKubeconfigToken(c *gin.Context) (model.User, bool) {
+	auth := c.GetHeader("Authorization")
+	encoded, hasBearer := strings.CutPrefix(auth, "Bearer ")
+	if !hasBearer || strings.Count(auth, "Bearer ") != 1 || strings.TrimSpace(encoded) == "" {
+		writeK8sStatus(c, http.StatusUnauthorized, "invalid kubeconfig token", metav1.StatusReasonUnauthorized)
+		return model.User{}, false
+	}
+	service, err := newKubeconfigTokenService()
+	if err != nil {
+		writeK8sStatus(c, http.StatusUnauthorized, "invalid kubeconfig token", metav1.StatusReasonUnauthorized)
+		return model.User{}, false
+	}
+	principal, err := service.Authenticate(c.Request.Context(), strings.TrimSpace(encoded))
+	if err != nil {
+		message := "invalid kubeconfig token"
+		if errors.Is(err, statefultoken.ErrExpired) {
+			message = "Kubeconfig token has expired; please download a new kubeconfig"
+		}
+		writeK8sStatus(c, http.StatusUnauthorized, message, metav1.StatusReasonUnauthorized)
+		return model.User{}, false
+	}
+	ownerID, err := strconv.ParseUint(principal.SubjectID, 10, 64)
+	if err != nil {
+		writeK8sStatus(c, http.StatusUnauthorized, "invalid kubeconfig token", metav1.StatusReasonUnauthorized)
+		return model.User{}, false
+	}
+	owner, err := model.GetUserByIDCached(ownerID)
+	if err != nil || !owner.Enabled {
+		writeK8sStatus(c, http.StatusUnauthorized, "invalid kubeconfig token", metav1.StatusReasonUnauthorized)
+		return model.User{}, false
+	}
+	owner.Roles = nil
+	c.Set("kubeconfig_token_id", principal.TokenID)
+	return *owner, true
+}
+
+func (cm *ClusterManager) getRestConfig(cluster *model.Cluster) (*rest.Config, error) {
+	if cluster.InCluster {
+		return rest.InClusterConfig()
+	}
+	if cluster.ClusterAgent {
+		config, _, err := cm.clusterAgentManager.RESTConfig(cluster.ID)
+		return config, err
+	}
+	return clientcmd.RESTConfigFromKubeConfig([]byte(cluster.Config))
+}
+
+func buildK8sProxyURL(host, proxyPath string) (*url.URL, error) {
+	target, err := url.Parse(host)
+	if err != nil {
+		return nil, err
+	}
+	target.Path = path.Join(target.Path, "/"+strings.TrimPrefix(proxyPath, "/"))
+	target.RawPath = ""
+	return target, nil
+}
+func buildProxyTransport(config *rest.Config, forceHTTP1 bool) (http.RoundTripper, error) {
+	cfg := rest.CopyConfig(config)
+	if forceHTTP1 {
+		cfg.NextProtos = []string{"http/1.1"}
+	}
+	return rest.TransportFor(cfg)
+}
+
+func buildUpgradeConnectionTransport(config *rest.Config) (*http.Transport, error) {
+	cfg := rest.CopyConfig(config)
+	cfg.WrapTransport = nil
+	cfg.NextProtos = []string{"http/1.1"}
+
+	transport, err := rest.TransportFor(cfg)
+	if err != nil {
+		return nil, err
+	}
+	dialer, err := utilnet.DialerFor(transport)
+	if err != nil {
+		return nil, fmt.Errorf("get upgrade connection dialer: %w", err)
+	}
+	if cfg.Dial != nil {
+		dialer = cfg.Dial
+	}
+	if dialer == nil {
+		return nil, fmt.Errorf("upgrade connection transport has no dialer")
+	}
+	tlsConfig, err := utilnet.TLSClientConfig(transport)
+	if err != nil {
+		return nil, fmt.Errorf("get upgrade TLS config: %w", err)
+	}
+	return &http.Transport{
+		Proxy:             http.ProxyFromEnvironment,
+		DialContext:       dialer,
+		ForceAttemptHTTP2: false,
+		TLSClientConfig:   tlsConfig,
+	}, nil
+}
+func isDiscoveryPath(p string) bool {
+	p = strings.TrimSuffix(p, "/")
+	if discoveryPaths[p] {
+		return true
+	}
+	if strings.HasPrefix(p, "/api/") {
+		return len(strings.Split(strings.TrimPrefix(p, "/api/"), "/")) == 1
+	}
+	if strings.HasPrefix(p, "/apis/") {
+		return len(strings.Split(strings.TrimPrefix(p, "/apis/"), "/")) <= 2
+	}
+	return strings.HasPrefix(p, "/openapi/")
+}
+func parseK8sAPIPath(p, method string) (string, string, string, string) {
+	verb := methodToVerb(method)
+	parts := strings.Split(strings.TrimPrefix(p, "/"), "/")
+	var idx int
+	switch {
+	case len(parts) >= 2 && parts[0] == "api":
+		idx = 2
+	case len(parts) >= 3 && parts[0] == "apis":
+		idx = 3
+	default:
+		return "", "", verb, ""
+	}
+	if idx >= len(parts) {
+		return "", "", verb, ""
+	}
+
+	var resource, namespace, subresource string
+	if parts[idx] == "namespaces" {
+		if idx+2 >= len(parts) {
+			return "namespaces", "", verb, ""
+		}
+		namespace, resource = parts[idx+1], parts[idx+2]
+		if idx+4 < len(parts) {
+			subresource = parts[idx+4]
+		}
+	} else {
+		resource = parts[idx]
+		if idx+2 < len(parts) {
+			subresource = parts[idx+2]
+		}
+	}
+	if _, ok := subResourceVerbs[subresource]; !ok {
+		subresource = ""
+	}
+	return resource, namespace, verb, subresource
+}
+func methodToVerb(method string) string {
+	switch method {
+	case http.MethodPost:
+		return string(common.VerbCreate)
+	case http.MethodPut, http.MethodPatch:
+		return string(common.VerbUpdate)
+	case http.MethodDelete:
+		return string(common.VerbDelete)
+	default:
+		return string(common.VerbGet)
+	}
+}
+
+type k8sProxyResponder struct{}
+
+func (*k8sProxyResponder) Error(w http.ResponseWriter, _ *http.Request, err error) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusBadGateway)
+	encoder := json.NewEncoder(w)
+	err = encoder.Encode(metav1.Status{TypeMeta: metav1.TypeMeta{Kind: "Status", APIVersion: "v1"}, Status: metav1.StatusFailure, Message: fmt.Sprintf("proxy error: %v", err), Reason: metav1.StatusReasonServiceUnavailable, Code: http.StatusBadGateway})
+	if err != nil {
+		return
+	}
+}
+func writeK8sStatus(c *gin.Context, code int, message string, reason metav1.StatusReason) {
+	c.JSON(code, metav1.Status{TypeMeta: metav1.TypeMeta{Kind: "Status", APIVersion: "v1"}, Status: metav1.StatusFailure, Message: message, Reason: reason, Code: int32(code)})
+}

--- a/pkg/cluster/kubeconfig.go
+++ b/pkg/cluster/kubeconfig.go
@@ -1,0 +1,121 @@
+package cluster
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/zxh326/kite/pkg/model"
+	"github.com/zxh326/kite/pkg/rbac"
+	"github.com/zxh326/kite/pkg/statefultoken"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+)
+
+const (
+	minKubeconfigTTL = int64(3600)
+	maxKubeconfigTTL = int64(157680000)
+)
+
+type kubeconfigRequest struct {
+	ClusterUUIDs []string `json:"clusterUUIDs" binding:"required"`
+	TTLSeconds   int64    `json:"ttlSeconds" binding:"required"`
+}
+
+func sanitizeKubeconfigName(name string) string {
+	return strings.NewReplacer("/", "-", "\\", "-", ":", "-", " ", "-").Replace(name)
+}
+
+func (cm *ClusterManager) DownloadKubeconfig(c *gin.Context) {
+	var req kubeconfigRequest
+	if err := c.ShouldBindJSON(&req); err != nil || len(req.ClusterUUIDs) == 0 || req.TTLSeconds < minKubeconfigTTL || req.TTLSeconds > maxKubeconfigTTL {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "ttlSeconds must be an integer between 3600 and 157680000"})
+		return
+	}
+	user := c.MustGet("user").(model.User)
+	clusters := make([]*model.Cluster, 0, len(req.ClusterUUIDs))
+	seen := make(map[string]struct{}, len(req.ClusterUUIDs))
+	for _, clusterUUID := range req.ClusterUUIDs {
+		if _, err := uuid.Parse(clusterUUID); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid cluster UUID"})
+			return
+		}
+		if _, ok := seen[clusterUUID]; ok {
+			continue
+		}
+		seen[clusterUUID] = struct{}{}
+		cluster, err := model.GetClusterByUUID(clusterUUID)
+		if err != nil {
+			c.JSON(http.StatusNotFound, gin.H{"error": "cluster not found"})
+			return
+		}
+		if !cluster.Enable {
+			c.JSON(http.StatusConflict, gin.H{"error": "cluster is disabled"})
+			return
+		}
+		if !rbac.CanAccessClusterCurrent(user, cluster.Name) {
+			c.JSON(http.StatusForbidden, gin.H{"error": "access denied to cluster"})
+			return
+		}
+		clusters = append(clusters, cluster)
+	}
+
+	now := time.Now().UTC()
+	expiresAt := now.Add(time.Duration(req.TTLSeconds) * time.Second)
+	name := fmt.Sprintf("kubeconfig-%s-%s", sanitizeKubeconfigName(user.Key()), now.Format("20060102150405.000"))
+	service, err := newKubeconfigTokenService()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "kubeconfig token signing is unavailable"})
+		return
+	}
+	issued, err := service.Issue(c.Request.Context(), statefultoken.IssueRequest{
+		SubjectID: strconv.FormatUint(uint64(user.ID), 10), Name: name, ExpiresAt: expiresAt,
+	})
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to create kubeconfig token"})
+		return
+	}
+	config := clientcmdapi.NewConfig()
+	serverURL := clusterAgentServerURL(c)
+	entryNames := make(map[string]string, len(clusters))
+	usedNames := make(map[string]struct{}, len(clusters))
+	for _, cluster := range clusters {
+		baseName := sanitizeKubeconfigName(cluster.Name)
+		entryName := baseName
+		for suffix := 2; ; suffix++ {
+			if _, exists := usedNames[entryName]; !exists {
+				break
+			}
+			entryName = fmt.Sprintf("%s-%d", baseName, suffix)
+		}
+		usedNames[entryName] = struct{}{}
+		entryNames[cluster.UUID] = entryName
+		config.Clusters[entryName] = &clientcmdapi.Cluster{Server: fmt.Sprintf("%s/api/v1/clusters/%s/k8s-proxy", strings.TrimRight(serverURL, "/"), cluster.UUID)}
+		config.Contexts[entryName] = &clientcmdapi.Context{Cluster: entryName, AuthInfo: "kite-kubeconfig", Namespace: "default"}
+	}
+	config.AuthInfos["kite-kubeconfig"] = &clientcmdapi.AuthInfo{Token: issued.Encoded}
+	currentCluster := c.GetHeader("X-Cluster-Name")
+	for _, cluster := range clusters {
+		if cluster.Name == currentCluster {
+			config.CurrentContext = entryNames[cluster.UUID]
+			break
+		}
+	}
+	if config.CurrentContext == "" {
+		config.CurrentContext = entryNames[clusters[0].UUID]
+	}
+	content, err := clientcmd.Write(*config)
+	if err != nil {
+		_ = service.Discard(c.Request.Context(), issued.Record.ID)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to generate kubeconfig"})
+		return
+	}
+	c.Header("Content-Disposition", `attachment; filename="kite-kubeconfig.yaml"`)
+	c.Header("Cache-Control", "no-store")
+	c.Header("Pragma", "no-cache")
+	c.Data(http.StatusOK, "application/yaml", content)
+}

--- a/pkg/cluster/kubeconfig_stateful_test.go
+++ b/pkg/cluster/kubeconfig_stateful_test.go
@@ -1,0 +1,453 @@
+package cluster
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/glebarez/sqlite"
+	"github.com/zxh326/kite/pkg/common"
+	"github.com/zxh326/kite/pkg/model"
+	"github.com/zxh326/kite/pkg/rbac"
+	"github.com/zxh326/kite/pkg/statefultoken"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+func TestDownloadKubeconfigCreatesOneJWTAndTokenRecord(t *testing.T) {
+	setupKubeconfigStatefulTest(t)
+	user := createKubeconfigTestUser(t, "alice")
+	first := createKubeconfigTestCluster(t, "first cluster")
+	second := createKubeconfigTestCluster(t, "second/cluster")
+	setKubeconfigTestRBAC(t, user.Username, []string{"*"})
+
+	manager := &ClusterManager{}
+	router := gin.New()
+	router.POST("/kubeconfig", withKubeconfigTestUser(user), manager.DownloadKubeconfig)
+	response := performKubeconfigRequest(router, http.MethodPost, "/kubeconfig", fmt.Sprintf(`{"clusterUUIDs":[%q,%q,%q],"ttlSeconds":3600}`, first.UUID, second.UUID, first.UUID), map[string]string{
+		"X-Forwarded-Proto": "https",
+		"X-Forwarded-Host":  "kite.example.test",
+		"X-Cluster-Name":    second.Name,
+	})
+	if response.Code != http.StatusOK {
+		t.Fatalf("download status = %d, want %d: %s", response.Code, http.StatusOK, response.Body.String())
+	}
+	if got := response.Header().Get("Content-Type"); !strings.HasPrefix(got, "application/yaml") {
+		t.Fatalf("Content-Type = %q", got)
+	}
+	if response.Header().Get("Content-Disposition") != `attachment; filename="kite-kubeconfig.yaml"` || response.Header().Get("Cache-Control") != "no-store" || response.Header().Get("Pragma") != "no-cache" {
+		t.Fatalf("download headers = %#v", response.Header())
+	}
+	config, err := clientcmd.Load(response.Body.Bytes())
+	if err != nil {
+		t.Fatalf("parse kubeconfig: %v", err)
+	}
+	if len(config.Clusters) != 2 || len(config.Contexts) != 2 || config.CurrentContext != "second-cluster" {
+		t.Fatalf("kubeconfig clusters=%d contexts=%d current=%q", len(config.Clusters), len(config.Contexts), config.CurrentContext)
+	}
+	token := config.AuthInfos["kite-kubeconfig"].Token
+	if token == "" || len(config.AuthInfos) != 1 {
+		t.Fatalf("auth infos = %#v", config.AuthInfos)
+	}
+	for _, cluster := range config.Clusters {
+		if !strings.Contains(cluster.Server, "/api/v1/clusters/") || !strings.HasSuffix(cluster.Server, "/k8s-proxy") {
+			t.Fatalf("unexpected proxy server URL %q", cluster.Server)
+		}
+	}
+	service, err := newKubeconfigTokenService()
+	if err != nil {
+		t.Fatal(err)
+	}
+	principal, err := service.Authenticate(context.Background(), token)
+	if err != nil || principal.SubjectID != fmt.Sprint(user.ID) {
+		t.Fatalf("issued JWT principal=%#v err=%v", principal, err)
+	}
+	var records []model.KubeconfigToken
+	if err := model.DB.Find(&records).Error; err != nil || len(records) != 1 {
+		t.Fatalf("token records=%#v err=%v", records, err)
+	}
+	record := records[0]
+	if record.OwnerID != user.ID || len(record.JTIHash) != 64 || record.SigningKeyID != common.KubeconfigJWTKID {
+		t.Fatalf("token record = %#v", record)
+	}
+	if delta := record.ExpiresAt.Sub(record.CreatedAt); delta < 59*time.Minute || delta > 61*time.Minute {
+		t.Fatalf("token TTL = %s", delta)
+	}
+}
+
+func TestDownloadKubeconfigKeepsCollidingClusterNamesDistinct(t *testing.T) {
+	setupKubeconfigStatefulTest(t)
+	user := createKubeconfigTestUser(t, "collision-user")
+	first := createKubeconfigTestCluster(t, "prod/a")
+	second := createKubeconfigTestCluster(t, "prod-a")
+	setKubeconfigTestRBAC(t, user.Username, []string{"*"})
+
+	manager := &ClusterManager{}
+	router := gin.New()
+	router.POST("/kubeconfig", withKubeconfigTestUser(user), manager.DownloadKubeconfig)
+	response := performKubeconfigRequest(router, http.MethodPost, "/kubeconfig", fmt.Sprintf(`{"clusterUUIDs":[%q,%q],"ttlSeconds":3600}`, first.UUID, second.UUID), map[string]string{
+		"X-Cluster-Name": first.Name,
+	})
+	if response.Code != http.StatusOK {
+		t.Fatalf("download status = %d, want %d: %s", response.Code, http.StatusOK, response.Body.String())
+	}
+	config, err := clientcmd.Load(response.Body.Bytes())
+	if err != nil {
+		t.Fatalf("parse kubeconfig: %v", err)
+	}
+	if len(config.Clusters) != 2 || len(config.Contexts) != 2 || config.CurrentContext != "prod-a" {
+		t.Fatalf("kubeconfig clusters=%d contexts=%d current=%q", len(config.Clusters), len(config.Contexts), config.CurrentContext)
+	}
+	if config.Contexts[config.CurrentContext].Cluster != config.CurrentContext || !strings.Contains(config.Clusters[config.CurrentContext].Server, first.UUID) {
+		t.Fatalf("current context points to %#v", config.Contexts[config.CurrentContext])
+	}
+	if _, ok := config.Clusters["prod-a-2"]; !ok {
+		t.Fatalf("collision entry missing: %#v", config.Clusters)
+	}
+}
+
+func TestK8sProxyRejectsUnsupportedNonResourcePath(t *testing.T) {
+	setupKubeconfigStatefulTest(t)
+	user := createKubeconfigTestUser(t, "proxy-user")
+	cluster := createKubeconfigTestCluster(t, "proxy-cluster")
+	setKubeconfigTestRBAC(t, user.Username, []string{cluster.Name})
+	service, err := newKubeconfigTokenService()
+	if err != nil {
+		t.Fatal(err)
+	}
+	issued, err := service.Issue(context.Background(), statefultoken.IssueRequest{SubjectID: fmt.Sprint(user.ID), Name: "proxy", ExpiresAt: time.Now().UTC().Add(time.Hour)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	token := issued.Encoded
+
+	manager := &ClusterManager{}
+	router := gin.New()
+	router.Any("/clusters/:clusterUUID/k8s-proxy/*path", manager.HandleK8sProxy)
+	response := performKubeconfigRequest(router, http.MethodGet, fmt.Sprintf("/clusters/%s/k8s-proxy/healthz", cluster.UUID), "", map[string]string{"Authorization": "Bearer " + token})
+	if response.Code != http.StatusForbidden {
+		t.Fatalf("non-resource proxy status = %d, want %d: %s", response.Code, http.StatusForbidden, response.Body.String())
+	}
+}
+
+func TestBuildUpgradeConnectionTransportPreservesDialer(t *testing.T) {
+	sentinel := fmt.Errorf("agent dialer used")
+	transport, err := buildUpgradeConnectionTransport(&rest.Config{
+		Host: "https://10.247.0.1:443",
+		TLSClientConfig: rest.TLSClientConfig{
+			Insecure: true,
+		},
+		Dial: func(_ context.Context, network, address string) (net.Conn, error) {
+			if network != "tcp" || address != "10.247.0.1:443" {
+				t.Fatalf("Dial called with network=%q address=%q", network, address)
+			}
+			return nil, sentinel
+		},
+	})
+	if err != nil {
+		t.Fatalf("buildUpgradeConnectionTransport() error = %v", err)
+	}
+	if transport.DialContext == nil {
+		t.Fatal("DialContext is nil")
+	}
+	_, err = transport.DialContext(context.Background(), "tcp", "10.247.0.1:443")
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("DialContext() error = %v, want %v", err, sentinel)
+	}
+	if got := transport.TLSClientConfig.NextProtos; len(got) != 1 || got[0] != "http/1.1" {
+		t.Fatalf("NextProtos = %#v, want []string{\"http/1.1\"}", got)
+	}
+}
+
+func TestDownloadKubeconfigRejectsTTLAndUnauthorizedClusters(t *testing.T) {
+	setupKubeconfigStatefulTest(t)
+	user := createKubeconfigTestUser(t, "limited")
+	allowed := createKubeconfigTestCluster(t, "allowed")
+	blocked := createKubeconfigTestCluster(t, "blocked")
+	setKubeconfigTestRBAC(t, user.Username, []string{allowed.Name})
+	manager := &ClusterManager{}
+	router := gin.New()
+	router.POST("/kubeconfig", withKubeconfigTestUser(user), manager.DownloadKubeconfig)
+
+	for _, ttl := range []int64{minKubeconfigTTL - 1, maxKubeconfigTTL + 1} {
+		response := performKubeconfigRequest(router, http.MethodPost, "/kubeconfig", fmt.Sprintf(`{"clusterUUIDs":[%q],"ttlSeconds":%d}`, allowed.UUID, ttl), nil)
+		if response.Code != http.StatusBadRequest {
+			t.Fatalf("TTL %d status = %d, want %d", ttl, response.Code, http.StatusBadRequest)
+		}
+	}
+	response := performKubeconfigRequest(router, http.MethodPost, "/kubeconfig", fmt.Sprintf(`{"clusterUUIDs":[%q],"ttlSeconds":%d}`, blocked.UUID, minKubeconfigTTL), nil)
+	if response.Code != http.StatusForbidden {
+		t.Fatalf("unauthorized cluster status = %d, want %d", response.Code, http.StatusForbidden)
+	}
+}
+
+func TestKubeconfigTokenListAndDeleteRespectOwnershipAndRedactJTI(t *testing.T) {
+	setupKubeconfigStatefulTest(t)
+	owner := createKubeconfigTestUser(t, "owner")
+	other := createKubeconfigTestUser(t, "other")
+	ownerToken := createKubeconfigTestToken(t, owner, "owner token", time.Now().UTC().Add(time.Hour))
+	service, err := newKubeconfigTokenService()
+	if err != nil {
+		t.Fatal(err)
+	}
+	otherIssued, err := service.Issue(context.Background(), statefultoken.IssueRequest{SubjectID: fmt.Sprint(other.ID), Name: "other token", ExpiresAt: time.Now().UTC().Add(time.Hour)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	otherToken := &model.KubeconfigToken{Model: model.Model{ID: otherIssued.Record.ID}, JTIHash: otherIssued.Record.JTIHash}
+	router := gin.New()
+	router.GET("/me/tokens", withKubeconfigTestUser(owner), ListCurrentUserKubeconfigTokens)
+	router.DELETE("/me/tokens/:id", withKubeconfigTestUser(owner), DeleteCurrentUserKubeconfigToken)
+	router.GET("/admin/tokens", withKubeconfigTestUser(owner), ListAllKubeconfigTokens)
+	router.DELETE("/admin/tokens/:id", withKubeconfigTestUser(owner), DeleteAnyKubeconfigToken)
+
+	list := performKubeconfigRequest(router, http.MethodGet, "/me/tokens", "", nil)
+	if list.Code != http.StatusOK || strings.Contains(list.Body.String(), "jtiHash") || strings.Contains(list.Body.String(), ownerToken.JTIHash) {
+		t.Fatalf("user token list status=%d body=%s", list.Code, list.Body.String())
+	}
+	var ownResponse struct {
+		Tokens []map[string]any `json:"tokens"`
+	}
+	if err := json.Unmarshal(list.Body.Bytes(), &ownResponse); err != nil || len(ownResponse.Tokens) != 1 || ownResponse.Tokens[0]["ownerId"] != nil || ownResponse.Tokens[0]["owner"] != nil {
+		t.Fatalf("user token response=%#v err=%v", ownResponse, err)
+	}
+
+	denied := performKubeconfigRequest(router, http.MethodDelete, fmt.Sprintf("/me/tokens/%d", otherToken.ID), "", nil)
+	if denied.Code != http.StatusNotFound {
+		t.Fatalf("cross-owner delete status = %d, want %d", denied.Code, http.StatusNotFound)
+	}
+	adminList := performKubeconfigRequest(router, http.MethodGet, "/admin/tokens", "", nil)
+	if adminList.Code != http.StatusOK || !strings.Contains(adminList.Body.String(), `"owner":"owner"`) || strings.Contains(adminList.Body.String(), otherToken.JTIHash) {
+		t.Fatalf("admin token list status=%d body=%s", adminList.Code, adminList.Body.String())
+	}
+	deleted := performKubeconfigRequest(router, http.MethodDelete, fmt.Sprintf("/admin/tokens/%d", otherToken.ID), "", nil)
+	if deleted.Code != http.StatusOK {
+		t.Fatalf("admin delete status = %d", deleted.Code)
+	}
+	var reloaded model.KubeconfigToken
+	if err := model.DB.First(&reloaded, otherToken.ID).Error; !model.IsKubeconfigTokenNotFound(err) {
+		t.Fatalf("deleted record=%#v err=%v", reloaded, err)
+	}
+	if _, err := service.Authenticate(context.Background(), otherIssued.Encoded); err == nil {
+		t.Fatal("deleted token still authenticated")
+	}
+}
+
+func TestAdminKubeconfigTokenListPaginationAndFilters(t *testing.T) {
+	setupKubeconfigStatefulTest(t)
+	alice := createKubeconfigTestUser(t, "Alice")
+	bob := createKubeconfigTestUser(t, "bob")
+	now := time.Now().UTC()
+	active := createKubeconfigTestToken(t, alice, "active", now.Add(time.Hour))
+	expired := createKubeconfigTestToken(t, alice, "expired", now.Add(-time.Hour))
+	bobActive := createKubeconfigTestToken(t, bob, "bob active", now.Add(time.Hour))
+	createdAt := map[uint]time.Time{
+		active.ID: now.Add(-time.Hour), expired.ID: now.Add(-2 * time.Hour), bobActive.ID: now.Add(-3 * time.Hour),
+	}
+	for id, value := range createdAt {
+		if err := model.DB.Model(&model.KubeconfigToken{}).Where("id = ?", id).Update("created_at", value).Error; err != nil {
+			t.Fatal(err)
+		}
+	}
+	router := gin.New()
+	router.GET("/admin/tokens", withKubeconfigTestUser(alice), ListAllKubeconfigTokens)
+
+	list := performKubeconfigRequest(router, http.MethodGet, "/admin/tokens?page=1&size=2", "", nil)
+	var response struct {
+		Tokens []struct {
+			ID uint `json:"id"`
+		} `json:"tokens"`
+		Total int64 `json:"total"`
+		Page  int   `json:"page"`
+		Size  int   `json:"size"`
+	}
+	if err := json.Unmarshal(list.Body.Bytes(), &response); err != nil || list.Code != http.StatusOK || response.Total != 3 || response.Page != 1 || response.Size != 2 || len(response.Tokens) != 2 || response.Tokens[0].ID != active.ID || response.Tokens[1].ID != expired.ID {
+		t.Fatalf("paginated response=%s err=%v", list.Body.String(), err)
+	}
+	ownerFiltered := performKubeconfigRequest(router, http.MethodGet, "/admin/tokens?owner=ALI", "", nil)
+	if err := json.Unmarshal(ownerFiltered.Body.Bytes(), &response); err != nil || ownerFiltered.Code != http.StatusOK || response.Total != 2 || len(response.Tokens) != 2 || response.Tokens[0].ID != active.ID || response.Tokens[1].ID != expired.ID {
+		t.Fatalf("owner-filtered response=%s err=%v", ownerFiltered.Body.String(), err)
+	}
+	for _, test := range []struct {
+		query string
+		want  []uint
+	}{
+		{"status=active", []uint{active.ID, bobActive.ID}},
+		{"status=expired", []uint{expired.ID}},
+	} {
+		result := performKubeconfigRequest(router, http.MethodGet, "/admin/tokens?"+test.query, "", nil)
+		if err := json.Unmarshal(result.Body.Bytes(), &response); err != nil || result.Code != http.StatusOK || response.Total != int64(len(test.want)) || len(response.Tokens) != len(test.want) {
+			t.Fatalf("query %q response=%s err=%v", test.query, result.Body.String(), err)
+		}
+		for i, id := range test.want {
+			if response.Tokens[i].ID != id {
+				t.Fatalf("query %q token %d = %d, want %d", test.query, i, response.Tokens[i].ID, id)
+			}
+		}
+	}
+	for _, query := range []string{"page=0", "page=bad", "size=0", "size=101", "size=bad", "status=invalid", "status=revoked"} {
+		result := performKubeconfigRequest(router, http.MethodGet, "/admin/tokens?"+query, "", nil)
+		if result.Code != http.StatusBadRequest {
+			t.Fatalf("query %q status=%d, want %d", query, result.Code, http.StatusBadRequest)
+		}
+	}
+}
+
+func TestKubeconfigJWTValidationAndAuthenticationState(t *testing.T) {
+	setupKubeconfigStatefulTest(t)
+	owner := createKubeconfigTestUser(t, "jwt-owner")
+	service, err := newKubeconfigTokenService()
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC()
+	expired, err := service.Issue(context.Background(), statefultoken.IssueRequest{SubjectID: fmt.Sprint(owner.ID), Name: "expired", ExpiresAt: now.Add(-time.Hour)})
+	if !errors.Is(err, statefultoken.ErrInvalidToken) || expired.Encoded != "" {
+		t.Fatalf("expired token issue error = %v", err)
+	}
+
+	issued, err := service.Issue(context.Background(), statefultoken.IssueRequest{SubjectID: fmt.Sprint(owner.ID), Name: "active", ExpiresAt: now.Add(time.Hour)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertKubeconfigAuthStatus(t, &ClusterManager{}, issued.Encoded, http.StatusOK, "")
+	deleted, err := model.DeleteKubeconfigToken(issued.Record.ID, &owner.ID)
+	if err != nil || !deleted {
+		t.Fatalf("delete token deleted=%v err=%v", deleted, err)
+	}
+	assertKubeconfigAuthStatus(t, &ClusterManager{}, issued.Encoded, http.StatusUnauthorized, "invalid kubeconfig token")
+
+	disabledOwnerToken, issueErr := service.Issue(context.Background(), statefultoken.IssueRequest{SubjectID: fmt.Sprint(owner.ID), Name: "disabled-owner", ExpiresAt: now.Add(time.Hour)})
+	if issueErr != nil {
+		t.Fatal(issueErr)
+	}
+	if err := model.SetUserEnabled(owner.ID, false); err != nil {
+		t.Fatal(err)
+	}
+	assertKubeconfigAuthStatus(t, &ClusterManager{}, disabledOwnerToken.Encoded, http.StatusUnauthorized, "invalid kubeconfig token")
+}
+
+func assertKubeconfigAuthStatus(t *testing.T, manager *ClusterManager, token string, wantCode int, wantMessage string) {
+	t.Helper()
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	ctx.Request = httptest.NewRequest(http.MethodGet, "/", nil)
+	ctx.Request.Header.Set("Authorization", "Bearer "+token)
+	_, ok := manager.authenticateKubeconfigToken(ctx)
+	if ok != (wantCode == http.StatusOK) || recorder.Code != wantCode {
+		t.Fatalf("authenticated=%v status=%d, want status=%d", ok, recorder.Code, wantCode)
+	}
+	if wantCode != http.StatusOK {
+		var status v1.Status
+		if err := json.Unmarshal(recorder.Body.Bytes(), &status); err != nil || status.Kind != "Status" || status.Reason != v1.StatusReasonUnauthorized || !strings.Contains(status.Message, wantMessage) {
+			t.Fatalf("Kubernetes status=%#v err=%v", status, err)
+		}
+	}
+}
+
+func setupKubeconfigStatefulTest(t *testing.T) {
+	t.Helper()
+	originalDB := model.DB
+	originalSecret, originalKID := common.KubeconfigJWTSecret, common.KubeconfigJWTKID
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{Logger: logger.Default.LogMode(logger.Silent)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.AutoMigrate(&model.User{}, &model.Cluster{}, &model.KubeconfigToken{}); err != nil {
+		t.Fatal(err)
+	}
+	model.DB = db
+	common.KubeconfigJWTSecret, common.KubeconfigJWTKID = "stateful-kubeconfig-test-secret", "stateful-test-kid"
+	gin.SetMode(gin.TestMode)
+	t.Cleanup(func() {
+		model.InvalidateUserCache(1)
+		model.InvalidateUserCache(2)
+		model.DB = originalDB
+		common.KubeconfigJWTSecret, common.KubeconfigJWTKID = originalSecret, originalKID
+		sqlDB, _ := db.DB()
+		if sqlDB != nil {
+			_ = sqlDB.Close()
+		}
+	})
+}
+
+func createKubeconfigTestUser(t *testing.T, username string) model.User {
+	t.Helper()
+	user := model.User{Username: username, Enabled: true}
+	if err := model.DB.Create(&user).Error; err != nil {
+		t.Fatal(err)
+	}
+	model.InvalidateUserCache(uint64(user.ID))
+	return user
+}
+
+func createKubeconfigTestCluster(t *testing.T, name string) model.Cluster {
+	t.Helper()
+	cluster := model.Cluster{Name: name, Enable: true}
+	if err := model.DB.Create(&cluster).Error; err != nil {
+		t.Fatal(err)
+	}
+	return cluster
+}
+
+func createKubeconfigTestToken(t *testing.T, owner model.User, name string, expiresAt time.Time) *model.KubeconfigToken {
+	t.Helper()
+	if !expiresAt.After(time.Now().UTC()) {
+		record := &model.KubeconfigToken{
+			JTIHash: statefultoken.HashJTI(name), OwnerID: owner.ID, Name: name,
+			ExpiresAt: expiresAt, SigningKeyID: common.KubeconfigJWTKID,
+		}
+		if err := model.DB.Create(record).Error; err != nil {
+			t.Fatal(err)
+		}
+		return record
+	}
+	service, err := newKubeconfigTokenService()
+	if err != nil {
+		t.Fatal(err)
+	}
+	issued, err := service.Issue(context.Background(), statefultoken.IssueRequest{SubjectID: fmt.Sprint(owner.ID), Name: name, ExpiresAt: expiresAt})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var record model.KubeconfigToken
+	if err := model.DB.First(&record, issued.Record.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	return &record
+}
+
+func setKubeconfigTestRBAC(t *testing.T, username string, clusters []string) {
+	t.Helper()
+	original := rbac.RBACConfig
+	rbac.RBACConfig = &common.RolesConfig{Roles: []common.Role{{Name: "download", Clusters: clusters, Resources: []string{"*"}, Namespaces: []string{"*"}, Verbs: []string{"*"}}}, RoleMapping: []common.RoleMapping{{Name: "download", Users: []string{username}}}}
+	t.Cleanup(func() { rbac.RBACConfig = original })
+}
+
+func withKubeconfigTestUser(user model.User) gin.HandlerFunc {
+	return func(c *gin.Context) { c.Set("user", user) }
+}
+
+func performKubeconfigRequest(router *gin.Engine, method, path, body string, headers map[string]string) *httptest.ResponseRecorder {
+	request := httptest.NewRequest(method, path, strings.NewReader(body))
+	if body != "" {
+		request.Header.Set("Content-Type", "application/json")
+	}
+	for name, value := range headers {
+		request.Header.Set(name, value)
+	}
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, request)
+	return recorder
+}

--- a/pkg/cluster/kubeconfig_token.go
+++ b/pkg/cluster/kubeconfig_token.go
@@ -1,0 +1,21 @@
+package cluster
+
+import (
+	"errors"
+	"os"
+
+	"github.com/zxh326/kite/pkg/common"
+	"github.com/zxh326/kite/pkg/statefultoken"
+)
+
+const kubeconfigJWTIssuer = "kite-kubeconfig"
+
+func newKubeconfigTokenService() (*statefultoken.Service, error) {
+	secret := common.KubeconfigJWTSecret
+	if secret == "" || (secret == common.DefaultJWTSecret && os.Getenv("KUBECONFIG_JWT_SECRET") == "" && os.Getenv("KITE_ENV") == "production") {
+		return nil, errors.New("KUBECONFIG_JWT_SECRET is required")
+	}
+	return statefultoken.New(statefultoken.Config{
+		Issuer: kubeconfigJWTIssuer, Purpose: "kubeconfig", Secret: []byte(secret), KeyID: common.KubeconfigJWTKID,
+	}, kubeconfigTokenStore{})
+}

--- a/pkg/cluster/kubeconfig_token_handler.go
+++ b/pkg/cluster/kubeconfig_token_handler.go
@@ -1,0 +1,132 @@
+package cluster
+
+import (
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/zxh326/kite/pkg/model"
+)
+
+type kubeconfigTokenResponse struct {
+	ID           uint    `json:"id"`
+	Name         string  `json:"name"`
+	OwnerID      uint    `json:"ownerId,omitempty"`
+	Owner        string  `json:"owner,omitempty"`
+	CreatedAt    string  `json:"createdAt"`
+	ExpiresAt    string  `json:"expiresAt"`
+	LastUsedAt   *string `json:"lastUsedAt,omitempty"`
+	SigningKeyID string  `json:"signingKeyId"`
+}
+
+func kubeconfigTokenDTO(token model.KubeconfigToken, includeOwner bool) kubeconfigTokenResponse {
+	result := kubeconfigTokenResponse{ID: token.ID, Name: token.Name, CreatedAt: token.CreatedAt.UTC().Format(time.RFC3339), ExpiresAt: token.ExpiresAt.UTC().Format(time.RFC3339), SigningKeyID: token.SigningKeyID}
+	if token.LastUsedAt != nil {
+		value := token.LastUsedAt.UTC().Format(time.RFC3339)
+		result.LastUsedAt = &value
+	}
+	if includeOwner {
+		result.OwnerID = token.OwnerID
+		if token.Owner != nil {
+			result.Owner = token.Owner.Key()
+		}
+	}
+	return result
+}
+
+func listKubeconfigTokenResponses(c *gin.Context, ownerID uint, includeOwner bool) {
+	tokens, err := model.ListKubeconfigTokens(ownerID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to list kubeconfig tokens"})
+		return
+	}
+	result := make([]kubeconfigTokenResponse, 0, len(tokens))
+	for _, token := range tokens {
+		result = append(result, kubeconfigTokenDTO(token, includeOwner))
+	}
+	c.JSON(http.StatusOK, gin.H{"tokens": result})
+}
+
+func ListCurrentUserKubeconfigTokens(c *gin.Context) {
+	user := c.MustGet("user").(model.User)
+	listKubeconfigTokenResponses(c, user.ID, false)
+}
+
+func ListAllKubeconfigTokens(c *gin.Context) {
+	page, size, ok := parseKubeconfigTokenPagination(c)
+	if !ok {
+		return
+	}
+	status := c.Query("status")
+	if status != "" && status != "active" && status != "expired" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid status"})
+		return
+	}
+	tokens, total, err := model.ListAdminKubeconfigTokens(model.KubeconfigTokenListOptions{
+		Page: page, Size: size, Owner: c.Query("owner"), Status: status,
+	})
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to list kubeconfig tokens"})
+		return
+	}
+	result := make([]kubeconfigTokenResponse, 0, len(tokens))
+	for _, token := range tokens {
+		result = append(result, kubeconfigTokenDTO(token, true))
+	}
+	c.JSON(http.StatusOK, gin.H{"tokens": result, "total": total, "page": page, "size": size})
+}
+
+func parseKubeconfigTokenPagination(c *gin.Context) (int, int, bool) {
+	page, size := 1, 20
+	var err error
+	if value := c.Query("page"); value != "" {
+		page, err = strconv.Atoi(value)
+		if err != nil || page < 1 {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid page"})
+			return 0, 0, false
+		}
+	}
+	if value := c.Query("size"); value != "" {
+		size, err = strconv.Atoi(value)
+		if err != nil || size < 1 || size > 100 {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid size"})
+			return 0, 0, false
+		}
+	}
+	return page, size, true
+}
+
+func deleteKubeconfigToken(c *gin.Context, ownerID *uint) {
+	id, err := strconv.ParseUint(c.Param("id"), 10, 32)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid ID"})
+		return
+	}
+	service, err := newKubeconfigTokenService()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "kubeconfig token service is unavailable"})
+		return
+	}
+	var ownerSubject *string
+	if ownerID != nil {
+		value := strconv.FormatUint(uint64(*ownerID), 10)
+		ownerSubject = &value
+	}
+	deleted, err := service.Delete(c.Request.Context(), uint(id), ownerSubject)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to delete kubeconfig token"})
+		return
+	}
+	if !deleted {
+		c.JSON(http.StatusNotFound, gin.H{"error": "kubeconfig token not found"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"message": "kubeconfig token deleted"})
+}
+
+func DeleteCurrentUserKubeconfigToken(c *gin.Context) {
+	user := c.MustGet("user").(model.User)
+	deleteKubeconfigToken(c, &user.ID)
+}
+func DeleteAnyKubeconfigToken(c *gin.Context) { deleteKubeconfigToken(c, nil) }

--- a/pkg/cluster/kubeconfig_token_store.go
+++ b/pkg/cluster/kubeconfig_token_store.go
@@ -1,0 +1,55 @@
+package cluster
+
+import (
+	"context"
+	"strconv"
+
+	"github.com/zxh326/kite/pkg/model"
+	"github.com/zxh326/kite/pkg/statefultoken"
+)
+
+type kubeconfigTokenStore struct{}
+
+func (kubeconfigTokenStore) Create(_ context.Context, record statefultoken.Record) (statefultoken.Record, error) {
+	ownerID, err := strconv.ParseUint(record.SubjectID, 10, 64)
+	if err != nil {
+		return statefultoken.Record{}, err
+	}
+	modelRecord := &model.KubeconfigToken{
+		JTIHash: record.JTIHash, OwnerID: uint(ownerID), Name: record.Name,
+		ExpiresAt: record.ExpiresAt, SigningKeyID: record.SigningKeyID,
+	}
+	if err := model.DB.Create(modelRecord).Error; err != nil {
+		return statefultoken.Record{}, err
+	}
+	record.ID = modelRecord.ID
+	return record, nil
+}
+
+func (kubeconfigTokenStore) FindByJTIHash(_ context.Context, jtiHash string) (statefultoken.Record, error) {
+	record, err := model.GetKubeconfigTokenByJTIHash(jtiHash)
+	if err != nil {
+		return statefultoken.Record{}, err
+	}
+	return statefultoken.Record{
+		ID: record.ID, JTIHash: record.JTIHash, SubjectID: strconv.FormatUint(uint64(record.OwnerID), 10),
+		Name: record.Name, ExpiresAt: record.ExpiresAt, SigningKeyID: record.SigningKeyID,
+	}, nil
+}
+
+func (kubeconfigTokenStore) Touch(_ context.Context, tokenID uint) error {
+	return model.TouchKubeconfigToken(tokenID)
+}
+
+func (kubeconfigTokenStore) Delete(_ context.Context, tokenID uint, subjectID *string) (bool, error) {
+	var ownerID *uint
+	if subjectID != nil {
+		owner, err := strconv.ParseUint(*subjectID, 10, 64)
+		if err != nil {
+			return false, err
+		}
+		value := uint(owner)
+		ownerID = &value
+	}
+	return model.DeleteKubeconfigToken(tokenID, ownerID)
+}

--- a/pkg/cluster/kubeconfig_token_test.go
+++ b/pkg/cluster/kubeconfig_token_test.go
@@ -1,0 +1,26 @@
+package cluster
+
+import (
+	"testing"
+
+	"github.com/zxh326/kite/pkg/common"
+	"github.com/zxh326/kite/pkg/statefultoken"
+)
+
+func TestNewKubeconfigTokenServiceUsesDedicatedConfiguration(t *testing.T) {
+	previousSecret, previousKID := common.KubeconfigJWTSecret, common.KubeconfigJWTKID
+	common.KubeconfigJWTSecret, common.KubeconfigJWTKID = "test-kubeconfig-secret", "test-kid"
+	t.Cleanup(func() { common.KubeconfigJWTSecret, common.KubeconfigJWTKID = previousSecret, previousKID })
+
+	if _, err := newKubeconfigTokenService(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestKubeconfigTokenHashDoesNotContainJTI(t *testing.T) {
+	jti := "sensitive-jti"
+	hash := statefultoken.HashJTI(jti)
+	if hash == jti || len(hash) != 64 {
+		t.Fatalf("unexpected jti hash %q", hash)
+	}
+}

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -25,11 +25,13 @@ const (
 )
 
 var (
-	Port            = "8080"
-	JwtSecret       = DefaultJWTSecret
-	EnableAnalytics = false
-	Host            = ""
-	Base            = ""
+	Port                = "8080"
+	JwtSecret           = DefaultJWTSecret
+	KubeconfigJWTSecret = DefaultJWTSecret
+	KubeconfigJWTKID    = "default"
+	EnableAnalytics     = false
+	Host                = ""
+	Base                = ""
 
 	NodeTerminalImage    = "busybox:latest"
 	KubectlTerminalImage = "zzde/kubectl:latest"
@@ -101,6 +103,12 @@ func SetManagedSections(sections map[string]bool) {
 func LoadEnvs() {
 	if secret := os.Getenv("JWT_SECRET"); secret != "" {
 		JwtSecret = secret
+	}
+	if secret := os.Getenv("KUBECONFIG_JWT_SECRET"); secret != "" {
+		KubeconfigJWTSecret = secret
+	}
+	if kid := os.Getenv("KUBECONFIG_JWT_KID"); kid != "" {
+		KubeconfigJWTKID = kid
 	}
 
 	if port := os.Getenv("PORT"); port != "" {

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -75,7 +75,7 @@ var (
 	ConfigFilePath = ""
 
 	// ManagedSections tracks which configuration sections are managed by the config file.
-	// Keys: "clusters", "oauth", "ldap", "rbac", "superUser"
+	// Keys: "clusters", "oauth", "ldap", "smtp", "rbac", "superUser"
 	ManagedSections = map[string]bool{}
 	managedMu       sync.RWMutex
 )

--- a/pkg/common/types.go
+++ b/pkg/common/types.go
@@ -44,7 +44,9 @@ type ImportClustersRequest struct {
 
 type ClusterInfo struct {
 	Name      string `json:"name"`
+	UUID      string `json:"uuid"`
 	Version   string `json:"version"`
+	Enabled   bool   `json:"enabled"`
 	IsDefault bool   `json:"isDefault"`
 	Error     string `json:"error,omitempty"`
 }

--- a/pkg/model/cluster.go
+++ b/pkg/model/cluster.go
@@ -1,7 +1,15 @@
 package model
 
+import (
+	"errors"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
 type Cluster struct {
 	Model
+	UUID                   string       `json:"uuid" gorm:"type:varchar(36);uniqueIndex"`
 	Name                   string       `json:"name" gorm:"type:varchar(100);uniqueIndex;not null"`
 	Description            string       `json:"description" gorm:"type:text"`
 	Config                 SecretString `json:"config" gorm:"type:text"`
@@ -15,8 +23,48 @@ type Cluster struct {
 	Enable                 bool         `json:"enable" gorm:"type:boolean;default:true"`
 }
 
+func (cluster *Cluster) BeforeCreate(*gorm.DB) error {
+	if cluster.UUID == "" {
+		cluster.UUID = uuid.NewString()
+	}
+	return nil
+}
+
 func AddCluster(cluster *Cluster) error {
 	return DB.Create(cluster).Error
+}
+
+func GetClusterByUUID(value string) (*Cluster, error) {
+	var cluster Cluster
+	if err := DB.Where("uuid = ?", value).First(&cluster).Error; err != nil {
+		return nil, err
+	}
+	return &cluster, nil
+}
+
+// BackfillClusterUUIDs assigns UUIDv4 values to legacy clusters. The database
+// unique index remains the authority if concurrent instances race.
+func BackfillClusterUUIDs() error {
+	for {
+		var clusters []Cluster
+		if err := DB.Where("uuid IS NULL OR uuid = ?", "").Find(&clusters).Error; err != nil {
+			return err
+		}
+		if len(clusters) == 0 {
+			return nil
+		}
+		for _, cluster := range clusters {
+			for {
+				result := DB.Model(&Cluster{}).Where("id = ? AND (uuid IS NULL OR uuid = ?)", cluster.ID, "").Update("uuid", uuid.NewString())
+				if result.Error == nil || !errors.Is(result.Error, gorm.ErrDuplicatedKey) {
+					if result.Error != nil {
+						return result.Error
+					}
+					break
+				}
+			}
+		}
+	}
 }
 
 func GetClusterByName(name string) (*Cluster, error) {

--- a/pkg/model/general_setting.go
+++ b/pkg/model/general_setting.go
@@ -65,6 +65,16 @@ type GeneralSetting struct {
 	LoginPrompt             string       `json:"loginPrompt" gorm:"column:login_prompt;type:text"`
 	JWTSecret               SecretString `json:"-" gorm:"column:jwt_secret;type:text"`
 	GlobalSidebarPreference string       `json:"-" gorm:"column:global_sidebar_preference;type:text"`
+	SMTPEnabled             bool         `json:"smtpEnabled" gorm:"column:smtp_enabled;type:boolean;not null;default:false"`
+	SMTPHost                string       `json:"smtpHost" gorm:"column:smtp_host;type:varchar(255)"`
+	SMTPPort                int          `json:"smtpPort" gorm:"column:smtp_port;type:integer"`
+	SMTPUsername            string       `json:"smtpUsername" gorm:"column:smtp_username;type:varchar(255)"`
+	SMTPPassword            SecretString `json:"-" gorm:"column:smtp_password;type:text"`
+	SMTPFromEmail           string       `json:"smtpFromEmail" gorm:"column:smtp_from_email;type:varchar(255)"`
+	SMTPFromName            string       `json:"smtpFromName" gorm:"column:smtp_from_name;type:varchar(255)"`
+	SMTPEncryption          string       `json:"smtpEncryption" gorm:"column:smtp_encryption;type:varchar(20)"`
+	SMTPSkipTLSVerify       bool         `json:"smtpSkipTlsVerify" gorm:"column:smtp_skip_tls_verify;type:boolean;not null;default:false"`
+	SMTPTimeoutSeconds      int          `json:"smtpTimeoutSeconds" gorm:"column:smtp_timeout_seconds;type:integer"`
 }
 
 func NormalizeGeneralAIProvider(provider string) string {

--- a/pkg/model/kubeconfig_token.go
+++ b/pkg/model/kubeconfig_token.go
@@ -1,0 +1,77 @@
+package model
+
+import (
+	"errors"
+	"strings"
+	"time"
+
+	"gorm.io/gorm"
+)
+
+type KubeconfigToken struct {
+	Model
+	JTIHash      string     `json:"-" gorm:"type:varchar(64);uniqueIndex;not null"`
+	OwnerID      uint       `json:"ownerId" gorm:"index;not null"`
+	Name         string     `json:"name" gorm:"type:varchar(255);not null"`
+	ExpiresAt    time.Time  `json:"expiresAt" gorm:"index;not null"`
+	LastUsedAt   *time.Time `json:"lastUsedAt,omitempty"`
+	SigningKeyID string     `json:"signingKeyId" gorm:"type:varchar(255);not null"`
+	Owner        *User      `json:"owner,omitempty" gorm:"foreignKey:OwnerID"`
+}
+
+func GetKubeconfigTokenByJTIHash(jtiHash string) (*KubeconfigToken, error) {
+	var token KubeconfigToken
+	if err := DB.Where("jti_hash = ?", jtiHash).First(&token).Error; err != nil {
+		return nil, err
+	}
+	return &token, nil
+}
+
+func ListKubeconfigTokens(ownerID uint) ([]KubeconfigToken, error) {
+	var tokens []KubeconfigToken
+	return tokens, DB.Where("owner_id = ?", ownerID).Order("created_at DESC").Find(&tokens).Error
+}
+
+type KubeconfigTokenListOptions struct {
+	Page   int
+	Size   int
+	Owner  string
+	Status string
+}
+
+func ListAdminKubeconfigTokens(options KubeconfigTokenListOptions) ([]KubeconfigToken, int64, error) {
+	var tokens []KubeconfigToken
+	query := DB.Model(&KubeconfigToken{}).Joins("JOIN users ON users.id = kubeconfig_tokens.owner_id")
+	if options.Owner != "" {
+		query = query.Where("LOWER(users.username) LIKE ?", "%"+strings.ToLower(options.Owner)+"%")
+	}
+	now := time.Now().UTC()
+	switch options.Status {
+	case "active":
+		query = query.Where("kubeconfig_tokens.expires_at > ?", now)
+	case "expired":
+		query = query.Where("kubeconfig_tokens.expires_at <= ?", now)
+	}
+	var total int64
+	if err := query.Count(&total).Error; err != nil {
+		return nil, 0, err
+	}
+	err := query.Preload("Owner").Order("kubeconfig_tokens.created_at DESC").Offset((options.Page - 1) * options.Size).Limit(options.Size).Find(&tokens).Error
+	return tokens, total, err
+}
+
+func TouchKubeconfigToken(id uint) error {
+	now := time.Now().UTC()
+	return DB.Model(&KubeconfigToken{}).Where("id = ?", id).Update("last_used_at", now).Error
+}
+
+func DeleteKubeconfigToken(id uint, ownerID *uint) (bool, error) {
+	query := DB.Where("id = ?", id)
+	if ownerID != nil {
+		query = query.Where("owner_id = ?", *ownerID)
+	}
+	result := query.Delete(&KubeconfigToken{})
+	return result.RowsAffected > 0, result.Error
+}
+
+func IsKubeconfigTokenNotFound(err error) bool { return errors.Is(err, gorm.ErrRecordNotFound) }

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -104,12 +104,16 @@ func InitDB() {
 		PendingSession{},
 		HelmRepository{},
 		ScheduledTask{},
+		KubeconfigToken{},
 	}
 	for _, model := range models {
 		err = DB.AutoMigrate(model)
 		if err != nil {
 			panic("failed to migrate database: " + err.Error())
 		}
+	}
+	if err := BackfillClusterUUIDs(); err != nil {
+		panic("failed to backfill cluster UUIDs: " + err.Error())
 	}
 	sqldb, err := DB.DB()
 	if err == nil {

--- a/pkg/rbac/rbac.go
+++ b/pkg/rbac/rbac.go
@@ -70,6 +70,11 @@ func CanAccessCluster(user model.User, name string) bool {
 	return false
 }
 
+func CanAccessClusterCurrent(user model.User, name string) bool {
+	user.Roles = nil
+	return CanAccessCluster(user, name)
+}
+
 func CanAccessNamespace(user model.User, cluster, name string) bool {
 	roles := GetUserRoles(user)
 	for _, role := range roles {

--- a/pkg/settings/handler.go
+++ b/pkg/settings/handler.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/gin-gonic/gin"
+	"github.com/zxh326/kite/pkg/common"
 	"github.com/zxh326/kite/pkg/model"
 )
 
@@ -15,25 +16,40 @@ func HandleGetGeneralSetting(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("Failed to load general setting: %v", err)})
 		return
 	}
+	writeGeneralSettingResponse(c, setting)
+}
+
+func writeGeneralSettingResponse(c *gin.Context, setting *model.GeneralSetting) {
 	hasAIAPIKey := strings.TrimSpace(string(setting.AIAPIKey)) != ""
+	hasSMTPPassword := strings.TrimSpace(string(setting.SMTPPassword)) != ""
 	c.JSON(http.StatusOK, gin.H{
-		"aiAgentEnabled":        setting.AIAgentEnabled,
-		"aiProvider":            setting.AIProvider,
-		"aiModel":               setting.AIModel,
-		"aiApiKey":              "",
-		"aiApiKeyConfigured":    hasAIAPIKey,
-		"aiBaseUrl":             setting.AIBaseURL,
-		"aiMaxTokens":           setting.AIMaxTokens,
-		"kubectlEnabled":        setting.KubectlEnabled,
-		"kubectlImage":          setting.KubectlImage,
-		"nodeTerminalImage":     setting.NodeTerminalImage,
-		"clusterAgentImage":     setting.ClusterAgentImage,
-		"enableAnalytics":       setting.EnableAnalytics,
-		"enableVersionCheck":    setting.EnableVersionCheck,
-		"passwordLoginDisabled": setting.PasswordLoginDisabled,
-		"enableMFA":             setting.EnableMFA,
-		"enablePasskeyLogin":    setting.EnablePasskeyLogin,
-		"loginPrompt":           setting.LoginPrompt,
+		"aiAgentEnabled":         setting.AIAgentEnabled,
+		"aiProvider":             setting.AIProvider,
+		"aiModel":                setting.AIModel,
+		"aiApiKey":               "",
+		"aiApiKeyConfigured":     hasAIAPIKey,
+		"aiBaseUrl":              setting.AIBaseURL,
+		"aiMaxTokens":            setting.AIMaxTokens,
+		"kubectlEnabled":         setting.KubectlEnabled,
+		"kubectlImage":           setting.KubectlImage,
+		"nodeTerminalImage":      setting.NodeTerminalImage,
+		"clusterAgentImage":      setting.ClusterAgentImage,
+		"enableAnalytics":        setting.EnableAnalytics,
+		"enableVersionCheck":     setting.EnableVersionCheck,
+		"passwordLoginDisabled":  setting.PasswordLoginDisabled,
+		"enableMFA":              setting.EnableMFA,
+		"enablePasskeyLogin":     setting.EnablePasskeyLogin,
+		"loginPrompt":            setting.LoginPrompt,
+		"smtpEnabled":            setting.SMTPEnabled,
+		"smtpHost":               setting.SMTPHost,
+		"smtpPort":               setting.SMTPPort,
+		"smtpUsername":           setting.SMTPUsername,
+		"smtpPasswordConfigured": hasSMTPPassword,
+		"smtpFromEmail":          setting.SMTPFromEmail,
+		"smtpFromName":           setting.SMTPFromName,
+		"smtpEncryption":         setting.SMTPEncryption,
+		"smtpSkipTLSVerify":      setting.SMTPSkipTLSVerify,
+		"smtpTimeoutSeconds":     setting.SMTPTimeoutSeconds,
 	})
 }
 
@@ -54,12 +70,27 @@ type UpdateGeneralSettingRequest struct {
 	EnableMFA             *bool   `json:"enableMFA"`
 	EnablePasskeyLogin    *bool   `json:"enablePasskeyLogin"`
 	LoginPrompt           *string `json:"loginPrompt"`
+	SMTPEnabled           *bool   `json:"smtpEnabled"`
+	SMTPHost              *string `json:"smtpHost"`
+	SMTPPort              *int    `json:"smtpPort"`
+	SMTPUsername          *string `json:"smtpUsername"`
+	SMTPPassword          *string `json:"smtpPassword"`
+	SMTPClearPassword     *bool   `json:"smtpClearPassword"`
+	SMTPFromEmail         *string `json:"smtpFromEmail"`
+	SMTPFromName          *string `json:"smtpFromName"`
+	SMTPEncryption        *string `json:"smtpEncryption"`
+	SMTPSkipTLSVerify     *bool   `json:"smtpSkipTLSVerify"`
+	SMTPTimeoutSeconds    *int    `json:"smtpTimeoutSeconds"`
 }
 
 func HandleUpdateGeneralSetting(c *gin.Context) { //nolint:gocyclo
 	var req UpdateGeneralSettingRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("Invalid request: %v", err)})
+		return
+	}
+	if common.IsSectionManaged("smtp") && (req.SMTPEnabled != nil || req.SMTPHost != nil || req.SMTPPort != nil || req.SMTPUsername != nil || req.SMTPPassword != nil || req.SMTPClearPassword != nil || req.SMTPFromEmail != nil || req.SMTPFromName != nil || req.SMTPEncryption != nil || req.SMTPSkipTLSVerify != nil || req.SMTPTimeoutSeconds != nil) {
+		c.JSON(http.StatusForbidden, gin.H{"error": common.ManagedSectionError})
 		return
 	}
 	currentSetting, err := model.GetGeneralSetting()
@@ -79,7 +110,6 @@ func HandleUpdateGeneralSetting(c *gin.Context) { //nolint:gocyclo
 			aiProvider = model.NormalizeGeneralAIProvider(incomingProvider)
 		}
 	}
-
 	aiModel := strings.TrimSpace(currentSetting.AIModel)
 	if req.AIModel != nil {
 		aiModel = strings.TrimSpace(*req.AIModel)
@@ -90,8 +120,7 @@ func HandleUpdateGeneralSetting(c *gin.Context) { //nolint:gocyclo
 	aiAPIKey := strings.TrimSpace(string(currentSetting.AIAPIKey))
 	shouldUpdateAIAPIKey := false
 	if req.AIAPIKey != nil {
-		incomingKey := strings.TrimSpace(*req.AIAPIKey)
-		if incomingKey != "" {
+		if incomingKey := strings.TrimSpace(*req.AIAPIKey); incomingKey != "" {
 			aiAPIKey = incomingKey
 			shouldUpdateAIAPIKey = true
 		}
@@ -134,13 +163,45 @@ func HandleUpdateGeneralSetting(c *gin.Context) { //nolint:gocyclo
 	if clusterAgentImage == "" {
 		clusterAgentImage = model.DefaultGeneralClusterAgentImageValue()
 	}
-
 	aiMaxTokens := currentSetting.AIMaxTokens
 	if req.AIMaxTokens != nil {
 		aiMaxTokens = *req.AIMaxTokens
 	}
 	if aiMaxTokens <= 0 {
 		aiMaxTokens = 16384
+	}
+
+	smtpSetting := *currentSetting
+	if req.SMTPEnabled != nil {
+		smtpSetting.SMTPEnabled = *req.SMTPEnabled
+	}
+	if req.SMTPHost != nil {
+		smtpSetting.SMTPHost = strings.TrimSpace(*req.SMTPHost)
+	}
+	if req.SMTPPort != nil {
+		smtpSetting.SMTPPort = *req.SMTPPort
+	}
+	if req.SMTPUsername != nil {
+		smtpSetting.SMTPUsername = strings.TrimSpace(*req.SMTPUsername)
+	}
+	if req.SMTPFromEmail != nil {
+		smtpSetting.SMTPFromEmail = strings.TrimSpace(*req.SMTPFromEmail)
+	}
+	if req.SMTPFromName != nil {
+		smtpSetting.SMTPFromName = strings.TrimSpace(*req.SMTPFromName)
+	}
+	if req.SMTPEncryption != nil {
+		smtpSetting.SMTPEncryption = normalizeSMTPEncryption(*req.SMTPEncryption)
+	}
+	if req.SMTPSkipTLSVerify != nil {
+		smtpSetting.SMTPSkipTLSVerify = *req.SMTPSkipTLSVerify
+	}
+	if req.SMTPTimeoutSeconds != nil {
+		smtpSetting.SMTPTimeoutSeconds = *req.SMTPTimeoutSeconds
+	}
+	if err := validateSMTPSetting(&smtpSetting); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
 	}
 
 	updates := map[string]interface{}{}
@@ -192,31 +253,134 @@ func HandleUpdateGeneralSetting(c *gin.Context) { //nolint:gocyclo
 	if shouldUpdateAIAPIKey {
 		updates["ai_api_key"] = model.SecretString(aiAPIKey)
 	}
+	if req.SMTPEnabled != nil {
+		updates["smtp_enabled"] = smtpSetting.SMTPEnabled
+	}
+	if req.SMTPHost != nil {
+		updates["smtp_host"] = smtpSetting.SMTPHost
+	}
+	if req.SMTPPort != nil {
+		updates["smtp_port"] = smtpSetting.SMTPPort
+	}
+	if req.SMTPUsername != nil {
+		updates["smtp_username"] = smtpSetting.SMTPUsername
+	}
+	if req.SMTPFromEmail != nil {
+		updates["smtp_from_email"] = smtpSetting.SMTPFromEmail
+	}
+	if req.SMTPFromName != nil {
+		updates["smtp_from_name"] = smtpSetting.SMTPFromName
+	}
+	if req.SMTPEncryption != nil {
+		updates["smtp_encryption"] = smtpSetting.SMTPEncryption
+	}
+	if req.SMTPSkipTLSVerify != nil {
+		updates["smtp_skip_tls_verify"] = smtpSetting.SMTPSkipTLSVerify
+	}
+	if req.SMTPTimeoutSeconds != nil {
+		updates["smtp_timeout_seconds"] = smtpSetting.SMTPTimeoutSeconds
+	}
+	if req.SMTPClearPassword != nil && *req.SMTPClearPassword {
+		updates["smtp_password"] = model.SecretString("")
+	} else if req.SMTPPassword != nil {
+		if password := strings.TrimSpace(*req.SMTPPassword); password != "" {
+			updates["smtp_password"] = model.SecretString(password)
+		}
+	}
 
 	updated, err := model.UpdateGeneralSetting(updates)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("Failed to update general setting: %v", err)})
 		return
 	}
+	writeGeneralSettingResponse(c, updated)
+}
 
-	hasAIAPIKey := strings.TrimSpace(string(updated.AIAPIKey)) != ""
-	c.JSON(http.StatusOK, gin.H{
-		"aiAgentEnabled":        updated.AIAgentEnabled,
-		"aiProvider":            updated.AIProvider,
-		"aiModel":               updated.AIModel,
-		"aiApiKey":              "",
-		"aiApiKeyConfigured":    hasAIAPIKey,
-		"aiBaseUrl":             updated.AIBaseURL,
-		"aiMaxTokens":           updated.AIMaxTokens,
-		"kubectlEnabled":        updated.KubectlEnabled,
-		"kubectlImage":          updated.KubectlImage,
-		"nodeTerminalImage":     updated.NodeTerminalImage,
-		"clusterAgentImage":     updated.ClusterAgentImage,
-		"enableAnalytics":       updated.EnableAnalytics,
-		"enableVersionCheck":    updated.EnableVersionCheck,
-		"passwordLoginDisabled": updated.PasswordLoginDisabled,
-		"enableMFA":             updated.EnableMFA,
-		"enablePasskeyLogin":    updated.EnablePasskeyLogin,
-		"loginPrompt":           updated.LoginPrompt,
-	})
+type SMTPTestRequest struct {
+	Recipient          string  `json:"recipient"`
+	SMTPEnabled        *bool   `json:"smtpEnabled"`
+	SMTPHost           *string `json:"smtpHost"`
+	SMTPPort           *int    `json:"smtpPort"`
+	SMTPUsername       *string `json:"smtpUsername"`
+	SMTPPassword       *string `json:"smtpPassword"`
+	SMTPFromEmail      *string `json:"smtpFromEmail"`
+	SMTPFromName       *string `json:"smtpFromName"`
+	SMTPEncryption     *string `json:"smtpEncryption"`
+	SMTPSkipTLSVerify  *bool   `json:"smtpSkipTLSVerify"`
+	SMTPTimeoutSeconds *int    `json:"smtpTimeoutSeconds"`
+}
+
+func (req SMTPTestRequest) hasSMTPOverride() bool {
+	return req.SMTPEnabled != nil || req.SMTPHost != nil || req.SMTPPort != nil || req.SMTPUsername != nil || req.SMTPPassword != nil || req.SMTPFromEmail != nil || req.SMTPFromName != nil || req.SMTPEncryption != nil || req.SMTPSkipTLSVerify != nil || req.SMTPTimeoutSeconds != nil
+}
+
+func (req SMTPTestRequest) applySMTPOverride(setting *model.GeneralSetting) {
+	if req.SMTPEnabled != nil {
+		setting.SMTPEnabled = *req.SMTPEnabled
+	}
+	if req.SMTPHost != nil {
+		setting.SMTPHost = strings.TrimSpace(*req.SMTPHost)
+	}
+	if req.SMTPPort != nil {
+		setting.SMTPPort = *req.SMTPPort
+	}
+	if req.SMTPUsername != nil {
+		setting.SMTPUsername = strings.TrimSpace(*req.SMTPUsername)
+	}
+	if req.SMTPPassword != nil {
+		if password := strings.TrimSpace(*req.SMTPPassword); password != "" {
+			setting.SMTPPassword = model.SecretString(password)
+		}
+	}
+	if req.SMTPFromEmail != nil {
+		setting.SMTPFromEmail = strings.TrimSpace(*req.SMTPFromEmail)
+	}
+	if req.SMTPFromName != nil {
+		setting.SMTPFromName = strings.TrimSpace(*req.SMTPFromName)
+	}
+	if req.SMTPEncryption != nil {
+		setting.SMTPEncryption = normalizeSMTPEncryption(*req.SMTPEncryption)
+	}
+	if req.SMTPSkipTLSVerify != nil {
+		setting.SMTPSkipTLSVerify = *req.SMTPSkipTLSVerify
+	}
+	if req.SMTPTimeoutSeconds != nil {
+		setting.SMTPTimeoutSeconds = *req.SMTPTimeoutSeconds
+	}
+}
+
+func HandleTestSMTP(c *gin.Context) {
+	var req SMTPTestRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("Invalid request: %v", err)})
+		return
+	}
+	recipient := strings.TrimSpace(req.Recipient)
+	if !isValidEmail(recipient) {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "recipient must be a valid email address"})
+		return
+	}
+	setting, err := model.GetGeneralSetting()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("Failed to load general setting: %v", err)})
+		return
+	}
+	if req.hasSMTPOverride() {
+		temporarySetting := *setting
+		req.applySMTPOverride(&temporarySetting)
+		setting = &temporarySetting
+		if err := validateSMTPSetting(setting); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+	}
+	if !setting.SMTPEnabled {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "SMTP is not enabled"})
+		return
+	}
+	if err := sendSMTPTestEmail(c.Request.Context(), setting, recipient); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Failed to send SMTP test email"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"success": true})
 }

--- a/pkg/settings/handler_test.go
+++ b/pkg/settings/handler_test.go
@@ -2,6 +2,7 @@ package settings
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -56,6 +57,125 @@ func TestGeneralSettingHandlersDoNotExposeOrEraseAPIKey(t *testing.T) {
 	}
 	if stored.AIAPIKey != model.SecretString("existing-secret") {
 		t.Fatalf("stored API key = %q, want preserved value", stored.AIAPIKey)
+	}
+}
+
+func TestGeneralSettingHandlersDoNotExposeOrEraseSMTPPassword(t *testing.T) {
+	setupGeneralSettingTestDB(t, "")
+	if err := model.DB.Model(&model.GeneralSetting{}).Where("id = ?", 1).Updates(map[string]interface{}{
+		"smtp_password": model.SecretString("existing-smtp-password"),
+	}).Error; err != nil {
+		t.Fatalf("storing SMTP password: %v", err)
+	}
+	router := generalSettingTestRouter()
+
+	getResponse := performGeneralSettingRequest(t, router, http.MethodGet, "")
+	if getResponse.Code != http.StatusOK {
+		t.Fatalf("GET status = %d, want %d: %s", getResponse.Code, http.StatusOK, getResponse.Body.String())
+	}
+	getBody := decodeGeneralSettingResponse(t, getResponse)
+	if _, ok := getBody["smtpPassword"]; ok || getBody["smtpPasswordConfigured"] != true {
+		t.Fatalf("GET SMTP password fields = %#v", getBody)
+	}
+	if getBody["smtpSkipTLSVerify"] != false {
+		t.Fatalf("GET smtpSkipTLSVerify = %#v, want false", getBody["smtpSkipTLSVerify"])
+	}
+	if _, ok := getBody["smtpSkipTlsVerify"]; ok {
+		t.Fatalf("GET response has deprecated smtpSkipTlsVerify field = %#v", getBody)
+	}
+	if strings.Contains(getResponse.Body.String(), "existing-smtp-password") {
+		t.Fatal("GET response exposed the stored SMTP password")
+	}
+
+	updateResponse := performGeneralSettingRequest(t, router, http.MethodPut, `{"smtpPassword":"  ","smtpSkipTLSVerify":true}`)
+	if updateResponse.Code != http.StatusOK {
+		t.Fatalf("PUT status = %d, want %d: %s", updateResponse.Code, http.StatusOK, updateResponse.Body.String())
+	}
+	if strings.Contains(updateResponse.Body.String(), "existing-smtp-password") {
+		t.Fatal("PUT response exposed the stored SMTP password")
+	}
+	var stored model.GeneralSetting
+	if err := model.DB.First(&stored, 1).Error; err != nil {
+		t.Fatalf("loading stored setting: %v", err)
+	}
+	if stored.SMTPPassword != model.SecretString("existing-smtp-password") {
+		t.Fatalf("stored SMTP password = %q, want preserved value", stored.SMTPPassword)
+	}
+	if !stored.SMTPSkipTLSVerify {
+		t.Fatal("stored SMTPSkipTLSVerify = false, want true")
+	}
+}
+
+func TestHandleUpdateGeneralSettingRejectsManagedSMTP(t *testing.T) {
+	setupGeneralSettingTestDB(t, "")
+	originalManagedSections := common.ManagedSections
+	common.SetManagedSections(map[string]bool{"smtp": true})
+	t.Cleanup(func() { common.ManagedSections = originalManagedSections })
+
+	response := performGeneralSettingRequest(t, generalSettingTestRouter(), http.MethodPut, `{"smtpClearPassword":true}`)
+	if response.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d: %s", response.Code, http.StatusForbidden, response.Body.String())
+	}
+	body := decodeGeneralSettingResponse(t, response)
+	if body["error"] != common.ManagedSectionError {
+		t.Fatalf("error = %q, want %q", body["error"], common.ManagedSectionError)
+	}
+}
+
+func TestHandleUpdateGeneralSettingValidatesEnabledSMTPConfiguration(t *testing.T) {
+	setupGeneralSettingTestDB(t, "")
+	response := performGeneralSettingRequest(t, generalSettingTestRouter(), http.MethodPut, `{"smtpEnabled":true,"smtpHost":" ","smtpPort":0,"smtpFromEmail":"not-an-email","smtpEncryption":"invalid"}`)
+	if response.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d: %s", response.Code, http.StatusBadRequest, response.Body.String())
+	}
+	body := decodeGeneralSettingResponse(t, response)
+	if body["error"] != "smtpHost is required when smtpEnabled is true" {
+		t.Fatalf("error = %q", body["error"])
+	}
+}
+
+func TestHandleTestSMTPRejectsWhenDisabled(t *testing.T) {
+	setupGeneralSettingTestDB(t, "")
+	response := performGeneralSettingRequest(t, generalSettingTestRouter(), http.MethodPost, `{"recipient":"recipient@example.com"}`)
+	if response.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d: %s", response.Code, http.StatusBadRequest, response.Body.String())
+	}
+	body := decodeGeneralSettingResponse(t, response)
+	if body["error"] != "SMTP is not enabled" {
+		t.Fatalf("error = %q", body["error"])
+	}
+}
+
+func TestHandleTestSMTPUsesTemporaryOverrideWithoutPersisting(t *testing.T) {
+	setupGeneralSettingTestDB(t, "")
+	server := newFakeSMTPServer(t, false, false)
+	setting := server.setting()
+	if err := model.DB.Model(&model.GeneralSetting{}).Where("id = ?", 1).Updates(map[string]interface{}{
+		"smtp_password": model.SecretString("stored-password"),
+		"smtp_host":     "stored.example.com",
+	}).Error; err != nil {
+		t.Fatalf("storing SMTP setting: %v", err)
+	}
+
+	body := fmt.Sprintf(`{"recipient":"recipient@example.com","smtpEnabled":true,"smtpHost":"%s","smtpPort":%d,"smtpUsername":"temporary-user","smtpPassword":"temporary-password","smtpFromEmail":"%s","smtpFromName":"Temporary Sender","smtpEncryption":"none","smtpSkipTLSVerify":false,"smtpTimeoutSeconds":1}`,
+		setting.SMTPHost, setting.SMTPPort, setting.SMTPFromEmail)
+	response := performGeneralSettingRequest(t, generalSettingTestRouter(), http.MethodPost, body)
+	if response.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d: %s", response.Code, http.StatusOK, response.Body.String())
+	}
+
+	server.mu.Lock()
+	received := server.message
+	server.mu.Unlock()
+	if received == "" {
+		t.Fatal("temporary SMTP configuration did not send an email")
+	}
+	var stored model.GeneralSetting
+	if err := model.DB.First(&stored, 1).Error; err != nil {
+		t.Fatalf("loading stored setting: %v", err)
+	}
+	if stored.SMTPHost != "stored.example.com" || stored.SMTPPassword != model.SecretString("stored-password") {
+		t.Fatalf("SMTP test persisted temporary configuration: %#v", stored)
 	}
 }
 
@@ -152,6 +272,7 @@ func generalSettingTestRouter() *gin.Engine {
 	router := gin.New()
 	router.GET("/settings", HandleGetGeneralSetting)
 	router.PUT("/settings", HandleUpdateGeneralSetting)
+	router.POST("/settings", HandleTestSMTP)
 	return router
 }
 

--- a/pkg/settings/smtp.go
+++ b/pkg/settings/smtp.go
@@ -1,0 +1,137 @@
+package settings
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net"
+	"net/mail"
+	"net/smtp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/zxh326/kite/pkg/model"
+)
+
+const defaultSMTPTimeoutSeconds = 30
+
+func normalizeSMTPEncryption(encryption string) string {
+	return strings.ToLower(strings.TrimSpace(encryption))
+}
+
+func isSMTPEncryptionSupported(encryption string) bool {
+	switch encryption {
+	case "none", "starttls", "tls":
+		return true
+	default:
+		return false
+	}
+}
+
+func isValidEmail(address string) bool {
+	parsed, err := mail.ParseAddress(address)
+	return err == nil && parsed.Address == address
+}
+
+func validateSMTPSetting(setting *model.GeneralSetting) error {
+	if !setting.SMTPEnabled {
+		return nil
+	}
+	if setting.SMTPHost == "" {
+		return fmt.Errorf("smtpHost is required when smtpEnabled is true")
+	}
+	if setting.SMTPPort < 1 || setting.SMTPPort > 65535 {
+		return fmt.Errorf("smtpPort must be between 1 and 65535 when smtpEnabled is true")
+	}
+	if !isValidEmail(setting.SMTPFromEmail) {
+		return fmt.Errorf("smtpFromEmail must be a valid email address when smtpEnabled is true")
+	}
+	if !isSMTPEncryptionSupported(setting.SMTPEncryption) {
+		return fmt.Errorf("smtpEncryption must be one of none, starttls, tls when smtpEnabled is true")
+	}
+	return nil
+}
+
+func sendSMTPTestEmail(ctx context.Context, setting *model.GeneralSetting, recipient string) error {
+	if !setting.SMTPEnabled {
+		return fmt.Errorf("SMTP is not enabled")
+	}
+	if err := validateSMTPSetting(setting); err != nil {
+		return err
+	}
+	if !isValidEmail(recipient) {
+		return fmt.Errorf("recipient must be a valid email address")
+	}
+
+	timeout := setting.SMTPTimeoutSeconds
+	if timeout <= 0 {
+		timeout = defaultSMTPTimeoutSeconds
+	}
+	deadline := time.Now().Add(time.Duration(timeout) * time.Second)
+	address := net.JoinHostPort(setting.SMTPHost, strconv.Itoa(setting.SMTPPort))
+	tlsConfig := &tls.Config{ServerName: setting.SMTPHost, InsecureSkipVerify: setting.SMTPSkipTLSVerify}
+	dialer := &net.Dialer{Timeout: time.Duration(timeout) * time.Second}
+
+	var conn net.Conn
+	var err error
+	if setting.SMTPEncryption == "tls" {
+		conn, err = tls.DialWithDialer(dialer, "tcp", address, tlsConfig)
+	} else {
+		conn, err = dialer.DialContext(ctx, "tcp", address)
+	}
+	if err != nil {
+		return fmt.Errorf("connect to SMTP server: %w", err)
+	}
+	defer func() {
+		_ = conn.Close()
+	}()
+	if err := conn.SetDeadline(deadline); err != nil {
+		return fmt.Errorf("set SMTP deadline: %w", err)
+	}
+
+	client, err := smtp.NewClient(conn, setting.SMTPHost)
+	if err != nil {
+		return fmt.Errorf("create SMTP client: %w", err)
+	}
+	defer func() {
+		_ = client.Quit()
+	}()
+
+	if setting.SMTPEncryption == "starttls" {
+		if ok, _ := client.Extension("STARTTLS"); !ok {
+			return fmt.Errorf("SMTP server does not support STARTTLS")
+		}
+		if err := client.StartTLS(tlsConfig); err != nil {
+			return fmt.Errorf("start SMTP TLS: %w", err)
+		}
+	}
+	if setting.SMTPUsername != "" {
+		if err := client.Auth(smtp.PlainAuth("", setting.SMTPUsername, string(setting.SMTPPassword), setting.SMTPHost)); err != nil {
+			return fmt.Errorf("authenticate SMTP client: %w", err)
+		}
+	}
+	if err := client.Mail(setting.SMTPFromEmail); err != nil {
+		return fmt.Errorf("set SMTP sender: %w", err)
+	}
+	if err := client.Rcpt(recipient); err != nil {
+		return fmt.Errorf("set SMTP recipient: %w", err)
+	}
+	writer, err := client.Data()
+	if err != nil {
+		return fmt.Errorf("open SMTP message: %w", err)
+	}
+	from := (&mail.Address{Name: setting.SMTPFromName, Address: setting.SMTPFromEmail}).String()
+	message := "From: " + from + "\r\n" +
+		"To: " + recipient + "\r\n" +
+		"Subject: Kite SMTP test email\r\n" +
+		"\r\n" +
+		"This is a test email from Kite.\r\n"
+	if _, err := writer.Write([]byte(message)); err != nil {
+		return fmt.Errorf("write SMTP message: %w", err)
+	}
+	if err := writer.Close(); err != nil {
+		return fmt.Errorf("send SMTP message: %w", err)
+	}
+	return nil
+}

--- a/pkg/settings/smtp_test.go
+++ b/pkg/settings/smtp_test.go
@@ -1,0 +1,251 @@
+package settings
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"net"
+	"net/mail"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/zxh326/kite/pkg/model"
+)
+
+type fakeSMTPServer struct {
+	listener   net.Listener
+	rejectAuth bool
+	rejectRcpt bool
+
+	mu       sync.Mutex
+	mailFrom string
+	rcptTo   string
+	message  string
+	done     chan struct{}
+}
+
+func newFakeSMTPServer(t *testing.T, rejectAuth, rejectRcpt bool) *fakeSMTPServer {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listening for fake SMTP server: %v", err)
+	}
+	server := &fakeSMTPServer{
+		listener:   listener,
+		rejectAuth: rejectAuth,
+		rejectRcpt: rejectRcpt,
+		done:       make(chan struct{}),
+	}
+	go server.serve()
+	t.Cleanup(func() {
+		_ = listener.Close()
+		<-server.done
+	})
+	return server
+}
+
+func (s *fakeSMTPServer) serve() {
+	defer close(s.done)
+	conn, err := s.listener.Accept()
+	if err != nil {
+		return
+	}
+	defer func() {
+		_ = conn.Close()
+	}()
+
+	reader := bufio.NewReader(conn)
+	writer := bufio.NewWriter(conn)
+	write := func(message string) {
+		_, _ = writer.WriteString(message)
+		_ = writer.Flush()
+	}
+	write("220 fake SMTP server\r\n")
+	for {
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			return
+		}
+		line = strings.TrimSpace(line)
+		switch {
+		case strings.HasPrefix(line, "EHLO "):
+			write("250-fake SMTP server\r\n250-AUTH PLAIN\r\n250 OK\r\n")
+		case strings.HasPrefix(line, "AUTH PLAIN "):
+			if s.rejectAuth {
+				write("535 authentication failed\r\n")
+			} else {
+				write("235 authentication succeeded\r\n")
+			}
+		case strings.HasPrefix(line, "MAIL FROM:"):
+			s.mu.Lock()
+			s.mailFrom = strings.Trim(strings.TrimPrefix(line, "MAIL FROM:"), "<>")
+			s.mu.Unlock()
+			write("250 sender accepted\r\n")
+		case strings.HasPrefix(line, "RCPT TO:"):
+			if s.rejectRcpt {
+				write("550 recipient rejected\r\n")
+				continue
+			}
+			s.mu.Lock()
+			s.rcptTo = strings.Trim(strings.TrimPrefix(line, "RCPT TO:"), "<>")
+			s.mu.Unlock()
+			write("250 recipient accepted\r\n")
+		case line == "DATA":
+			write("354 send message\r\n")
+			var message strings.Builder
+			for {
+				dataLine, err := reader.ReadString('\n')
+				if err != nil {
+					return
+				}
+				if dataLine == ".\r\n" {
+					break
+				}
+				message.WriteString(dataLine)
+			}
+			s.mu.Lock()
+			s.message = message.String()
+			s.mu.Unlock()
+			write("250 message accepted\r\n")
+		case line == "QUIT":
+			write("221 goodbye\r\n")
+			return
+		default:
+			write("500 unsupported command\r\n")
+		}
+	}
+}
+
+func (s *fakeSMTPServer) setting() *model.GeneralSetting {
+	_, port, err := net.SplitHostPort(s.listener.Addr().String())
+	if err != nil {
+		panic(err)
+	}
+	var smtpPort int
+	if _, err := fmt.Sscanf(port, "%d", &smtpPort); err != nil {
+		panic(err)
+	}
+	return &model.GeneralSetting{
+		SMTPEnabled:        true,
+		SMTPHost:           "127.0.0.1",
+		SMTPPort:           smtpPort,
+		SMTPFromEmail:      "sender@example.com",
+		SMTPFromName:       "Kite Sender",
+		SMTPEncryption:     "none",
+		SMTPTimeoutSeconds: 1,
+	}
+}
+
+func TestSendSMTPTestEmailPlainNoneDelivers(t *testing.T) {
+	server := newFakeSMTPServer(t, false, false)
+	setting := server.setting()
+
+	if err := sendSMTPTestEmail(context.Background(), setting, "recipient@example.com"); err != nil {
+		t.Fatalf("sending test email: %v", err)
+	}
+
+	server.mu.Lock()
+	mailFrom, rcptTo, message := server.mailFrom, server.rcptTo, server.message
+	server.mu.Unlock()
+	if mailFrom != "sender@example.com" {
+		t.Errorf("MAIL FROM = %q, want sender@example.com", mailFrom)
+	}
+	if rcptTo != "recipient@example.com" {
+		t.Errorf("RCPT TO = %q, want recipient@example.com", rcptTo)
+	}
+	parsed, err := mail.ReadMessage(strings.NewReader(message))
+	if err != nil {
+		t.Fatalf("parsing delivered message: %v", err)
+	}
+	from, err := mail.ParseAddress(parsed.Header.Get("From"))
+	if err != nil || from.Name != "Kite Sender" || from.Address != "sender@example.com" {
+		t.Errorf("From = %q, parsed as %#v, error = %v", parsed.Header.Get("From"), from, err)
+	}
+	if got := parsed.Header.Get("To"); got != "recipient@example.com" {
+		t.Errorf("To = %q", got)
+	}
+	if got := parsed.Header.Get("Subject"); got != "Kite SMTP test email" {
+		t.Errorf("Subject = %q", got)
+	}
+}
+
+func TestSendSMTPTestEmailFailsWhenStartTLSIsUnsupported(t *testing.T) {
+	server := newFakeSMTPServer(t, false, true)
+	setting := server.setting()
+	setting.SMTPEncryption = "starttls"
+
+	err := sendSMTPTestEmail(context.Background(), setting, "recipient@example.com")
+	if err == nil || !strings.Contains(err.Error(), "does not support STARTTLS") {
+		t.Fatalf("error = %v, want STARTTLS unsupported error", err)
+	}
+}
+
+func TestSendSMTPTestEmailRejectsAuthenticationOrRecipient(t *testing.T) {
+	tests := []struct {
+		name       string
+		rejectAuth bool
+		rejectRcpt bool
+		configure  func(*model.GeneralSetting)
+		want       string
+	}{
+		{
+			name:       "authentication",
+			rejectAuth: true,
+			configure: func(setting *model.GeneralSetting) {
+				setting.SMTPUsername = "username"
+				setting.SMTPPassword = model.SecretString("password")
+			},
+			want: "authenticate SMTP client",
+		},
+		{
+			name:       "recipient",
+			rejectRcpt: true,
+			configure:  func(*model.GeneralSetting) {},
+			want:       "set SMTP recipient",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := newFakeSMTPServer(t, tt.rejectAuth, tt.rejectRcpt)
+			setting := server.setting()
+			tt.configure(setting)
+
+			err := sendSMTPTestEmail(context.Background(), setting, "recipient@example.com")
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("error = %v, want %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestHandleUpdateGeneralSettingReplacesAndClearsSMTPPassword(t *testing.T) {
+	setupGeneralSettingTestDB(t, "")
+	if err := model.DB.Model(&model.GeneralSetting{}).Where("id = ?", 1).Update("smtp_password", model.SecretString("old-password")).Error; err != nil {
+		t.Fatalf("storing SMTP password: %v", err)
+	}
+	router := generalSettingTestRouter()
+
+	replaceResponse := performGeneralSettingRequest(t, router, "PUT", `{"smtpPassword":" new-password "}`)
+	if replaceResponse.Code != 200 || strings.Contains(replaceResponse.Body.String(), "new-password") {
+		t.Fatalf("replace response = %d: %s", replaceResponse.Code, replaceResponse.Body.String())
+	}
+	var stored model.GeneralSetting
+	if err := model.DB.First(&stored, 1).Error; err != nil {
+		t.Fatalf("loading replaced setting: %v", err)
+	}
+	if stored.SMTPPassword != model.SecretString("new-password") {
+		t.Fatalf("stored SMTP password = %q, want replaced value", stored.SMTPPassword)
+	}
+
+	clearResponse := performGeneralSettingRequest(t, router, "PUT", `{"smtpPassword":"ignored-password","smtpClearPassword":true}`)
+	if clearResponse.Code != 200 || strings.Contains(clearResponse.Body.String(), "ignored-password") {
+		t.Fatalf("clear response = %d: %s", clearResponse.Code, clearResponse.Body.String())
+	}
+	if err := model.DB.First(&stored, 1).Error; err != nil {
+		t.Fatalf("loading cleared setting: %v", err)
+	}
+	if stored.SMTPPassword != "" {
+		t.Fatalf("stored SMTP password = %q, want empty", stored.SMTPPassword)
+	}
+}

--- a/pkg/statefultoken/statefultoken.go
+++ b/pkg/statefultoken/statefultoken.go
@@ -1,0 +1,155 @@
+package statefultoken
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+var (
+	ErrInvalidToken = errors.New("invalid stateful token")
+	ErrExpired      = errors.New("stateful token expired")
+)
+
+type Record struct {
+	ID           uint
+	JTIHash      string
+	SubjectID    string
+	Name         string
+	ExpiresAt    time.Time
+	SigningKeyID string
+}
+
+type Store interface {
+	Create(context.Context, Record) (Record, error)
+	FindByJTIHash(context.Context, string) (Record, error)
+	Delete(context.Context, uint, *string) (bool, error)
+	Touch(context.Context, uint) error
+}
+
+type Config struct {
+	Issuer  string
+	Purpose string
+	Secret  []byte
+	KeyID   string
+}
+
+type IssueRequest struct {
+	SubjectID string
+	Name      string
+	ExpiresAt time.Time
+}
+
+type IssuedToken struct {
+	Encoded string
+	Record  Record
+}
+
+type Principal struct {
+	TokenID   uint
+	SubjectID string
+	ExpiresAt time.Time
+	KeyID     string
+}
+
+type claims struct {
+	Purpose string `json:"token_use"`
+	jwt.RegisteredClaims
+}
+
+type Service struct {
+	config Config
+	store  Store
+	now    func() time.Time
+}
+
+func New(config Config, store Store) (*Service, error) {
+	if config.Issuer == "" || config.Purpose == "" || len(config.Secret) == 0 || config.KeyID == "" {
+		return nil, errors.New("stateful token configuration is incomplete")
+	}
+	if store == nil {
+		return nil, errors.New("stateful token store is required")
+	}
+	return &Service{config: config, store: store, now: func() time.Time { return time.Now().UTC() }}, nil
+}
+
+func HashJTI(jti string) string {
+	sum := sha256.Sum256([]byte(jti))
+	return hex.EncodeToString(sum[:])
+}
+
+func (s *Service) Issue(ctx context.Context, request IssueRequest) (IssuedToken, error) {
+	if request.SubjectID == "" || request.Name == "" || !request.ExpiresAt.After(s.now()) {
+		return IssuedToken{}, ErrInvalidToken
+	}
+	jti, err := randomJTI()
+	if err != nil {
+		return IssuedToken{}, err
+	}
+	now := s.now()
+	tokenClaims := claims{Purpose: s.config.Purpose, RegisteredClaims: jwt.RegisteredClaims{
+		Issuer: s.config.Issuer, Subject: request.SubjectID, ID: jti,
+		IssuedAt: jwt.NewNumericDate(now), NotBefore: jwt.NewNumericDate(now), ExpiresAt: jwt.NewNumericDate(request.ExpiresAt),
+	}}
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, tokenClaims)
+	token.Header["kid"] = s.config.KeyID
+	encoded, err := token.SignedString(s.config.Secret)
+	if err != nil {
+		return IssuedToken{}, err
+	}
+	record, err := s.store.Create(ctx, Record{
+		JTIHash: HashJTI(jti), SubjectID: request.SubjectID, Name: request.Name, ExpiresAt: request.ExpiresAt, SigningKeyID: s.config.KeyID,
+	})
+	if err != nil {
+		return IssuedToken{}, err
+	}
+	return IssuedToken{Encoded: encoded, Record: record}, nil
+}
+
+func (s *Service) Authenticate(ctx context.Context, encoded string) (Principal, error) {
+	parsedClaims := &claims{}
+	token, err := jwt.ParseWithClaims(encoded, parsedClaims, func(token *jwt.Token) (any, error) {
+		if token.Method != jwt.SigningMethodHS256 || token.Header["kid"] != s.config.KeyID {
+			return nil, ErrInvalidToken
+		}
+		return s.config.Secret, nil
+	}, jwt.WithIssuer(s.config.Issuer), jwt.WithLeeway(0))
+	if err != nil || !token.Valid || parsedClaims.Purpose != s.config.Purpose || parsedClaims.Subject == "" || parsedClaims.ID == "" || parsedClaims.IssuedAt == nil || parsedClaims.NotBefore == nil || parsedClaims.ExpiresAt == nil {
+		return Principal{}, ErrInvalidToken
+	}
+	record, err := s.store.FindByJTIHash(ctx, HashJTI(parsedClaims.ID))
+	if err != nil || record.SubjectID != parsedClaims.Subject || record.SigningKeyID != s.config.KeyID || record.ExpiresAt.Unix() != parsedClaims.ExpiresAt.Unix() {
+		return Principal{}, ErrInvalidToken
+	}
+	if !s.now().Before(record.ExpiresAt) {
+		return Principal{}, ErrExpired
+	}
+	return Principal{TokenID: record.ID, SubjectID: record.SubjectID, ExpiresAt: record.ExpiresAt, KeyID: record.SigningKeyID}, nil
+}
+
+func (s *Service) Touch(ctx context.Context, tokenID uint) error {
+	return s.store.Touch(ctx, tokenID)
+}
+
+func (s *Service) Delete(ctx context.Context, tokenID uint, subjectID *string) (bool, error) {
+	return s.store.Delete(ctx, tokenID, subjectID)
+}
+
+func (s *Service) Discard(ctx context.Context, tokenID uint) error {
+	_, err := s.store.Delete(ctx, tokenID, nil)
+	return err
+}
+
+func randomJTI() (string, error) {
+	value := make([]byte, 32)
+	if _, err := rand.Read(value); err != nil {
+		return "", fmt.Errorf("generate token ID: %w", err)
+	}
+	return hex.EncodeToString(value), nil
+}

--- a/pkg/statefultoken/statefultoken_test.go
+++ b/pkg/statefultoken/statefultoken_test.go
@@ -1,0 +1,77 @@
+package statefultoken
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+type memoryStore struct {
+	record *Record
+}
+
+func (s *memoryStore) Create(_ context.Context, record Record) (Record, error) {
+	record.ID = 1
+	s.record = &record
+	return record, nil
+}
+
+func (s *memoryStore) FindByJTIHash(_ context.Context, hash string) (Record, error) {
+	if s.record == nil || s.record.JTIHash != hash {
+		return Record{}, errors.New("not found")
+	}
+	return *s.record, nil
+}
+
+func (s *memoryStore) Delete(_ context.Context, tokenID uint, subjectID *string) (bool, error) {
+	if s.record == nil || s.record.ID != tokenID || (subjectID != nil && s.record.SubjectID != *subjectID) {
+		return false, nil
+	}
+	s.record = nil
+	return true, nil
+}
+
+func (*memoryStore) Touch(context.Context, uint) error { return nil }
+
+func TestIssueAndAuthenticateChecksState(t *testing.T) {
+	store := &memoryStore{}
+	service, err := New(Config{Issuer: "kite", Purpose: "kubeconfig", Secret: []byte("secret"), KeyID: "primary"}, store)
+	if err != nil {
+		t.Fatal(err)
+	}
+	issued, err := service.Issue(context.Background(), IssueRequest{SubjectID: "42", Name: "test", ExpiresAt: time.Now().UTC().Add(time.Hour)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	principal, err := service.Authenticate(context.Background(), issued.Encoded)
+	if err != nil || principal.SubjectID != "42" || principal.TokenID != issued.Record.ID {
+		t.Fatalf("principal=%#v err=%v", principal, err)
+	}
+	deleted, err := service.Delete(context.Background(), issued.Record.ID, nil)
+	if err != nil || !deleted {
+		t.Fatalf("delete token deleted=%v err=%v", deleted, err)
+	}
+	if _, err := service.Authenticate(context.Background(), issued.Encoded); !errors.Is(err, ErrInvalidToken) {
+		t.Fatalf("authenticate deleted token error = %v", err)
+	}
+}
+
+func TestAuthenticateRejectsWrongPurpose(t *testing.T) {
+	store := &memoryStore{}
+	issuer, err := New(Config{Issuer: "kite", Purpose: "other", Secret: []byte("secret"), KeyID: "primary"}, store)
+	if err != nil {
+		t.Fatal(err)
+	}
+	issued, err := issuer.Issue(context.Background(), IssueRequest{SubjectID: "42", Name: "test", ExpiresAt: time.Now().UTC().Add(time.Hour)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	consumer, err := New(Config{Issuer: "kite", Purpose: "kubeconfig", Secret: []byte("secret"), KeyID: "primary"}, store)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := consumer.Authenticate(context.Background(), issued.Encoded); !errors.Is(err, ErrInvalidToken) {
+		t.Fatalf("authenticate wrong-purpose token error = %v", err)
+	}
+}

--- a/routes.go
+++ b/routes.go
@@ -79,6 +79,8 @@ func registerUserRoutes(r *gin.RouterGroup, authHandler *auth.AuthHandler) {
 	userGroup.POST("/me/passkeys/begin", authHandler.RequireAuth(), users.BeginCurrentUserPasskeyRegistration)
 	userGroup.POST("/me/passkeys/finish", authHandler.RequireAuth(), users.FinishCurrentUserPasskeyRegistration)
 	userGroup.DELETE("/me/passkeys/:id", authHandler.RequireAuth(), users.DeleteCurrentUserPasskey)
+	userGroup.GET("/me/kubeconfig-tokens", authHandler.RequireAuth(), cluster.ListCurrentUserKubeconfigTokens)
+	userGroup.DELETE("/me/kubeconfig-tokens/:id", authHandler.RequireAuth(), cluster.DeleteCurrentUserKubeconfigToken)
 	userGroup.POST("/sidebar_preference", authHandler.RequireAuth(), users.UpdateSidebarPreference)
 }
 
@@ -129,6 +131,8 @@ func registerAdminRoutes(r *gin.RouterGroup, authHandler *auth.AuthHandler, cm *
 	apiKeyAPI.GET("/", apikeys.ListAPIKeys)
 	apiKeyAPI.POST("/", apikeys.CreateAPIKey)
 	apiKeyAPI.DELETE("/:id", apikeys.DeleteAPIKey)
+	adminAPI.GET("/kubeconfig-tokens", cluster.ListAllKubeconfigTokens)
+	adminAPI.DELETE("/kubeconfig-tokens/:id", cluster.DeleteAnyKubeconfigToken)
 
 	generalSettingAPI := adminAPI.Group("/general-setting")
 	generalSettingAPI.GET("/", settings.HandleGetGeneralSetting)
@@ -144,6 +148,8 @@ func registerAdminRoutes(r *gin.RouterGroup, authHandler *auth.AuthHandler, cm *
 
 func registerProtectedRoutes(r *gin.RouterGroup, authHandler *auth.AuthHandler, cm *cluster.ClusterManager, helmChartsHandler *helm.HelmChartHandler) {
 	api := r.Group("/api/v1")
+	api.POST("/kubeconfig", authHandler.RequireAuth(), cm.DownloadKubeconfig)
+	api.Any("/clusters/:clusterUUID/k8s-proxy/*path", cm.HandleK8sProxy)
 	api.GET("/clusters", authHandler.RequireAuth(), cm.GetClusters)
 	defaultAPI := api.Group("")
 	defaultAPI.Use(authHandler.RequireAuth(), middleware.ClusterMiddleware(cm))

--- a/routes.go
+++ b/routes.go
@@ -137,6 +137,7 @@ func registerAdminRoutes(r *gin.RouterGroup, authHandler *auth.AuthHandler, cm *
 	generalSettingAPI := adminAPI.Group("/general-setting")
 	generalSettingAPI.GET("/", settings.HandleGetGeneralSetting)
 	generalSettingAPI.PUT("/", settings.HandleUpdateGeneralSetting)
+	generalSettingAPI.POST("/smtp/test", settings.HandleTestSMTP)
 
 	templateAPI := adminAPI.Group("/templates")
 	templateAPI.POST("/", templates.CreateTemplate)

--- a/ui/src/components/account-settings-dialog.tsx
+++ b/ui/src/components/account-settings-dialog.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState, type FormEvent } from 'react'
 import { useAuth } from '@/contexts/auth-context'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { Fingerprint, KeyRound, ShieldCheck, Trash2 } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
@@ -7,6 +8,7 @@ import { toast } from 'sonner'
 import {
   beginCurrentUserPasskeyRegistration,
   changeCurrentUserPassword,
+  deleteCurrentUserKubeconfigToken,
   deleteCurrentUserPasskey,
   disableCurrentUserMFA,
   enableCurrentUserMFA,
@@ -14,6 +16,7 @@ import {
   listCurrentUserPasskeys,
   setupCurrentUserMFA,
   updateCurrentUser,
+  useCurrentUserKubeconfigTokens,
   type MFASetupResponse,
   type PasskeyCredential,
 } from '@/lib/api'
@@ -31,8 +34,10 @@ import {
 } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
+import { Separator } from '@/components/ui/separator'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { Textarea } from '@/components/ui/textarea'
+import { KubeconfigTokenList } from '@/components/kubeconfig-token-list'
 
 interface AccountSettingsDialogProps {
   open: boolean
@@ -45,6 +50,21 @@ export function AccountSettingsDialog({
 }: AccountSettingsDialogProps) {
   const { t } = useTranslation()
   const { user, checkAuth, mfaEnabled, passkeyLoginEnabled } = useAuth()
+  const queryClient = useQueryClient()
+  const { data: kubeconfigTokens = [], isLoading: kubeconfigTokensLoading } =
+    useCurrentUserKubeconfigTokens(open)
+  const deleteKubeconfigMutation = useMutation({
+    mutationFn: deleteCurrentUserKubeconfigToken,
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ['current-user-kubeconfig-tokens'],
+      })
+      toast.success(
+        t('kubeconfigTokens.deleteSuccess', 'Kubeconfig token deleted')
+      )
+    },
+    onError: (error) => toast.error(error.message),
+  })
   const [nickname, setNickname] = useState(user?.name || '')
   const [currentPassword, setCurrentPassword] = useState('')
   const [newPassword, setNewPassword] = useState('')
@@ -121,7 +141,6 @@ export function AccountSettingsDialog({
   if (!user) return null
 
   const isPasswordUser = !user.provider || user.provider === 'password'
-  if (!isPasswordUser) return null
 
   const mfaControlsDisabled = !mfaEnabled || savingMFA
   const passkeyControlsDisabled = !passkeyLoginEnabled || savingPasskey
@@ -345,16 +364,22 @@ export function AccountSettingsDialog({
           </DialogHeader>
 
           <Tabs defaultValue="profile" className="gap-4">
-            <TabsList className="grid w-full grid-cols-3">
+            <TabsList
+              className={`grid w-full ${isPasswordUser ? 'grid-cols-3' : 'grid-cols-1'}`}
+            >
               <TabsTrigger value="profile">
                 {t('accountSettings.tabs.profile', 'Profile')}
               </TabsTrigger>
-              <TabsTrigger value="password">
-                {t('accountSettings.tabs.password', 'Password')}
-              </TabsTrigger>
-              <TabsTrigger value="security">
-                {t('accountSettings.tabs.security', 'Security')}
-              </TabsTrigger>
+              {isPasswordUser && (
+                <TabsTrigger value="password">
+                  {t('accountSettings.tabs.password', 'Password')}
+                </TabsTrigger>
+              )}
+              {isPasswordUser && (
+                <TabsTrigger value="security">
+                  {t('accountSettings.tabs.security', 'Security')}
+                </TabsTrigger>
+              )}
             </TabsList>
 
             <TabsContent value="profile">
@@ -587,7 +612,8 @@ export function AccountSettingsDialog({
                   )}
                 </div>
 
-                <div className="space-y-4 border-t pt-4">
+                <div className="space-y-4">
+                  <Separator />
                   <div className="flex items-center gap-2 text-sm font-medium">
                     <Fingerprint className="h-4 w-4" />
                     <span>
@@ -687,6 +713,32 @@ export function AccountSettingsDialog({
                       ))
                     )}
                   </div>
+                </div>
+
+                <div className="space-y-4">
+                  <Separator />
+                  <div className="flex items-center gap-2 text-sm font-medium">
+                    <KeyRound className="h-4 w-4" />
+                    <span>
+                      {t(
+                        'accountSettings.tabs.kubeconfigTokens',
+                        'Kubeconfig Tokens'
+                      )}
+                    </span>
+                  </div>
+                  {kubeconfigTokensLoading ? (
+                    <p className="text-sm text-muted-foreground">
+                      {t('common.messages.loading', 'Loading...')}
+                    </p>
+                  ) : (
+                    <KubeconfigTokenList
+                      tokens={kubeconfigTokens}
+                      onDelete={(token) =>
+                        deleteKubeconfigMutation.mutate(token.id)
+                      }
+                      deletingId={deleteKubeconfigMutation.variables}
+                    />
+                  )}
                 </div>
               </div>
             </TabsContent>

--- a/ui/src/components/kubeconfig-download-dialog.test.tsx
+++ b/ui/src/components/kubeconfig-download-dialog.test.tsx
@@ -1,0 +1,161 @@
+/// <reference types="@testing-library/jest-dom" />
+
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+
+import { KubeconfigDownloadDialog } from './kubeconfig-download-dialog'
+
+const { useCluster } = vi.hoisted(() => ({
+  useCluster: vi.fn(),
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (
+      _key: string,
+      defaultValue?: string,
+      values?: Record<string, string | number>
+    ) =>
+      Object.entries(values ?? {}).reduce(
+        (text, [key, value]) => text.replace(`{{${key}}}`, String(value)),
+        defaultValue ?? _key
+      ),
+  }),
+}))
+
+vi.mock('@/lib/api', () => ({
+  downloadKubeconfig: vi.fn(),
+}))
+
+vi.mock('@/hooks/use-cluster', () => ({ useCluster }))
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
+
+const clusters = [
+  { uuid: 'current-id', name: 'current', enabled: true },
+  { uuid: 'other-id', name: 'other', enabled: true },
+  { uuid: 'disabled-id', name: 'disabled', enabled: false },
+]
+
+function renderDialog() {
+  const onOpenChange = vi.fn()
+  render(<KubeconfigDownloadDialog open onOpenChange={onOpenChange} />)
+  return onOpenChange
+}
+
+function mockClusters() {
+  useCluster.mockReturnValue({
+    clusters,
+    currentCluster: 'current',
+    refreshClusters: vi.fn(),
+  })
+}
+
+describe('KubeconfigDownloadDialog', () => {
+  it('refreshes clusters when opened', () => {
+    const refreshClusters = vi.fn()
+    useCluster.mockReturnValue({
+      clusters,
+      currentCluster: 'current',
+      refreshClusters,
+    })
+
+    renderDialog()
+
+    expect(refreshClusters).toHaveBeenCalledOnce()
+  })
+
+  it('defaults to the current cluster and supports selecting all clusters', async () => {
+    mockClusters()
+    renderDialog()
+    const user = userEvent.setup()
+
+    expect(screen.getByText('1 selected / 2 total')).toBeInTheDocument()
+    expect(screen.getByRole('checkbox', { name: /current/i })).toBeChecked()
+    expect(screen.getByRole('checkbox', { name: /^other$/i })).not.toBeChecked()
+    expect(screen.queryByText('disabled')).not.toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Select all' }))
+
+    expect(screen.getByText('2 selected / 2 total')).toBeInTheDocument()
+    expect(screen.getByRole('checkbox', { name: /current/i })).toBeChecked()
+    expect(screen.getByRole('checkbox', { name: /^other$/i })).toBeChecked()
+    expect(
+      screen.getByRole('button', { name: 'Deselect all' })
+    ).toBeInTheDocument()
+  })
+
+  it('selects only matching clusters while preserving hidden selections', async () => {
+    mockClusters()
+    renderDialog()
+    const user = userEvent.setup()
+    const search = screen.getByPlaceholderText('Search clusters')
+
+    await user.type(search, 'other')
+
+    expect(
+      screen.getByRole('button', { name: 'Select matching' })
+    ).toBeInTheDocument()
+    await user.click(screen.getByRole('button', { name: 'Select matching' }))
+    await user.clear(search)
+
+    expect(screen.getByRole('checkbox', { name: /current/i })).toBeChecked()
+    expect(screen.getByRole('checkbox', { name: /^other$/i })).toBeChecked()
+  })
+
+  it('deselects only matching clusters while preserving hidden selections', async () => {
+    mockClusters()
+    renderDialog()
+    const user = userEvent.setup()
+    const search = screen.getByPlaceholderText('Search clusters')
+
+    await user.click(screen.getByRole('button', { name: 'Select all' }))
+    await user.type(search, 'other')
+
+    expect(
+      screen.getByRole('button', { name: 'Deselect matching' })
+    ).toBeInTheDocument()
+    await user.click(screen.getByRole('button', { name: 'Deselect matching' }))
+    await user.clear(search)
+
+    expect(screen.getByRole('checkbox', { name: /current/i })).toBeChecked()
+    expect(screen.getByRole('checkbox', { name: /^other$/i })).not.toBeChecked()
+  })
+
+  it('disables matching selection and shows an empty state when no clusters match', async () => {
+    mockClusters()
+    renderDialog()
+    const user = userEvent.setup()
+
+    await user.type(screen.getByPlaceholderText('Search clusters'), 'missing')
+
+    expect(
+      screen.getByRole('button', { name: 'Select matching' })
+    ).toBeDisabled()
+    expect(screen.getByText('No matching clusters found.')).toBeInTheDocument()
+  })
+
+  it('renders concise expiration presets', () => {
+    mockClusters()
+    renderDialog()
+
+    for (const preset of ['1d', '7d', '30d', '1year']) {
+      expect(screen.getByRole('button', { name: preset })).toBeInTheDocument()
+    }
+  })
+
+  it('uses selectors for a custom expiration time', async () => {
+    mockClusters()
+    renderDialog()
+    const user = userEvent.setup()
+
+    await user.click(screen.getByRole('button', { name: 'Custom' }))
+
+    for (const field of ['year', 'month', 'day', 'hour', 'minute', 'second']) {
+      expect(screen.getByRole('combobox', { name: field })).toBeInTheDocument()
+    }
+    expect(
+      screen.queryByRole('textbox', { name: 'second' })
+    ).not.toBeInTheDocument()
+  })
+})

--- a/ui/src/components/kubeconfig-download-dialog.tsx
+++ b/ui/src/components/kubeconfig-download-dialog.tsx
@@ -1,0 +1,459 @@
+import { useEffect, useMemo, useState } from 'react'
+import { Download } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import { toast } from 'sonner'
+
+import { downloadKubeconfig } from '@/lib/api'
+import { useCluster } from '@/hooks/use-cluster'
+import { Button } from '@/components/ui/button'
+import { Checkbox } from '@/components/ui/checkbox'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+
+const presets = [
+  { value: 86400, label: '1d' },
+  { value: 604800, label: '7d' },
+  { value: 2592000, label: '30d' },
+  { value: 31536000, label: '1year' },
+]
+const minTTL = 3600
+const maxTTL = 157680000
+const pad = (value: number) => String(value).padStart(2, '0')
+const dateParts = (date: Date) => ({
+  year: String(date.getFullYear()),
+  month: pad(date.getMonth() + 1),
+  day: pad(date.getDate()),
+  hour: pad(date.getHours()),
+  minute: pad(date.getMinutes()),
+  second: pad(date.getSeconds()),
+})
+type Expiration = ReturnType<typeof dateParts>
+const toExpirationDate = (expiration: Expiration) =>
+  new Date(
+    Number(expiration.year),
+    Number(expiration.month) - 1,
+    Number(expiration.day),
+    Number(expiration.hour),
+    Number(expiration.minute),
+    Number(expiration.second)
+  )
+const normalizeExpiration = (expiration: Expiration) => {
+  const lastDay = new Date(
+    Number(expiration.year),
+    Number(expiration.month),
+    0
+  ).getDate()
+  return Number(expiration.day) > lastDay
+    ? { ...expiration, day: pad(lastDay) }
+    : expiration
+}
+
+interface KubeconfigDownloadDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+export function KubeconfigDownloadDialog({
+  open,
+  onOpenChange,
+}: KubeconfigDownloadDialogProps) {
+  const { t } = useTranslation()
+  const { clusters, currentCluster, refreshClusters } = useCluster()
+  const [selected, setSelected] = useState<string[]>([])
+  const [clusterSearch, setClusterSearch] = useState('')
+  const [ttl, setTTL] = useState(2592000)
+  const [custom, setCustom] = useState(false)
+  const [expiration, setExpiration] = useState(() =>
+    dateParts(new Date(Date.now() + ttl * 1000))
+  )
+  const [now, setNow] = useState(Date.now())
+  const [downloading, setDownloading] = useState(false)
+
+  const downloadableClusters = useMemo(
+    () => clusters.filter((cluster) => cluster.enabled && cluster.uuid),
+    [clusters]
+  )
+  const filteredClusters = useMemo(
+    () =>
+      downloadableClusters.filter((cluster) =>
+        cluster.name.toLowerCase().includes(clusterSearch.trim().toLowerCase())
+      ),
+    [clusterSearch, downloadableClusters]
+  )
+  const hasClusterSearch = clusterSearch.trim() !== ''
+  const actionClusters = hasClusterSearch
+    ? filteredClusters
+    : downloadableClusters
+  const actionClusterUUIDs = actionClusters.map((cluster) => cluster.uuid)
+  const allActionClustersSelected =
+    actionClusterUUIDs.length > 0 &&
+    actionClusterUUIDs.every((uuid) => selected.includes(uuid))
+
+  useEffect(() => {
+    if (!open) return
+    void refreshClusters()
+  }, [open, refreshClusters])
+
+  useEffect(() => {
+    if (!open) return
+    setNow(Date.now())
+    const interval = window.setInterval(() => setNow(Date.now()), 1000)
+    const current = downloadableClusters.find(
+      (cluster) => cluster.name === currentCluster
+    )
+    setSelected(current ? [current.uuid] : [])
+    setClusterSearch('')
+    setTTL(2592000)
+    setCustom(false)
+    setExpiration(dateParts(new Date(Date.now() + 2592000 * 1000)))
+    return () => window.clearInterval(interval)
+  }, [open, currentCluster, downloadableClusters])
+
+  const expirationDate = useMemo(
+    () => toExpirationDate(expiration),
+    [expiration]
+  )
+  const customTTL = Math.ceil((expirationDate.getTime() - now) / 1000)
+  const clampExpiration = (candidate: Expiration) => {
+    const normalized = normalizeExpiration(candidate)
+    const timestamp = toExpirationDate(normalized).getTime()
+    const minimum = now + minTTL * 1000
+    const maximum = now + maxTTL * 1000
+    return dateParts(new Date(Math.min(Math.max(timestamp, minimum), maximum)))
+  }
+  const effectiveTTL = custom ? customTTL : ttl
+  const ttlError =
+    custom && (customTTL < minTTL || customTTL > maxTTL)
+      ? t(
+          'kubeconfigDownload.ttlError',
+          'Select an expiration time between 1 hour and 5 years from now.'
+        )
+      : ''
+
+  const toggleCluster = (uuid: string) => {
+    setSelected((items) =>
+      items.includes(uuid)
+        ? items.filter((item) => item !== uuid)
+        : [...items, uuid]
+    )
+  }
+
+  const handleDownload = async () => {
+    const downloadTTL = custom
+      ? Math.ceil((toExpirationDate(expiration).getTime() - Date.now()) / 1000)
+      : ttl
+    if (downloadTTL < minTTL || downloadTTL > maxTTL || selected.length === 0) {
+      return
+    }
+    setDownloading(true)
+    try {
+      const currentUUID = downloadableClusters.find(
+        (cluster) => cluster.name === currentCluster
+      )?.uuid
+      const clusterUUIDs = currentUUID
+        ? [
+            ...selected.filter((uuid) => uuid === currentUUID),
+            ...selected.filter((uuid) => uuid !== currentUUID),
+          ]
+        : selected
+      const blob = await downloadKubeconfig({
+        clusterUUIDs,
+        ttlSeconds: downloadTTL,
+      })
+      const url = URL.createObjectURL(blob)
+      const anchor = document.createElement('a')
+      anchor.href = url
+      anchor.download = 'kite-kubeconfig.yaml'
+      anchor.click()
+      URL.revokeObjectURL(url)
+      toast.success(t('kubeconfigDownload.success', 'Kubeconfig downloaded'))
+      onOpenChange(false)
+    } catch (error) {
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : t('kubeconfigDownload.error', 'Failed to download kubeconfig')
+      )
+    } finally {
+      setDownloading(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>
+            {t('kubeconfigDownload.title', 'Download Kubeconfig')}
+          </DialogTitle>
+          <DialogDescription>
+            {t(
+              'kubeconfigDownload.description',
+              'Choose accessible clusters and an expiration time.'
+            )}
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-5">
+          <div className="space-y-2">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-2">
+                <Label>{t('kubeconfigDownload.clusters', 'Clusters')}</Label>
+                <span className="text-xs text-muted-foreground">
+                  {t(
+                    'kubeconfigDownload.selectedSummary',
+                    '{{selected}} selected / {{total}} total',
+                    {
+                      selected: selected.length,
+                      total: downloadableClusters.length,
+                    }
+                  )}
+                </span>
+              </div>
+              <Button
+                type="button"
+                variant="link"
+                size="sm"
+                disabled={actionClusters.length === 0}
+                onClick={() =>
+                  setSelected((items) =>
+                    allActionClustersSelected
+                      ? items.filter(
+                          (uuid) => !actionClusterUUIDs.includes(uuid)
+                        )
+                      : [
+                          ...items,
+                          ...actionClusterUUIDs.filter(
+                            (uuid) => !items.includes(uuid)
+                          ),
+                        ]
+                  )
+                }
+              >
+                {allActionClustersSelected
+                  ? t(
+                      hasClusterSearch
+                        ? 'kubeconfigDownload.deselectMatching'
+                        : 'kubeconfigDownload.deselectAll',
+                      hasClusterSearch ? 'Deselect matching' : 'Deselect all'
+                    )
+                  : t(
+                      hasClusterSearch
+                        ? 'kubeconfigDownload.selectMatching'
+                        : 'kubeconfigDownload.selectAll',
+                      hasClusterSearch ? 'Select matching' : 'Select all'
+                    )}
+              </Button>
+            </div>
+            <Input
+              value={clusterSearch}
+              onChange={(event) => setClusterSearch(event.target.value)}
+              placeholder={t(
+                'kubeconfigDownload.searchClusters',
+                'Search clusters'
+              )}
+            />
+            <div className="max-h-44 space-y-2 overflow-y-auto rounded-md border p-3">
+              {filteredClusters.map((cluster) => (
+                <label
+                  key={cluster.uuid}
+                  className="flex cursor-pointer items-center gap-2 text-sm"
+                >
+                  <Checkbox
+                    checked={selected.includes(cluster.uuid)}
+                    onCheckedChange={() => toggleCluster(cluster.uuid)}
+                  />
+                  <span>{cluster.name}</span>
+                  {cluster.name === currentCluster && (
+                    <span className="text-xs text-muted-foreground">
+                      ({t('common.fields.current', 'Current')})
+                    </span>
+                  )}
+                </label>
+              ))}
+              {filteredClusters.length === 0 && (
+                <p className="text-sm text-muted-foreground">
+                  {t(
+                    'kubeconfigDownload.noClustersFound',
+                    'No matching clusters found.'
+                  )}
+                </p>
+              )}
+            </div>
+          </div>
+          <div className="space-y-2">
+            <Label>{t('kubeconfigDownload.expiration', 'Expiration')}</Label>
+            <div className="flex flex-wrap gap-2">
+              {presets.map((preset) => (
+                <Button
+                  key={preset.value}
+                  type="button"
+                  data-testid={`kubeconfig-ttl-${preset.value}`}
+                  size="sm"
+                  variant={
+                    !custom && ttl === preset.value ? 'default' : 'outline'
+                  }
+                  onClick={() => {
+                    setCustom(false)
+                    setTTL(preset.value)
+                  }}
+                >
+                  {t(
+                    `kubeconfigDownload.presets.${preset.label}`,
+                    preset.label
+                  )}
+                </Button>
+              ))}
+              <Button
+                type="button"
+                size="sm"
+                variant={custom ? 'default' : 'outline'}
+                onClick={() => {
+                  setCustom(true)
+                  setExpiration(dateParts(new Date(Date.now() + ttl * 1000)))
+                }}
+              >
+                {t('kubeconfigDownload.custom', 'Custom')}
+              </Button>
+            </div>
+            {custom && (
+              <div className="grid grid-cols-2 gap-2 sm:grid-cols-[minmax(5.5rem,1fr)_repeat(5,minmax(0,1fr))]">
+                {[
+                  [
+                    'year',
+                    expiration.year,
+                    Array.from({ length: 6 }, (_, index) =>
+                      String(new Date().getFullYear() + index)
+                    ),
+                  ],
+                  [
+                    'month',
+                    expiration.month,
+                    Array.from({ length: 12 }, (_, index) => pad(index + 1)),
+                  ],
+                  [
+                    'day',
+                    expiration.day,
+                    Array.from(
+                      {
+                        length: new Date(
+                          Number(expiration.year),
+                          Number(expiration.month),
+                          0
+                        ).getDate(),
+                      },
+                      (_, index) => pad(index + 1)
+                    ),
+                  ],
+                  [
+                    'hour',
+                    expiration.hour,
+                    Array.from({ length: 24 }, (_, index) => pad(index)),
+                  ],
+                  [
+                    'minute',
+                    expiration.minute,
+                    Array.from({ length: 60 }, (_, index) => pad(index)),
+                  ],
+                  [
+                    'second',
+                    expiration.second,
+                    Array.from({ length: 60 }, (_, index) => pad(index)),
+                  ],
+                ].map(([name, value, options]) => (
+                  <div key={name as string} className="space-y-1">
+                    <Label htmlFor={`kubeconfig-${name}`} className="text-xs">
+                      {t(`kubeconfigDownload.${name}`, name as string)}
+                    </Label>
+                    <Select
+                      value={value as string}
+                      onValueChange={(nextValue) =>
+                        setExpiration((current) => {
+                          const next: Expiration = {
+                            ...current,
+                            [name as keyof Expiration]: nextValue,
+                          }
+                          return clampExpiration(next)
+                        })
+                      }
+                    >
+                      <SelectTrigger
+                        id={`kubeconfig-${name}`}
+                        className={
+                          name === 'year'
+                            ? 'w-full min-w-[5.5rem] shrink-0'
+                            : 'w-full'
+                        }
+                      >
+                        <SelectValue
+                          className={
+                            name === 'year' ? 'whitespace-nowrap' : undefined
+                          }
+                        />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {(options as string[]).map((option) => (
+                          <SelectItem key={option} value={option}>
+                            {option}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                ))}
+              </div>
+            )}
+            {effectiveTTL !== null && (
+              <p className="text-xs text-muted-foreground">
+                {t('kubeconfigDownload.expiresAt', 'Expires {{date}}', {
+                  date: new Date(
+                    Date.now() + effectiveTTL * 1000
+                  ).toLocaleString(),
+                })}
+              </p>
+            )}
+            {ttlError && <p className="text-sm text-destructive">{ttlError}</p>}
+          </div>
+          <p className="border-t pt-3 text-xs text-muted-foreground">
+            {t(
+              'kubeconfigDownload.securityNotice',
+              'This file contains a sensitive Bearer token. Store it securely and set file permissions to 0600.'
+            )}
+          </p>
+        </div>
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+          >
+            {t('common.actions.cancel', 'Cancel')}
+          </Button>
+          <Button
+            disabled={downloading || selected.length === 0 || !!ttlError}
+            onClick={handleDownload}
+          >
+            <Download className="mr-2 h-4 w-4" />
+            {downloading
+              ? t('kubeconfigDownload.downloading', 'Downloading...')
+              : t('kubeconfigDownload.download', 'Download')}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/ui/src/components/kubeconfig-token-list.test.tsx
+++ b/ui/src/components/kubeconfig-token-list.test.tsx
@@ -1,0 +1,61 @@
+/// <reference types="@testing-library/jest-dom" />
+import { render, screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+
+import { KubeconfigTokenList } from './kubeconfig-token-list'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (_key: string, defaultValue?: string) => defaultValue ?? _key,
+  }),
+}))
+
+const now = new Date('2026-01-01T12:00:00.000Z')
+const tokens = [
+  {
+    id: 1,
+    createdAt: '2025-12-01T12:00:00.000Z',
+    expiresAt: '2026-02-01T12:00:00.000Z',
+    lastUsedAt: '2025-12-31T12:00:00.000Z',
+    signingKeyId: 'key-active',
+    token: 'secret-active-token',
+  },
+  {
+    id: 2,
+    createdAt: '2025-11-01T12:00:00.000Z',
+    expiresAt: '2025-12-01T12:00:00.000Z',
+    signingKeyId: 'key-expired',
+    token: 'secret-expired-token',
+  },
+]
+
+describe('KubeconfigTokenList', () => {
+  it('displays active and expired states without rendering sensitive token values', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(now)
+    render(<KubeconfigTokenList tokens={tokens} onDelete={vi.fn()} />)
+
+    expect(screen.getByText('Active')).toBeInTheDocument()
+    expect(screen.getByText('Expired')).toBeInTheDocument()
+    expect(screen.queryByText('Revoked')).not.toBeInTheDocument()
+    expect(screen.queryByText('secret-active-token')).not.toBeInTheDocument()
+    expect(screen.queryByText('secret-expired-token')).not.toBeInTheDocument()
+    expect(screen.queryByText('key-active')).not.toBeInTheDocument()
+    vi.useRealTimers()
+  })
+
+  it('confirms deleting both active and expired tokens', async () => {
+    const onDelete = vi.fn()
+    render(<KubeconfigTokenList tokens={tokens} onDelete={onDelete} />)
+    const user = userEvent.setup()
+
+    expect(screen.getAllByRole('button', { name: 'Delete' })).toHaveLength(2)
+    await user.click(screen.getAllByRole('button', { name: 'Delete' })[1])
+    expect(onDelete).not.toHaveBeenCalled()
+    await user.click(
+      within(screen.getByRole('dialog')).getByRole('button', { name: 'Delete' })
+    )
+    expect(onDelete).toHaveBeenCalledWith(tokens[1])
+  })
+})

--- a/ui/src/components/kubeconfig-token-list.tsx
+++ b/ui/src/components/kubeconfig-token-list.tsx
@@ -1,0 +1,161 @@
+import { useState } from 'react'
+import { Trash2 } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+
+import { KubeconfigToken } from '@/lib/api'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+
+interface KubeconfigTokenListProps {
+  tokens: KubeconfigToken[]
+  includeOwner?: boolean
+  onDelete: (token: KubeconfigToken) => void
+  deletingId?: number
+}
+
+export function KubeconfigTokenList({
+  tokens,
+  includeOwner = false,
+  onDelete,
+  deletingId,
+}: KubeconfigTokenListProps) {
+  const { t } = useTranslation()
+  const [tokenToDelete, setTokenToDelete] = useState<KubeconfigToken | null>(
+    null
+  )
+
+  if (tokens.length === 0) {
+    return (
+      <p className="py-6 text-center text-sm text-muted-foreground">
+        {t('kubeconfigTokens.empty', 'No kubeconfig tokens found.')}
+      </p>
+    )
+  }
+
+  return (
+    <>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            {includeOwner && (
+              <TableHead>{t('common.fields.owner', 'Owner')}</TableHead>
+            )}
+            <TableHead>{t('common.fields.createdAt', 'Created At')}</TableHead>
+            <TableHead>
+              {t('kubeconfigTokens.expiresAt', 'Expires At')}
+            </TableHead>
+            <TableHead>{t('common.fields.lastUsed', 'Last Used')}</TableHead>
+            <TableHead>{t('common.fields.status', 'Status')}</TableHead>
+            <TableHead>{t('common.fields.actions', 'Actions')}</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {tokens.map((token) => {
+            const expired = new Date(token.expiresAt) <= new Date()
+            return (
+              <TableRow key={token.id}>
+                {includeOwner && <TableCell>{token.owner || '-'}</TableCell>}
+                <TableCell>
+                  {new Date(token.createdAt).toLocaleString()}
+                </TableCell>
+                <TableCell>
+                  {new Date(token.expiresAt).toLocaleString()}
+                </TableCell>
+                <TableCell>
+                  {token.lastUsedAt
+                    ? new Date(token.lastUsedAt).toLocaleString()
+                    : t('common.messages.neverUsed', 'Never')}
+                </TableCell>
+                <TableCell>
+                  <Badge
+                    variant="outline"
+                    className={
+                      expired
+                        ? 'border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-300'
+                        : 'border-green-500/30 bg-green-500/10 text-green-700 dark:text-green-300'
+                    }
+                  >
+                    {expired
+                      ? t('kubeconfigTokens.expired', 'Expired')
+                      : t('kubeconfigTokens.active', 'Active')}
+                  </Badge>
+                </TableCell>
+                <TableCell>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    disabled={deletingId === token.id}
+                    aria-label={t('kubeconfigTokens.delete', 'Delete')}
+                    onClick={() => setTokenToDelete(token)}
+                  >
+                    <Trash2 className="h-4 w-4 text-destructive" />
+                  </Button>
+                </TableCell>
+              </TableRow>
+            )
+          })}
+        </TableBody>
+      </Table>
+      <Dialog
+        open={tokenToDelete !== null}
+        onOpenChange={(open) => {
+          if (!open) setTokenToDelete(null)
+        }}
+      >
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle>
+              {t(
+                'kubeconfigTokens.deleteConfirmTitle',
+                'Delete kubeconfig token?'
+              )}
+            </DialogTitle>
+            <DialogDescription>
+              {t(
+                'kubeconfigTokens.deleteConfirmDescription',
+                'This token will be deleted, become invalid immediately, and cannot be recovered.'
+              )}
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => setTokenToDelete(null)}
+              disabled={deletingId === tokenToDelete?.id}
+            >
+              {t('common.actions.cancel', 'Cancel')}
+            </Button>
+            <Button
+              type="button"
+              variant="destructive"
+              disabled={deletingId === tokenToDelete?.id}
+              onClick={() => {
+                if (tokenToDelete) onDelete(tokenToDelete)
+                setTokenToDelete(null)
+              }}
+            >
+              {t('kubeconfigTokens.delete', 'Delete')}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}

--- a/ui/src/components/settings/general-management.test.tsx
+++ b/ui/src/components/settings/general-management.test.tsx
@@ -1,0 +1,289 @@
+/// <reference types="@testing-library/jest-dom" />
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { GeneralManagement } from './general-management'
+
+const {
+  testSMTPSetting,
+  updateGeneralSetting,
+  useBootstrap,
+  useGeneralSetting,
+} = vi.hoisted(() => ({
+  testSMTPSetting: vi.fn(),
+  updateGeneralSetting: vi.fn(),
+  useBootstrap: vi.fn(),
+  useGeneralSetting: vi.fn(),
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (_key: string, defaultValue?: string) => defaultValue ?? _key,
+  }),
+}))
+
+vi.mock('@/lib/api', () => ({
+  testSMTPSetting,
+  updateGeneralSetting,
+  useBootstrap,
+  useGeneralSetting,
+}))
+
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
+
+const generalSetting = {
+  aiAgentEnabled: false,
+  aiProvider: 'openai' as const,
+  aiModel: 'gpt-4o-mini',
+  aiApiKey: '',
+  aiApiKeyConfigured: false,
+  aiBaseUrl: '',
+  aiMaxTokens: 16384,
+  smtpEnabled: false,
+  smtpHost: '',
+  smtpPort: 587,
+  smtpUsername: '',
+  smtpPasswordConfigured: false,
+  smtpFromEmail: '',
+  smtpFromName: '',
+  smtpEncryption: 'starttls' as const,
+  smtpSkipTLSVerify: false,
+  smtpTimeoutSeconds: 30,
+  kubectlEnabled: true,
+  kubectlImage: 'zzde/kubectl:latest',
+  nodeTerminalImage: 'busybox:latest',
+  clusterAgentImage: 'ghcr.io/kite-org/kite:latest',
+  enableAnalytics: true,
+  enableVersionCheck: true,
+  passwordLoginDisabled: false,
+  enableMFA: false,
+  enablePasskeyLogin: false,
+  loginPrompt: '',
+}
+
+function renderManagement(
+  setting = generalSetting,
+  managedSections: Record<string, boolean> = {}
+) {
+  useGeneralSetting.mockReturnValue({ data: setting, isLoading: false })
+  useBootstrap.mockReturnValue({ data: { managedSections } })
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  })
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <GeneralManagement />
+    </QueryClientProvider>
+  )
+}
+
+async function enableSMTP(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(screen.getByRole('switch', { name: 'Enable SMTP' }))
+}
+
+describe('GeneralManagement SMTP', () => {
+  beforeEach(() => {
+    testSMTPSetting.mockReset()
+    updateGeneralSetting.mockReset()
+  })
+
+  it('renders the SMTP card after AI Agent', () => {
+    renderManagement()
+
+    const labels = screen.getAllByText(/^(AI Agent|SMTP)$/)
+    expect(labels.map((label) => label.textContent)).toEqual([
+      'AI Agent',
+      'SMTP',
+    ])
+  })
+
+  it('shows the SMTP form after enabling SMTP', async () => {
+    renderManagement()
+    const user = userEvent.setup()
+
+    expect(screen.queryByLabelText('Host')).not.toBeInTheDocument()
+    await enableSMTP(user)
+
+    expect(screen.getByLabelText('Host')).toBeInTheDocument()
+    expect(screen.getByLabelText('From Email')).toBeInTheDocument()
+    expect(screen.getByLabelText('Test recipient')).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'Send test email' })
+    ).toBeInTheDocument()
+  })
+
+  it('hides the SMTP test controls while SMTP is disabled', () => {
+    renderManagement()
+
+    expect(screen.queryByLabelText('Test recipient')).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: 'Send test email' })
+    ).not.toBeInTheDocument()
+  })
+
+  it('shows the password retention hint when a password is already configured', () => {
+    renderManagement({
+      ...generalSetting,
+      smtpEnabled: true,
+      smtpPasswordConfigured: true,
+    })
+
+    expect(screen.getByLabelText('Password')).toHaveAttribute(
+      'placeholder',
+      'Leave empty to keep current password'
+    )
+  })
+
+  it('renders managed SMTP as read-only while allowing test email', async () => {
+    renderManagement(
+      {
+        ...generalSetting,
+        smtpEnabled: true,
+        smtpHost: 'smtp.example.com',
+        smtpFromEmail: 'sender@example.com',
+      },
+      { smtp: true }
+    )
+    const user = userEvent.setup()
+
+    expect(
+      screen.getByText(
+        'Managed by configuration file and cannot be modified here.'
+      )
+    ).toBeInTheDocument()
+    expect(screen.getByRole('switch', { name: 'Enable SMTP' })).toBeDisabled()
+    expect(screen.getByLabelText('Host')).toBeDisabled()
+    expect(screen.getByLabelText('Port')).toBeDisabled()
+    expect(screen.getByLabelText('Encryption')).toBeDisabled()
+    expect(screen.getByLabelText('Timeout (seconds)')).toBeDisabled()
+    expect(screen.getByLabelText('Username')).toBeDisabled()
+    expect(screen.getByLabelText('Password')).toBeDisabled()
+    expect(screen.getByLabelText('From Email')).toBeDisabled()
+    expect(screen.getByLabelText('From Name')).toBeDisabled()
+    expect(
+      screen.getByLabelText('Skip TLS certificate verification')
+    ).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Save' })).toBeEnabled()
+    expect(screen.getByLabelText('Test recipient')).toBeEnabled()
+    expect(
+      screen.getByRole('button', { name: 'Send test email' })
+    ).toBeEnabled()
+
+    await user.type(
+      screen.getByLabelText('Test recipient'),
+      'recipient@example.com'
+    )
+    await user.click(screen.getByRole('button', { name: 'Send test email' }))
+
+    await waitFor(() => {
+      expect(testSMTPSetting).toHaveBeenCalled()
+    })
+    expect(testSMTPSetting.mock.calls[0][0]).toEqual({
+      recipient: 'recipient@example.com',
+      smtpEnabled: true,
+      smtpHost: 'smtp.example.com',
+      smtpPort: 587,
+      smtpUsername: '',
+      smtpFromEmail: 'sender@example.com',
+      smtpFromName: '',
+      smtpEncryption: 'starttls',
+      smtpSkipTLSVerify: false,
+      smtpTimeoutSeconds: 30,
+    })
+  })
+
+  it('uses the single bottom Save button for SMTP and general settings', async () => {
+    updateGeneralSetting.mockResolvedValue(generalSetting)
+    renderManagement()
+    const user = userEvent.setup()
+
+    await enableSMTP(user)
+    await user.type(screen.getByLabelText('Host'), ' smtp.example.com ')
+    await user.type(screen.getByLabelText('Username'), ' mailer ')
+    await user.type(screen.getByLabelText('Password'), 'secret')
+    await user.type(screen.getByLabelText('From Email'), ' sender@example.com ')
+    await user.type(screen.getByLabelText('From Name'), ' Kite ')
+    expect(screen.getAllByRole('button', { name: 'Save' })).toHaveLength(1)
+    await user.click(screen.getByRole('button', { name: 'Save' }))
+
+    await waitFor(() => {
+      expect(updateGeneralSetting).toHaveBeenCalledOnce()
+    })
+    expect(updateGeneralSetting).toHaveBeenCalledWith({
+      aiAgentEnabled: false,
+      aiProvider: 'openai',
+      aiModel: 'gpt-4o-mini',
+      aiBaseUrl: '',
+      aiMaxTokens: 16384,
+      kubectlEnabled: true,
+      kubectlImage: 'zzde/kubectl:latest',
+      nodeTerminalImage: 'busybox:latest',
+      clusterAgentImage: 'ghcr.io/kite-org/kite:latest',
+      enableAnalytics: true,
+      enableVersionCheck: true,
+      loginPrompt: '',
+      smtpEnabled: true,
+      smtpHost: 'smtp.example.com',
+      smtpPort: 587,
+      smtpUsername: 'mailer',
+      smtpPassword: 'secret',
+      smtpFromEmail: 'sender@example.com',
+      smtpFromName: 'Kite',
+      smtpEncryption: 'starttls',
+      smtpSkipTLSVerify: false,
+      smtpTimeoutSeconds: 30,
+    })
+  })
+
+  it('does not include SMTP fields when SMTP is managed', async () => {
+    updateGeneralSetting.mockResolvedValue(generalSetting)
+    renderManagement({ ...generalSetting, smtpEnabled: true }, { smtp: true })
+    const user = userEvent.setup()
+
+    await user.click(screen.getByRole('button', { name: 'Save' }))
+
+    await waitFor(() => expect(updateGeneralSetting).toHaveBeenCalledOnce())
+    expect(updateGeneralSetting.mock.calls[0][0]).not.toHaveProperty(
+      'smtpEnabled'
+    )
+    expect(updateGeneralSetting.mock.calls[0][0]).not.toHaveProperty('smtpHost')
+  })
+
+  it('sends the unsaved SMTP form through testSMTPSetting without updating settings', async () => {
+    testSMTPSetting.mockResolvedValue({ message: 'sent' })
+    renderManagement()
+    const user = userEvent.setup()
+
+    await enableSMTP(user)
+    await user.type(screen.getByLabelText('Host'), ' smtp.example.com ')
+    await user.type(screen.getByLabelText('Password'), 'temporary-secret')
+    await user.type(screen.getByLabelText('From Email'), ' sender@example.com ')
+    await user.type(
+      screen.getByLabelText('Test recipient'),
+      ' recipient@example.com '
+    )
+    await user.click(screen.getByRole('button', { name: 'Send test email' }))
+
+    await waitFor(() => {
+      expect(testSMTPSetting).toHaveBeenCalled()
+    })
+    expect(testSMTPSetting.mock.calls[0][0]).toEqual({
+      recipient: 'recipient@example.com',
+      smtpEnabled: true,
+      smtpHost: 'smtp.example.com',
+      smtpPort: 587,
+      smtpUsername: '',
+      smtpPassword: 'temporary-secret',
+      smtpFromEmail: 'sender@example.com',
+      smtpFromName: '',
+      smtpEncryption: 'starttls',
+      smtpSkipTLSVerify: false,
+      smtpTimeoutSeconds: 30,
+    })
+    expect(updateGeneralSetting).not.toHaveBeenCalled()
+  })
+})

--- a/ui/src/components/settings/general-management.tsx
+++ b/ui/src/components/settings/general-management.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import {
   IconLink,
+  IconMail,
   IconMessage,
   IconRobot,
   IconSettings,
@@ -12,7 +13,9 @@ import { toast } from 'sonner'
 
 import {
   GeneralSettingUpdateRequest,
+  testSMTPSetting,
   updateGeneralSetting,
+  useBootstrap,
   useGeneralSetting,
 } from '@/lib/api'
 import { translateError } from '@/lib/utils'
@@ -36,6 +39,21 @@ const DEFAULT_KUBECTL_IMAGE = 'zzde/kubectl:latest'
 const DEFAULT_NODE_TERMINAL_IMAGE = 'busybox:latest'
 const DEFAULT_CLUSTER_AGENT_IMAGE = 'ghcr.io/kite-org/kite:latest'
 
+interface SMTPSettingsFormData {
+  smtpEnabled: boolean
+  smtpHost: string
+  smtpPort: number
+  smtpUsername: string
+  smtpPassword: string
+  smtpPasswordConfigured: boolean
+  smtpFromEmail: string
+  smtpFromName: string
+  smtpEncryption: 'none' | 'starttls' | 'tls'
+  smtpSkipTLSVerify: boolean
+  smtpTimeoutSeconds: number
+  testRecipient: string
+}
+
 interface GeneralSettingsFormData {
   aiAgentEnabled: boolean
   aiProvider: 'openai' | 'anthropic'
@@ -57,6 +75,22 @@ export function GeneralManagement() {
   const { t } = useTranslation()
   const queryClient = useQueryClient()
   const { data, isLoading } = useGeneralSetting()
+  const { data: bootstrap } = useBootstrap()
+  const smtpManaged = bootstrap?.managedSections?.smtp ?? false
+  const [smtpFormData, setSMTPFormData] = useState<SMTPSettingsFormData>({
+    smtpEnabled: false,
+    smtpHost: '',
+    smtpPort: 587,
+    smtpUsername: '',
+    smtpPassword: '',
+    smtpPasswordConfigured: false,
+    smtpFromEmail: '',
+    smtpFromName: '',
+    smtpEncryption: 'starttls',
+    smtpSkipTLSVerify: false,
+    smtpTimeoutSeconds: 30,
+    testRecipient: '',
+  })
   const [formData, setFormData] = useState<GeneralSettingsFormData>({
     aiAgentEnabled: false,
     aiProvider: 'openai',
@@ -76,6 +110,20 @@ export function GeneralManagement() {
 
   useEffect(() => {
     if (!data) return
+    setSMTPFormData((prev) => ({
+      ...prev,
+      smtpEnabled: data.smtpEnabled ?? false,
+      smtpHost: data.smtpHost || '',
+      smtpPort: data.smtpPort || 587,
+      smtpUsername: data.smtpUsername || '',
+      smtpPassword: '',
+      smtpPasswordConfigured: data.smtpPasswordConfigured ?? false,
+      smtpFromEmail: data.smtpFromEmail || '',
+      smtpFromName: data.smtpFromName || '',
+      smtpEncryption: data.smtpEncryption || 'starttls',
+      smtpSkipTLSVerify: data.smtpSkipTLSVerify ?? false,
+      smtpTimeoutSeconds: data.smtpTimeoutSeconds || 30,
+    }))
     setFormData({
       aiAgentEnabled: data.aiAgentEnabled,
       aiProvider: data.aiProvider || 'openai',
@@ -112,6 +160,70 @@ export function GeneralManagement() {
       toast.error(translateError(error, t))
     },
   })
+
+  const smtpTestMutation = useMutation({
+    mutationFn: testSMTPSetting,
+    onSuccess: () => {
+      toast.success(
+        t(
+          'generalManagement.smtp.messages.testSent',
+          'Test email sent. Click Save at the bottom of the page to persist SMTP settings.'
+        )
+      )
+    },
+    onError: (error) => {
+      toast.error(translateError(error, t))
+    },
+  })
+
+  const validateSMTPForm = () => {
+    if (smtpFormData.smtpEnabled && !smtpFormData.smtpHost.trim()) {
+      toast.error(
+        t('generalManagement.smtp.errors.hostRequired', 'SMTP host is required')
+      )
+      return false
+    }
+    if (smtpFormData.smtpEnabled && !smtpFormData.smtpFromEmail.trim()) {
+      toast.error(
+        t(
+          'generalManagement.smtp.errors.fromEmailRequired',
+          'From email is required'
+        )
+      )
+      return false
+    }
+    return true
+  }
+
+  const handleSMTPTest = () => {
+    if (!smtpFormData.testRecipient.trim()) {
+      toast.error(
+        t(
+          'generalManagement.smtp.errors.recipientRequired',
+          'Recipient email is required'
+        )
+      )
+      return
+    }
+    if (!validateSMTPForm()) return
+
+    const payload = {
+      recipient: smtpFormData.testRecipient.trim(),
+      smtpEnabled: smtpFormData.smtpEnabled,
+      smtpHost: smtpFormData.smtpHost.trim(),
+      smtpPort: smtpFormData.smtpPort || 587,
+      smtpUsername: smtpFormData.smtpUsername.trim(),
+      smtpFromEmail: smtpFormData.smtpFromEmail.trim(),
+      smtpFromName: smtpFormData.smtpFromName.trim(),
+      smtpEncryption: smtpFormData.smtpEncryption,
+      smtpSkipTLSVerify: smtpFormData.smtpSkipTLSVerify,
+      smtpTimeoutSeconds: smtpFormData.smtpTimeoutSeconds || 30,
+    }
+    if (smtpFormData.smtpPassword.trim()) {
+      Object.assign(payload, { smtpPassword: smtpFormData.smtpPassword })
+    }
+    smtpTestMutation.mutate(payload)
+  }
 
   const handleSave = () => {
     const defaultModel =
@@ -156,6 +268,7 @@ export function GeneralManagement() {
       )
       return
     }
+    if (!smtpManaged && !validateSMTPForm()) return
 
     const payload: GeneralSettingUpdateRequest = {
       aiAgentEnabled: formData.aiAgentEnabled,
@@ -175,6 +288,22 @@ export function GeneralManagement() {
     }
     if (formData.aiApiKey.trim()) {
       payload.aiApiKey = formData.aiApiKey.trim()
+    }
+    if (!smtpManaged) {
+      Object.assign(payload, {
+        smtpEnabled: smtpFormData.smtpEnabled,
+        smtpHost: smtpFormData.smtpHost.trim(),
+        smtpPort: smtpFormData.smtpPort || 587,
+        smtpUsername: smtpFormData.smtpUsername.trim(),
+        smtpFromEmail: smtpFormData.smtpFromEmail.trim(),
+        smtpFromName: smtpFormData.smtpFromName.trim(),
+        smtpEncryption: smtpFormData.smtpEncryption,
+        smtpSkipTLSVerify: smtpFormData.smtpSkipTLSVerify,
+        smtpTimeoutSeconds: smtpFormData.smtpTimeoutSeconds || 30,
+      })
+      if (smtpFormData.smtpPassword.trim()) {
+        payload.smtpPassword = smtpFormData.smtpPassword
+      }
     }
 
     mutation.mutate(payload)
@@ -347,6 +476,274 @@ export function GeneralManagement() {
           <div className="flex items-center justify-between p-3">
             <div className="space-y-1">
               <Label className="flex items-center gap-2 text-sm font-medium">
+                <IconMail className="h-4 w-4" />
+                {t('generalManagement.smtp.title', 'SMTP')}
+              </Label>
+              <p className="text-xs text-muted-foreground">
+                {t(
+                  'generalManagement.smtp.description',
+                  'Configure email delivery for notifications.'
+                )}
+              </p>
+            </div>
+            <Switch
+              aria-label={t('generalManagement.smtp.toggle', 'Enable SMTP')}
+              checked={smtpFormData.smtpEnabled}
+              disabled={smtpManaged}
+              onCheckedChange={(checked) =>
+                setSMTPFormData((prev) => ({ ...prev, smtpEnabled: checked }))
+              }
+            />
+          </div>
+
+          {smtpManaged && (
+            <p className="border-t px-3 pt-3 text-xs text-muted-foreground">
+              {t(
+                'generalManagement.smtp.managed',
+                'Managed by configuration file and cannot be modified here.'
+              )}
+            </p>
+          )}
+
+          {smtpFormData.smtpEnabled && (
+            <>
+              <div className="space-y-4 border-t p-3">
+                <div className="grid gap-4 sm:grid-cols-2">
+                  <div className="space-y-2">
+                    <Label htmlFor="smtp-host">
+                      {t('generalManagement.smtp.form.host', 'Host')}
+                    </Label>
+                    <Input
+                      id="smtp-host"
+                      value={smtpFormData.smtpHost}
+                      disabled={smtpManaged}
+                      onChange={(e) =>
+                        setSMTPFormData((prev) => ({
+                          ...prev,
+                          smtpHost: e.target.value,
+                        }))
+                      }
+                      placeholder="smtp.example.com"
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="smtp-port">
+                      {t('generalManagement.smtp.form.port', 'Port')}
+                    </Label>
+                    <Input
+                      id="smtp-port"
+                      type="number"
+                      min="1"
+                      max="65535"
+                      value={smtpFormData.smtpPort}
+                      disabled={smtpManaged}
+                      onChange={(e) =>
+                        setSMTPFormData((prev) => ({
+                          ...prev,
+                          smtpPort: parseInt(e.target.value) || 587,
+                        }))
+                      }
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="smtp-username">
+                      {t('generalManagement.smtp.form.username', 'Username')}
+                    </Label>
+                    <Input
+                      id="smtp-username"
+                      value={smtpFormData.smtpUsername}
+                      disabled={smtpManaged}
+                      onChange={(e) =>
+                        setSMTPFormData((prev) => ({
+                          ...prev,
+                          smtpUsername: e.target.value,
+                        }))
+                      }
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="smtp-password">
+                      {t('generalManagement.smtp.form.password', 'Password')}
+                    </Label>
+                    <Input
+                      id="smtp-password"
+                      type="password"
+                      value={smtpFormData.smtpPassword}
+                      disabled={smtpManaged}
+                      onChange={(e) =>
+                        setSMTPFormData((prev) => ({
+                          ...prev,
+                          smtpPassword: e.target.value,
+                        }))
+                      }
+                      placeholder={
+                        smtpFormData.smtpPasswordConfigured
+                          ? t(
+                              'generalManagement.smtp.form.passwordPlaceholder',
+                              'Leave empty to keep current password'
+                            )
+                          : undefined
+                      }
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="smtp-from-email">
+                      {t('generalManagement.smtp.form.fromEmail', 'From Email')}
+                    </Label>
+                    <Input
+                      id="smtp-from-email"
+                      type="email"
+                      value={smtpFormData.smtpFromEmail}
+                      disabled={smtpManaged}
+                      onChange={(e) =>
+                        setSMTPFormData((prev) => ({
+                          ...prev,
+                          smtpFromEmail: e.target.value,
+                        }))
+                      }
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="smtp-from-name">
+                      {t('generalManagement.smtp.form.fromName', 'From Name')}
+                    </Label>
+                    <Input
+                      id="smtp-from-name"
+                      value={smtpFormData.smtpFromName}
+                      disabled={smtpManaged}
+                      onChange={(e) =>
+                        setSMTPFormData((prev) => ({
+                          ...prev,
+                          smtpFromName: e.target.value,
+                        }))
+                      }
+                    />
+                  </div>
+                </div>
+
+                <div className="grid gap-4 sm:grid-cols-4">
+                  <div className="space-y-2">
+                    <Label htmlFor="smtp-encryption">
+                      {t(
+                        'generalManagement.smtp.form.encryption',
+                        'Encryption'
+                      )}
+                    </Label>
+                    <Select
+                      value={smtpFormData.smtpEncryption}
+                      disabled={smtpManaged}
+                      onValueChange={(value: 'none' | 'starttls' | 'tls') =>
+                        setSMTPFormData((prev) => ({
+                          ...prev,
+                          smtpEncryption: value,
+                        }))
+                      }
+                    >
+                      <SelectTrigger id="smtp-encryption">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="starttls">STARTTLS</SelectItem>
+                        <SelectItem value="tls">TLS</SelectItem>
+                        <SelectItem value="none">
+                          {t('generalManagement.smtp.encryption.none', 'None')}
+                        </SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  <div className="flex items-end">
+                    <div className="flex h-10 w-full items-center justify-between gap-2">
+                      <Label htmlFor="smtp-skip-tls-verify" className="text-sm">
+                        {t(
+                          'generalManagement.smtp.form.skipTLSVerify',
+                          'Skip TLS certificate verification'
+                        )}
+                      </Label>
+                      <Switch
+                        id="smtp-skip-tls-verify"
+                        checked={smtpFormData.smtpSkipTLSVerify}
+                        disabled={smtpManaged}
+                        onCheckedChange={(checked) =>
+                          setSMTPFormData((prev) => ({
+                            ...prev,
+                            smtpSkipTLSVerify: checked,
+                          }))
+                        }
+                      />
+                    </div>
+                  </div>
+                  <div className="space-y-2 sm:col-span-2">
+                    <Label htmlFor="smtp-timeout">
+                      {t(
+                        'generalManagement.smtp.form.timeout',
+                        'Timeout (seconds)'
+                      )}
+                    </Label>
+                    <Input
+                      id="smtp-timeout"
+                      type="number"
+                      min="1"
+                      value={smtpFormData.smtpTimeoutSeconds}
+                      disabled={smtpManaged}
+                      onChange={(e) =>
+                        setSMTPFormData((prev) => ({
+                          ...prev,
+                          smtpTimeoutSeconds: parseInt(e.target.value) || 30,
+                        }))
+                      }
+                    />
+                  </div>
+                </div>
+
+                {(smtpFormData.smtpEncryption === 'none' ||
+                  smtpFormData.smtpSkipTLSVerify) && (
+                  <p className="text-xs text-amber-600 dark:text-amber-400">
+                    {t(
+                      'generalManagement.smtp.securityHint',
+                      'This configuration may transmit email credentials or content insecurely.'
+                    )}
+                  </p>
+                )}
+              </div>
+
+              <div className="flex flex-col gap-2 border-t p-3 sm:flex-row sm:items-end sm:justify-between">
+                <div className="w-full space-y-2 sm:max-w-sm">
+                  <Label htmlFor="smtp-test-recipient">
+                    {t(
+                      'generalManagement.smtp.form.testRecipient',
+                      'Test recipient'
+                    )}
+                  </Label>
+                  <Input
+                    id="smtp-test-recipient"
+                    type="email"
+                    value={smtpFormData.testRecipient}
+                    onChange={(e) =>
+                      setSMTPFormData((prev) => ({
+                        ...prev,
+                        testRecipient: e.target.value,
+                      }))
+                    }
+                  />
+                </div>
+                <Button
+                  onClick={handleSMTPTest}
+                  disabled={
+                    !smtpFormData.smtpEnabled || smtpTestMutation.isPending
+                  }
+                  variant="outline"
+                >
+                  {t('generalManagement.smtp.actions.test', 'Send test email')}
+                </Button>
+              </div>
+            </>
+          )}
+        </div>
+
+        <div className="rounded-lg border">
+          <div className="flex items-center justify-between p-3">
+            <div className="space-y-1">
+              <Label className="flex items-center gap-2 text-sm font-medium">
                 <IconTerminal2 className="h-4 w-4" />
                 {t('generalManagement.kubectl.title', 'Kubectl')}
               </Label>
@@ -358,6 +755,10 @@ export function GeneralManagement() {
               </p>
             </div>
             <Switch
+              aria-label={t(
+                'generalManagement.kubectl.toggle',
+                'Enable kubectl'
+              )}
               checked={formData.kubectlEnabled}
               onCheckedChange={(checked) =>
                 setFormData((prev) => ({ ...prev, kubectlEnabled: checked }))

--- a/ui/src/components/settings/kubeconfig-token-management.test.tsx
+++ b/ui/src/components/settings/kubeconfig-token-management.test.tsx
@@ -1,0 +1,155 @@
+/// <reference types="@testing-library/jest-dom" />
+import type { ReactNode } from 'react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+
+import { KubeconfigTokenManagement } from './kubeconfig-token-management'
+
+const { deleteAdminKubeconfigToken, useAdminKubeconfigTokens } = vi.hoisted(
+  () => ({
+    deleteAdminKubeconfigToken: vi.fn(),
+    useAdminKubeconfigTokens: vi.fn(),
+  })
+)
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (_key: string, defaultValue?: string, values?: Record<string, number>) =>
+      defaultValue
+        ?.replace('{{page}}', String(values?.page ?? ''))
+        .replace('{{totalPages}}', String(values?.totalPages ?? '')) ?? _key,
+  }),
+}))
+
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
+
+vi.mock('@/lib/api', () => ({
+  deleteAdminKubeconfigToken,
+  useAdminKubeconfigTokens,
+}))
+
+vi.mock('@/components/kubeconfig-token-list', () => ({
+  KubeconfigTokenList: () => <div>Token list</div>,
+}))
+
+vi.mock('@/components/ui/select', () => ({
+  Select: ({
+    children,
+    onValueChange,
+    value,
+  }: {
+    children: ReactNode
+    onValueChange: (value: string) => void
+    value: string
+  }) => (
+    <select
+      onChange={(event) => onValueChange(event.target.value)}
+      value={value}
+    >
+      {children}
+    </select>
+  ),
+  SelectContent: ({ children }: { children: ReactNode }) => <>{children}</>,
+  SelectItem: ({ children, value }: { children: ReactNode; value: string }) => (
+    <option value={value}>{children}</option>
+  ),
+  SelectTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
+  SelectValue: () => null,
+}))
+
+function renderManagement() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <KubeconfigTokenManagement />
+    </QueryClientProvider>
+  )
+}
+
+describe('KubeconfigTokenManagement', () => {
+  it('requests the first page, filters by username and active/expired status, and resets filters to page one', async () => {
+    useAdminKubeconfigTokens.mockReturnValue({
+      data: { tokens: [], total: 40, page: 1, size: 20 },
+      isLoading: false,
+      error: null,
+    })
+    renderManagement()
+    const user = userEvent.setup()
+
+    expect(useAdminKubeconfigTokens).toHaveBeenLastCalledWith({
+      page: 1,
+      size: 20,
+      owner: undefined,
+      status: undefined,
+    })
+    expect(
+      screen.queryByRole('option', { name: 'Revoked' })
+    ).not.toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Go to next page' }))
+    await waitFor(() => {
+      expect(useAdminKubeconfigTokens).toHaveBeenLastCalledWith({
+        page: 2,
+        size: 20,
+        owner: undefined,
+        status: undefined,
+      })
+    })
+
+    await user.type(screen.getByPlaceholderText('Filter by username'), 'alice')
+    await waitFor(() => {
+      expect(useAdminKubeconfigTokens).toHaveBeenLastCalledWith({
+        page: 1,
+        size: 20,
+        owner: 'alice',
+        status: undefined,
+      })
+    })
+
+    await user.selectOptions(
+      screen.getByRole('option', { name: 'Expired' })
+        .parentElement as HTMLSelectElement,
+      'expired'
+    )
+    await waitFor(() => {
+      expect(useAdminKubeconfigTokens).toHaveBeenLastCalledWith({
+        page: 1,
+        size: 20,
+        owner: 'alice',
+        status: 'expired',
+      })
+    })
+  })
+
+  it('enables and disables pagination controls at page boundaries', async () => {
+    useAdminKubeconfigTokens.mockReturnValue({
+      data: { tokens: [], total: 40, page: 1, size: 20 },
+      isLoading: false,
+      error: null,
+    })
+    renderManagement()
+    const user = userEvent.setup()
+
+    expect(
+      screen.getByRole('button', { name: 'Go to previous page' })
+    ).toBeDisabled()
+    expect(
+      screen.getByRole('button', { name: 'Go to next page' })
+    ).toBeEnabled()
+
+    await user.click(screen.getByRole('button', { name: 'Go to next page' }))
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: 'Go to previous page' })
+      ).toBeEnabled()
+      expect(
+        screen.getByRole('button', { name: 'Go to next page' })
+      ).toBeDisabled()
+      expect(screen.getByText('Page 2 of 2')).toBeInTheDocument()
+    })
+  })
+})

--- a/ui/src/components/settings/kubeconfig-token-management.tsx
+++ b/ui/src/components/settings/kubeconfig-token-management.tsx
@@ -1,0 +1,194 @@
+import { useState } from 'react'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { KeyRound } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import { toast } from 'sonner'
+
+import {
+  deleteAdminKubeconfigToken,
+  KubeconfigTokenStatus,
+  useAdminKubeconfigTokens,
+} from '@/lib/api'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { KubeconfigTokenList } from '@/components/kubeconfig-token-list'
+
+export function KubeconfigTokenManagement() {
+  const { t } = useTranslation()
+  const queryClient = useQueryClient()
+  const [page, setPage] = useState(1)
+  const [pageSize, setPageSize] = useState(20)
+  const [owner, setOwner] = useState('')
+  const [status, setStatus] = useState<KubeconfigTokenStatus | undefined>()
+  const { data, isLoading, error } = useAdminKubeconfigTokens({
+    page,
+    size: pageSize,
+    owner: owner || undefined,
+    status,
+  })
+  const deleteMutation = useMutation({
+    mutationFn: deleteAdminKubeconfigToken,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['admin-kubeconfig-tokens'] })
+      toast.success(
+        t('kubeconfigTokens.deleteSuccess', 'Kubeconfig token deleted')
+      )
+    },
+    onError: (error) => toast.error(error.message),
+  })
+  const totalPages = Math.max(1, Math.ceil((data?.total ?? 0) / pageSize))
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center justify-between">
+          <div>
+            <CardTitle className="flex items-center gap-2">
+              <KeyRound className="h-5 w-5" />
+              {t('kubeconfigTokens.adminTitle', 'Kubeconfig Tokens')}
+            </CardTitle>
+            <p className="text-sm text-muted-foreground">
+              {t(
+                'kubeconfigTokens.adminDescription',
+                'Review and delete kubeconfig tokens for all users.'
+              )}
+            </p>
+          </div>
+          <div className="flex items-center gap-3">
+            <Input
+              className="w-64"
+              value={owner}
+              onChange={(event) => {
+                setOwner(event.target.value)
+                setPage(1)
+              }}
+              placeholder={t(
+                'kubeconfigTokens.ownerPlaceholder',
+                'Filter by username'
+              )}
+            />
+            <Select
+              value={status ?? 'all'}
+              onValueChange={(value) => {
+                setStatus(
+                  value === 'all' ? undefined : (value as KubeconfigTokenStatus)
+                )
+                setPage(1)
+              }}
+            >
+              <SelectTrigger className="w-44">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">
+                  {t('kubeconfigTokens.allStatuses', 'All statuses')}
+                </SelectItem>
+                <SelectItem value="active">
+                  {t('kubeconfigTokens.active', 'Active')}
+                </SelectItem>
+                <SelectItem value="expired">
+                  {t('kubeconfigTokens.expired', 'Expired')}
+                </SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {error ? (
+          <p className="text-destructive">{error.message}</p>
+        ) : isLoading ? (
+          <p className="text-muted-foreground">
+            {t('common.messages.loading', 'Loading...')}
+          </p>
+        ) : (
+          <>
+            <KubeconfigTokenList
+              tokens={data?.tokens ?? []}
+              includeOwner
+              onDelete={(token) => deleteMutation.mutate(token.id)}
+              deletingId={deleteMutation.variables}
+            />
+            <div className="flex flex-col gap-3 px-2 py-1 sm:flex-row sm:items-center sm:justify-between">
+              <p className="hidden flex-1 text-sm text-muted-foreground lg:block">
+                {t(
+                  'kubeconfigTokens.totalTokens',
+                  '{{count}} token(s) total.',
+                  { count: data?.total ?? 0 }
+                )}
+              </p>
+              <div className="flex w-full flex-col gap-3 sm:flex-row sm:items-center sm:gap-4 lg:w-fit">
+                <div className="flex items-center justify-between gap-2 sm:justify-start">
+                  <span className="text-sm text-muted-foreground">
+                    {t('kubeconfigTokens.rowsPerPage', 'Rows per page:')}
+                  </span>
+                  <Select
+                    value={String(pageSize)}
+                    onValueChange={(value) => {
+                      setPageSize(Number(value))
+                      setPage(1)
+                    }}
+                  >
+                    <SelectTrigger size="sm" className="w-20">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {[10, 20, 50, 100].map((size) => (
+                        <SelectItem key={size} value={String(size)}>
+                          {size}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+                <p className="flex items-center justify-center text-sm font-medium">
+                  {t(
+                    'kubeconfigTokens.pagination',
+                    'Page {{page}} of {{totalPages}}',
+                    { page, totalPages }
+                  )}
+                </p>
+                <div className="flex items-center justify-end gap-2 sm:justify-start">
+                  <Button
+                    variant="outline"
+                    className="size-8"
+                    size="icon"
+                    disabled={page === 1}
+                    onClick={() => setPage((current) => current - 1)}
+                    aria-label={t(
+                      'kubeconfigTokens.previousPage',
+                      'Go to previous page'
+                    )}
+                  >
+                    <span aria-hidden>←</span>
+                  </Button>
+                  <Button
+                    variant="outline"
+                    className="size-8"
+                    size="icon"
+                    disabled={page >= totalPages}
+                    onClick={() => setPage((current) => current + 1)}
+                    aria-label={t(
+                      'kubeconfigTokens.nextPage',
+                      'Go to next page'
+                    )}
+                  >
+                    <span aria-hidden>→</span>
+                  </Button>
+                </div>
+              </div>
+            </div>
+          </>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/ui/src/components/settings/settings-sections.tsx
+++ b/ui/src/components/settings/settings-sections.tsx
@@ -6,6 +6,7 @@ import { AuditLog } from './audit-log'
 import { AuthenticationManagement } from './authentication-management'
 import { ClusterManagement } from './cluster-management'
 import { GeneralManagement } from './general-management'
+import { KubeconfigTokenManagement } from './kubeconfig-token-management'
 import { RBACManagement } from './rbac-management'
 import { TemplateManagement } from './template-management'
 import { UserManagement } from './user-management'
@@ -67,6 +68,12 @@ export const settingsSectionRegistry: SettingsSectionDefinition[] = [
     'settings.tabs.apikeys',
     'API Keys',
     APIKeyManagement
+  ),
+  createSettingsSectionDefinition(
+    'kubeconfig-tokens',
+    'settings.tabs.kubeconfigTokens',
+    'Kubeconfig Tokens',
+    KubeconfigTokenManagement
   ),
   createSettingsSectionDefinition(
     'templates',

--- a/ui/src/components/site-header.tsx
+++ b/ui/src/components/site-header.tsx
@@ -1,9 +1,10 @@
 import { useState } from 'react'
 import { useAuth } from '@/contexts/auth-context'
 import { useTerminal } from '@/contexts/terminal-context'
-import { Plus, Settings, TerminalSquare } from 'lucide-react'
+import { Download, Plus, Settings, TerminalSquare } from 'lucide-react'
 import { useNavigate } from 'react-router-dom'
 
+import { useCluster } from '@/hooks/use-cluster'
 import { useIsMobile } from '@/hooks/use-mobile'
 import { Button } from '@/components/ui/button'
 import { Separator } from '@/components/ui/separator'
@@ -11,6 +12,7 @@ import { SidebarTrigger } from '@/components/ui/sidebar'
 
 import { CreateResourceDialog } from './create-resource-dialog'
 import { DynamicBreadcrumb } from './dynamic-breadcrumb'
+import { KubeconfigDownloadDialog } from './kubeconfig-download-dialog'
 import { LanguageToggle } from './language-toggle'
 import { ModeToggle } from './mode-toggle'
 import { Search } from './search'
@@ -20,8 +22,10 @@ export function SiteHeader() {
   const isMobile = useIsMobile()
   const navigate = useNavigate()
   const { user, capabilities } = useAuth()
+  const { clusters } = useCluster()
   const { toggleTerminal, isOpen } = useTerminal()
   const [createDialogOpen, setCreateDialogOpen] = useState(false)
+  const [kubeconfigDialogOpen, setKubeconfigDialogOpen] = useState(false)
   const isAdmin = user?.isAdmin() ?? false
   const kubectlEnabled = capabilities.kubectlEnabled
 
@@ -56,6 +60,16 @@ export function SiteHeader() {
                 <TerminalSquare className="h-5 w-5" />
               </button>
             )}
+            {user && clusters.some((cluster) => cluster.enabled && cluster.uuid) && (
+              <button
+                onClick={() => setKubeconfigDialogOpen(true)}
+                title="Download Kubeconfig"
+                aria-label="Download Kubeconfig"
+                className="flex items-center justify-center rounded-sm p-1 text-muted-foreground transition-colors hover:text-foreground"
+              >
+                <Download className="h-5 w-5" />
+              </button>
+            )}
             {!isMobile && (
               <>
                 <Separator
@@ -88,6 +102,10 @@ export function SiteHeader() {
           onOpenChange={setCreateDialogOpen}
         />
       ) : null}
+      <KubeconfigDownloadDialog
+        open={kubeconfigDialogOpen}
+        onOpenChange={setKubeconfigDialogOpen}
+      />
     </>
   )
 }

--- a/ui/src/contexts/cluster-context.tsx
+++ b/ui/src/contexts/cluster-context.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react-refresh/only-export-components */
-import React, { createContext, useEffect, useState } from 'react'
+import React, { createContext, useCallback, useEffect, useState } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
@@ -18,6 +18,7 @@ interface ClusterContextType {
   isLoading: boolean
   isSwitching?: boolean
   error: Error | null
+  refreshClusters: () => Promise<void>
 }
 
 export const ClusterContext = createContext<ClusterContextType | undefined>(
@@ -47,32 +48,21 @@ export const ClusterProvider: React.FC<{ children: React.ReactNode }> = ({
     clearCurrentCluster()
   }, [currentCluster])
 
-  useEffect(() => {
-    let cancelled = false
-
-    const bootstrap = async () => {
-      setIsLoading(true)
-      const result = await refetchClusters()
-      if (cancelled) {
-        return
-      }
-
-      if (result.data) {
-        setClusters(result.data)
-        setError(null)
-      } else {
-        setClusters([])
-        setError(result.error instanceof Error ? result.error : null)
-      }
-      setIsLoading(false)
+  const refreshClusters = useCallback(async () => {
+    const result = await refetchClusters()
+    if (result.data) {
+      setClusters(result.data)
+      setError(null)
+    } else {
+      setClusters([])
+      setError(result.error instanceof Error ? result.error : null)
     }
-
-    void bootstrap()
-
-    return () => {
-      cancelled = true
-    }
+    setIsLoading(false)
   }, [refetchClusters])
+
+  useEffect(() => {
+    void refreshClusters()
+  }, [refreshClusters])
 
   useEffect(() => {
     if (clusters.length > 0 && !currentCluster) {
@@ -130,6 +120,7 @@ export const ClusterProvider: React.FC<{ children: React.ReactNode }> = ({
     isLoading,
     isSwitching,
     error,
+    refreshClusters,
   }
 
   return (

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -768,7 +768,8 @@
       "general": "General",
       "oauth": "Authentication",
       "rbac": "RBAC",
-      "users": "User"
+      "users": "User",
+      "kubeconfigTokens": "Kubeconfig Tokens"
     }
   },
   "generalManagement": {
@@ -1172,6 +1173,67 @@
   "apikeyManagement": {
     "actions": {
       "add": "Add API Key"
+    }
+  },
+  "kubeconfigDownload": {
+    "title": "Download Kubeconfig",
+    "description": "Choose accessible clusters and an expiration time.",
+    "clusters": "Clusters",
+    "searchClusters": "Search clusters",
+    "noClustersFound": "No matching clusters found.",
+    "selectAll": "Select all",
+    "deselectAll": "Deselect all",
+    "selectMatching": "Select matching",
+    "deselectMatching": "Deselect matching",
+    "selectedSummary": "{{selected}} selected / {{total}} total",
+    "expiration": "Expiration",
+    "custom": "Custom",
+    "year": "Year",
+    "month": "Month",
+    "day": "Day",
+    "hour": "Hour",
+    "minute": "Minute",
+    "second": "Second",
+    "expiresAt": "Expires {{date}}",
+    "ttlError": "Select an expiration time between 1 hour and 5 years from now.",
+    "securityNotice": "This file contains a sensitive Bearer token. Store it securely and set file permissions to 0600.",
+    "download": "Download",
+    "downloading": "Downloading...",
+    "success": "Kubeconfig downloaded",
+    "error": "Failed to download kubeconfig",
+    "presets": {
+      "1d": "1 day",
+      "7d": "7 days",
+      "30d": "30 days",
+      "1year": "1 year"
+    }
+  },
+  "kubeconfigTokens": {
+    "adminTitle": "Kubeconfig Tokens",
+    "adminDescription": "Review and delete kubeconfig tokens for all users.",
+    "empty": "No kubeconfig tokens found.",
+    "expiresAt": "Expires At",
+    "active": "Active",
+    "expired": "Expired",
+    "delete": "Delete",
+    "deleteSuccess": "Kubeconfig token deleted",
+    "ownerPlaceholder": "Filter by username",
+    "allStatuses": "All statuses",
+    "totalTokens": "{{count}} token(s) total.",
+    "rowsPerPage": "Rows per page:",
+    "pagination": "Page {{page}} of {{totalPages}}",
+    "previousPage": "Go to previous page",
+    "nextPage": "Go to next page",
+    "deleteConfirmTitle": "Delete kubeconfig token?",
+    "deleteConfirmDescription": "This token will be deleted, become invalid immediately, and cannot be recovered."
+  },
+  "accountSettings": {
+    "title": "Account Settings",
+    "tabs": {
+      "profile": "Profile",
+      "password": "Password",
+      "security": "Security",
+      "kubeconfigTokens": "Kubeconfig Tokens"
     }
   },
   "deleteConfirmation": {

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -737,7 +737,11 @@
   },
   "errors": {
     "crdNotInstalledTitle": "Resource Type Not Available",
-    "crdNotInstalled": "The {{kind}} resource type ({{version}}) is not installed in this cluster. Install the required CRD to use this feature."
+    "crdNotInstalled": "The {{kind}} resource type ({{version}}) is not installed in this cluster. Install the required CRD to use this feature.",
+    "noPermission": {
+      "title": "Access Denied",
+      "adminRequired": "You do not have permission to access this page."
+    }
   },
   "rbac": {
     "noPermissionCluster": "User {{user}} does not have permission to {{verb}} {{resource}} on cluster {{cluster}}",
@@ -786,8 +790,42 @@
         "maxTokens": "Max Tokens"
       }
     },
+    "smtp": {
+      "title": "SMTP",
+      "description": "Configure email delivery for notifications.",
+      "form": {
+        "host": "Host",
+        "port": "Port",
+        "encryption": "Encryption",
+        "timeout": "Timeout (seconds)",
+        "username": "Username",
+        "password": "Password",
+        "passwordPlaceholder": "Leave empty to keep current password",
+        "fromEmail": "From Email",
+        "fromName": "From Name",
+        "skipTLSVerify": "Skip TLS certificate verification",
+        "testRecipient": "Test recipient"
+      },
+      "encryption": {
+        "none": "None"
+      },
+      "securityHint": "This configuration may transmit email credentials or content insecurely.",
+      "managed": "Managed by configuration file and cannot be modified here.",
+      "actions": {
+        "test": "Send test email"
+      },
+      "errors": {
+        "hostRequired": "SMTP host is required",
+        "fromEmailRequired": "From email is required",
+        "recipientRequired": "Recipient email is required"
+      },
+      "messages": {
+        "testSent": "Test email sent. Click Save at the bottom of the page to persist SMTP settings."
+      }
+    },
     "kubectl": {
       "title": "Kubectl",
+      "toggle": "Enable kubectl",
       "description": "Enable kubectl terminal and configure runtime image.",
       "form": {
         "image": "Image"

--- a/ui/src/i18n/locales/zh.json
+++ b/ui/src/i18n/locales/zh.json
@@ -779,7 +779,8 @@
       "oauth": "认证",
       "rbac": "RBAC",
       "users": "用户",
-      "apikeys": "API 密钥"
+      "apikeys": "API 密钥",
+      "kubeconfigTokens": "Kubeconfig 令牌"
     }
   },
   "generalManagement": {
@@ -1118,6 +1119,67 @@
       "description": "创建新的 API 密钥用于程序化访问。",
       "namePlaceholder": "例如：生产环境 API 密钥",
       "nameRequired": "名称为必填项"
+    }
+  },
+  "kubeconfigDownload": {
+    "title": "下载 Kubeconfig",
+    "description": "选择可访问的集群和有效期。",
+    "clusters": "集群",
+    "searchClusters": "搜索集群",
+    "noClustersFound": "未找到匹配的集群。",
+    "selectAll": "全选",
+    "deselectAll": "取消全选",
+    "selectMatching": "全选匹配项",
+    "deselectMatching": "取消选择匹配项",
+    "selectedSummary": "已选 {{selected}} / 共 {{total}}",
+    "expiration": "有效期",
+    "custom": "自定义",
+    "year": "年",
+    "month": "月",
+    "day": "日",
+    "hour": "时",
+    "minute": "分",
+    "second": "秒",
+    "expiresAt": "将于 {{date}} 过期",
+    "ttlError": "请选择 1 小时到 5 年内的到期时间。",
+    "securityNotice": "此文件包含敏感 Bearer Token，请妥善保存并设置文件权限为 0600。",
+    "download": "下载",
+    "downloading": "下载中...",
+    "success": "Kubeconfig 已下载",
+    "error": "下载 Kubeconfig 失败",
+    "presets": {
+      "1d": "1 天",
+      "7d": "7 天",
+      "30d": "30 天",
+      "1year": "1 年"
+    }
+  },
+  "kubeconfigTokens": {
+    "adminTitle": "Kubeconfig 令牌",
+    "adminDescription": "查看并删除所有用户的 Kubeconfig 令牌。",
+    "empty": "暂无 Kubeconfig 令牌。",
+    "expiresAt": "过期时间",
+    "active": "有效",
+    "expired": "已过期",
+    "delete": "删除",
+    "deleteSuccess": "Kubeconfig 令牌已删除",
+    "ownerPlaceholder": "按用户名筛选",
+    "allStatuses": "全部状态",
+    "totalTokens": "共 {{count}} 个令牌。",
+    "rowsPerPage": "每页行数：",
+    "pagination": "第 {{page}} / {{totalPages}} 页",
+    "previousPage": "转到上一页",
+    "nextPage": "转到下一页",
+    "deleteConfirmTitle": "删除 Kubeconfig 令牌？",
+    "deleteConfirmDescription": "此令牌将被删除，立即失效且不可恢复。"
+  },
+  "accountSettings": {
+    "title": "账户设置",
+    "tabs": {
+      "profile": "资料",
+      "password": "密码",
+      "security": "安全",
+      "kubeconfigTokens": "Kubeconfig 令牌"
     }
   },
   "deleteConfirmation": {

--- a/ui/src/i18n/locales/zh.json
+++ b/ui/src/i18n/locales/zh.json
@@ -742,7 +742,11 @@
   },
   "errors": {
     "crdNotInstalledTitle": "资源类型不可用",
-    "crdNotInstalled": "此集群未安装 {{kind}} ({{version}})。请先安装对应的 CRD。"
+    "crdNotInstalled": "此集群未安装 {{kind}} ({{version}})。请先安装对应的 CRD。",
+    "noPermission": {
+      "title": "访问被拒绝",
+      "adminRequired": "你没有权限访问此页面。"
+    }
   },
   "rbac": {
     "title": "RBAC 管理",
@@ -797,8 +801,42 @@
         "maxTokens": "最大 Token 数"
       }
     },
+    "smtp": {
+      "title": "SMTP",
+      "description": "配置通知邮件投递。",
+      "form": {
+        "host": "主机地址",
+        "port": "端口",
+        "encryption": "加密方式",
+        "timeout": "超时（秒）",
+        "username": "用户名",
+        "password": "密码",
+        "passwordPlaceholder": "留空则保持当前密码不变",
+        "fromEmail": "发件人邮箱",
+        "fromName": "发件人名称",
+        "skipTLSVerify": "跳过 TLS 证书校验",
+        "testRecipient": "测试收件人"
+      },
+      "encryption": {
+        "none": "不加密"
+      },
+      "securityHint": "此配置可能会不安全地传输邮件凭据或内容。",
+      "managed": "由配置文件管理，不能在此修改。",
+      "actions": {
+        "test": "发送测试邮件"
+      },
+      "errors": {
+        "hostRequired": "SMTP 主机地址不能为空",
+        "fromEmailRequired": "发件人邮箱不能为空",
+        "recipientRequired": "收件人邮箱不能为空"
+      },
+      "messages": {
+        "testSent": "测试邮件已发送。请点击页面底部的保存按钮以持久化 SMTP 设置。"
+      }
+    },
     "kubectl": {
       "title": "Kubectl",
+      "toggle": "启用 kubectl",
       "description": "启用 kubectl 终端，配置运行镜像。",
       "form": {
         "image": "镜像"

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -1,6 +1,7 @@
 export type { PaginatedResult } from './api/shared'
 export * from './api/auth'
 export * from './api/cluster'
+export * from './api/kubeconfig'
 export * from './api/bootstrap'
 export * from './api/core'
 export * from './api/observability'

--- a/ui/src/lib/api/admin.ts
+++ b/ui/src/lib/api/admin.ts
@@ -365,6 +365,16 @@ export interface GeneralSetting {
   aiApiKeyConfigured: boolean
   aiBaseUrl: string
   aiMaxTokens: number
+  smtpEnabled: boolean
+  smtpHost: string
+  smtpPort: number
+  smtpUsername: string
+  smtpPasswordConfigured: boolean
+  smtpFromEmail: string
+  smtpFromName: string
+  smtpEncryption: 'none' | 'starttls' | 'tls'
+  smtpSkipTLSVerify: boolean
+  smtpTimeoutSeconds: number
   kubectlEnabled: boolean
   kubectlImage: string
   nodeTerminalImage: string
@@ -384,6 +394,17 @@ export interface GeneralSettingUpdateRequest {
   aiApiKey?: string
   aiBaseUrl?: string
   aiMaxTokens?: number
+  smtpEnabled?: boolean
+  smtpHost?: string
+  smtpPort?: number
+  smtpUsername?: string
+  smtpPassword?: string
+  smtpClearPassword?: boolean
+  smtpFromEmail?: string
+  smtpFromName?: string
+  smtpEncryption?: 'none' | 'starttls' | 'tls'
+  smtpSkipTLSVerify?: boolean
+  smtpTimeoutSeconds?: number
   kubectlEnabled?: boolean
   kubectlImage?: string
   nodeTerminalImage?: string
@@ -447,6 +468,27 @@ export const updateGeneralSetting = async (
   data: GeneralSettingUpdateRequest
 ): Promise<GeneralSetting> => {
   return await apiClient.put<GeneralSetting>('/admin/general-setting/', data)
+}
+
+export interface SMTPTestRequest {
+  recipient: string
+  smtpEnabled?: boolean
+  smtpHost?: string
+  smtpPort?: number
+  smtpUsername?: string
+  smtpPassword?: string
+  smtpFromEmail?: string
+  smtpFromName?: string
+  smtpEncryption?: 'none' | 'starttls' | 'tls'
+  smtpSkipTLSVerify?: boolean
+  smtpTimeoutSeconds?: number
+}
+
+export const testSMTPSetting = async (data: SMTPTestRequest) => {
+  return await apiClient.post<{ message: string }>(
+    '/admin/general-setting/smtp/test',
+    data
+  )
 }
 
 export const setGlobalSidebarPreference = async (sidebarPreference: string) => {

--- a/ui/src/lib/api/bootstrap.ts
+++ b/ui/src/lib/api/bootstrap.ts
@@ -26,6 +26,7 @@ export interface BootstrapResponse {
   setup: BootstrapSetup
   auth: AuthProviderCatalog
   capabilities: BootstrapCapabilities
+  managedSections: Record<string, boolean>
   user: AuthUser | null
   hasGlobalSidebarPreference: boolean
   globalSidebarPreference: string

--- a/ui/src/lib/api/kubeconfig.ts
+++ b/ui/src/lib/api/kubeconfig.ts
@@ -1,0 +1,100 @@
+import { useQuery } from '@tanstack/react-query'
+
+import { apiClient, authApiClient } from '../api-client'
+
+export interface KubeconfigDownloadRequest {
+  clusterUUIDs: string[]
+  ttlSeconds: number
+}
+
+export interface KubeconfigToken {
+  id: number
+  name: string
+  ownerId?: number
+  owner?: string
+  createdAt: string
+  expiresAt: string
+  lastUsedAt?: string
+  signingKeyId: string
+}
+
+const readError = async (response: Response) => {
+  const payload = await response.json().catch(() => ({}))
+  return payload.error || `HTTP error! status: ${response.status}`
+}
+
+export const downloadKubeconfig = async (
+  data: KubeconfigDownloadRequest
+): Promise<Blob> => {
+  const response = await apiClient.request('/kubeconfig', {
+    method: 'POST',
+    body: JSON.stringify(data),
+    retryOnUnauthorized: false,
+  })
+  if (!response.ok) throw new Error(await readError(response))
+  return response.blob()
+}
+
+export const fetchCurrentUserKubeconfigTokens = async (): Promise<
+  KubeconfigToken[]
+> => {
+  const response = await authApiClient.get<{ tokens: KubeconfigToken[] }>(
+    '/users/me/kubeconfig-tokens'
+  )
+  return response.tokens
+}
+
+export const deleteCurrentUserKubeconfigToken = (id: number) =>
+  authApiClient.delete<{ message: string }>(`/users/me/kubeconfig-tokens/${id}`)
+
+export type KubeconfigTokenStatus = 'active' | 'expired'
+
+export interface AdminKubeconfigTokenQuery {
+  page?: number
+  size?: number
+  owner?: string
+  status?: KubeconfigTokenStatus
+}
+
+export interface AdminKubeconfigTokenList {
+  tokens: KubeconfigToken[]
+  total: number
+  page: number
+  size: number
+}
+
+export const fetchAdminKubeconfigTokens = async ({
+  page = 1,
+  size = 20,
+  owner,
+  status,
+}: AdminKubeconfigTokenQuery = {}): Promise<AdminKubeconfigTokenList> => {
+  const params = new URLSearchParams({ page: String(page), size: String(size) })
+  if (owner) params.set('owner', owner)
+  if (status) params.set('status', status)
+  return apiClient.get<AdminKubeconfigTokenList>(
+    `/admin/kubeconfig-tokens?${params}`
+  )
+}
+
+export const deleteAdminKubeconfigToken = (id: number) =>
+  apiClient.delete<{ message: string }>(`/admin/kubeconfig-tokens/${id}`)
+
+export const useCurrentUserKubeconfigTokens = (enabled = true) =>
+  useQuery({
+    queryKey: ['current-user-kubeconfig-tokens'],
+    queryFn: fetchCurrentUserKubeconfigTokens,
+    enabled,
+  })
+
+export const useAdminKubeconfigTokens = (query: AdminKubeconfigTokenQuery) =>
+  useQuery({
+    queryKey: [
+      'admin-kubeconfig-tokens',
+      query.page,
+      query.size,
+      query.owner,
+      query.status,
+    ],
+    queryFn: () => fetchAdminKubeconfigTokens(query),
+  })

--- a/ui/src/pages/settings.tsx
+++ b/ui/src/pages/settings.tsx
@@ -1,4 +1,6 @@
 import { useMemo } from 'react'
+import { useAuth } from '@/contexts/auth-context'
+import { ShieldAlert } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 
 import { usePageTitle } from '@/hooks/use-page-title'
@@ -7,9 +9,22 @@ import { createSettingsTabs } from '@/components/settings/settings-sections'
 
 export function SettingsPage() {
   const { t } = useTranslation()
+  const { user } = useAuth()
   const tabs = useMemo(() => createSettingsTabs(t), [t])
 
   usePageTitle('Settings')
+
+  if (!user?.isAdmin()) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-3 py-20">
+        <ShieldAlert className="h-12 w-12 text-muted-foreground" />
+        <p className="text-lg font-medium">{t('errors.noPermission.title')}</p>
+        <p className="text-sm text-muted-foreground">
+          {t('errors.noPermission.adminRequired')}
+        </p>
+      </div>
+    )
+  }
 
   return (
     <div className="space-y-2">

--- a/ui/src/types/api.ts
+++ b/ui/src/types/api.ts
@@ -628,6 +628,7 @@ export interface RelatedResources {
 export interface Cluster {
   id: number
   name: string
+  uuid: string
   description?: string
   version?: string
   config?: string


### PR DESCRIPTION
## Summary

- Add SMTP configuration to General Settings, including enablement, authentication, encryption, timeout, and sender details.
- Add test-email support using the current form values without persisting them.
- Support SMTP configuration through the `smtp` section in `KITE_CONFIG_FILE`.
- Restrict Settings access to administrators and localize the access-denied page.
- Add SMTP UI, backend, unit, E2E, and documentation coverage.

## Why

Administrators need a built-in way to configure and validate SMTP delivery for future email-based features. SMTP configuration should also support configuration-file management for GitOps-style deployments.

## Related issue

Closes #699

## Validation

```text
go test ./internal ./pkg/settings ./pkg/auth
npm test -- src/components/settings/general-management.test.tsx
npm run type-check
npm run lint
npx prettier --check …
git diff --check
```

## Checklist

- [x] I reviewed this PR myself before requesting review.
- [x] I understand the changes, including AI-generated parts (if any).
- [x] For new features, a feature request issue is linked.
- [x] I cleaned up AI noise (unnecessary comments, dead code, and unrelated changes).
- [x] This PR is reasonably scoped (or split into smaller PRs).