### PR TITLE
feat: support namespace selection when creating resources

### DIFF
--- a/pkg/resources/apply_handler.go
+++ b/pkg/resources/apply_handler.go
@@ -30,7 +30,8 @@ func NewResourceApplyHandler() *ResourceApplyHandler {
 }
 
 type ApplyResourceRequest struct {
-	YAML string `json:"yaml" binding:"required"`
+	YAML      string `json:"yaml" binding:"required"`
+	Namespace string `json:"namespace"`
 }
 
 // ApplyResource applies one or more YAML resources to the cluster
@@ -87,6 +88,9 @@ func (h *ResourceApplyHandler) ApplyResource(c *gin.Context) {
 		if mapping.Scope.Name() == meta.RESTScopeNameRoot {
 			authorizationNamespace = common.AllNamespaces
 			obj.SetNamespace("")
+		} else if req.Namespace != "" {
+			authorizationNamespace = req.Namespace
+			obj.SetNamespace(req.Namespace)
 		}
 		resource := common.HistoryResourceType(mapping.Resource.Resource, mapping.Resource.Group)
 		canCreate := rbac.CanAccess(user, resource, string(common.VerbCreate), cs.Name, authorizationNamespace)

--- a/ui/src/components/create-resource-dialog.tsx
+++ b/ui/src/components/create-resource-dialog.tsx
@@ -1,5 +1,6 @@
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import { IconLoader2 } from '@tabler/icons-react'
+import * as yaml from 'js-yaml'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
 
@@ -22,6 +23,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
+import { NamespaceSelector } from '@/components/selector/namespace-selector'
 import { SimpleYamlEditor } from '@/components/simple-yaml-editor'
 
 interface CreateResourceDialogProps {
@@ -48,8 +50,28 @@ function CreateResourceDialogContent({
   const { t } = useTranslation()
   const { data: templates = [] } = useTemplates()
   const [selectedTemplateId, setSelectedTemplateId] = useState<string>('')
+  const [selectedNamespace, setSelectedNamespace] = useState<string>()
   const [yamlContent, setYamlContent] = useState('')
   const [isLoading, setIsLoading] = useState(false)
+  const hasNamespaceConflict = useMemo(() => {
+    if (!selectedNamespace) return false
+
+    try {
+      let conflict = false
+      yaml.loadAll(yamlContent, (document) => {
+        if (!document || typeof document !== 'object') return
+
+        const namespace = (document as { metadata?: { namespace?: unknown } })
+          .metadata?.namespace
+        if (typeof namespace === 'string' && namespace !== selectedNamespace) {
+          conflict = true
+        }
+      })
+      return conflict
+    } catch {
+      return false
+    }
+  }, [selectedNamespace, yamlContent])
 
   const handleTemplateChange = (templateName: string) => {
     if (templateName === 'empty') {
@@ -70,7 +92,7 @@ function CreateResourceDialogContent({
 
     setIsLoading(true)
     try {
-      await applyResource(yamlContent)
+      await applyResource(yamlContent, selectedNamespace)
       toast.success(t('common.messages.applied', 'Applied successfully'))
       onOpenChange(false)
     } catch (err) {
@@ -98,31 +120,51 @@ function CreateResourceDialogContent({
       </DialogHeader>
 
       <div className="min-h-0 flex-1 space-y-4 overflow-y-auto pr-1">
-        <div className="space-y-2">
-          <Label htmlFor="template">Template</Label>
-          <Select
-            value={selectedTemplateId || 'empty'}
-            onValueChange={handleTemplateChange}
-          >
-            <SelectTrigger>
-              <SelectValue
-                placeholder={t(
-                  'common.placeholders.selectTemplate',
-                  'Select a template'
-                )}
-              />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="empty">
-                {t('common.values.emptyTemplate', 'Empty Template')}
-              </SelectItem>
-              {templates.map((template) => (
-                <SelectItem key={template.name} value={template.name}>
-                  {template.name}
+        <div className="grid gap-4 sm:grid-cols-2">
+          <div className="space-y-2">
+            <Label htmlFor="template">Template</Label>
+            <Select
+              value={selectedTemplateId || 'empty'}
+              onValueChange={handleTemplateChange}
+            >
+              <SelectTrigger>
+                <SelectValue
+                  placeholder={t(
+                    'common.placeholders.selectTemplate',
+                    'Select a template'
+                  )}
+                />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="empty">
+                  {t('common.values.emptyTemplate', 'Empty Template')}
                 </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
+                {templates.map((template) => (
+                  <SelectItem key={template.name} value={template.name}>
+                    {template.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="space-y-2">
+            <Label>{t('common.fields.namespace', 'Namespace')}</Label>
+            <NamespaceSelector
+              selectedNamespace={selectedNamespace}
+              handleNamespaceChange={setSelectedNamespace}
+              triggerClassName="sm:w-full sm:max-w-none"
+              modal
+            />
+            {hasNamespaceConflict ? (
+              <p className="text-xs text-muted-foreground">
+                {t('common.messages.namespaceOverride', {
+                  namespace: selectedNamespace,
+                  defaultValue:
+                    'The selected namespace will override different namespaces in the YAML when applying.',
+                })}
+              </p>
+            ) : null}
+          </div>
         </div>
         <div className="space-y-2">
           <Label htmlFor="yaml">

--- a/ui/src/i18n/locales/en.json
+++ b/ui/src/i18n/locales/en.json
@@ -253,6 +253,7 @@
       "manageTemplatesDescription": "Manage resource templates for creating new resources.",
       "nameAndYamlRequired": "Name and YAML are required",
       "nameImmutable": "Name cannot be changed after creation",
+      "namespaceOverride": "The selected namespace will override different namespaces in the YAML when applying.",
       "neverUsed": "Never",
       "noChatHistory": "No chat history yet",
       "noData": "No data",

--- a/ui/src/i18n/locales/zh.json
+++ b/ui/src/i18n/locales/zh.json
@@ -253,6 +253,7 @@
       "manageTemplatesDescription": "管理用于创建资源的 YAML 模板。",
       "nameAndYamlRequired": "名称和 YAML 为必填项",
       "nameImmutable": "创建后名称不可修改",
+      "namespaceOverride": "应用时，选择的 Namespace 将覆盖 YAML 中不同的 Namespace。",
       "neverUsed": "从未使用",
       "noChatHistory": "暂无对话历史",
       "noData": "暂无数据",

--- a/ui/src/lib/api/core.ts
+++ b/ui/src/lib/api/core.ts
@@ -611,6 +611,7 @@ export const deleteResource = async <T extends ResourceType>(
 // Apply resource from YAML
 export interface ApplyResourceRequest {
   yaml: string
+  namespace?: string
 }
 
 export interface ApplyResourceResponse {
@@ -627,10 +628,12 @@ export interface ApplyResourceResponse {
 }
 
 export const applyResource = async (
-  yaml: string
+  yaml: string,
+  namespace?: string
 ): Promise<ApplyResourceResponse> => {
   return await apiClient.post<ApplyResourceResponse>('/resources/apply', {
     yaml,
+    namespace,
   })
 }
 


### PR DESCRIPTION
## Summary

- add an optional namespace selector to the Create Resource dialog
- use the selected namespace for all namespaced YAML documents while leaving cluster-scoped resources unchanged
- show a non-blocking hint when YAML namespaces differ from the selected namespace

## Why

Pasted manifests often omit `metadata.namespace`. Selecting a namespace lets users apply multi-document YAML without editing every document first.

## Related issue

Closes #712

## Validation

- `make pre-commit`

## Checklist

- [x] I reviewed this PR myself before requesting review.
- [x] I understand the changes, including AI-generated parts (if any).
- [x] For new features, a feature request issue is linked.
- [x] I cleaned up AI noise (unnecessary comments, dead code, and unrelated changes).
- [x] This PR is reasonably scoped (or split into smaller PRs).